### PR TITLE
docs: harden sub-agent review workflow

### DIFF
--- a/feedback-points/README.md
+++ b/feedback-points/README.md
@@ -1,8 +1,8 @@
 # Feedback Points
 
-This directory is the canonical location for feedback-point records in the real repository root.
+This directory is the canonical location for feedback-point records in the SKILL repository.
 
-Skills may be visible through symlinks from other repositories, but the operating files live here:
+Skills may be visible through symlinks from other repositories, but the canonical operating files live here:
 
 - `feedback-points.md`
 - `feedback-points-backlog.md`

--- a/feedback-points/feedback-points-backlog.md
+++ b/feedback-points/feedback-points-backlog.md
@@ -1,10 +1,10 @@
 # Feedback Points Backlog
 
-Canonical archive and backlog for feedback-point records.
+Canonical archive and backlog for SKILL repository feedback-point records.
 
 Location rule:
 
-- real repository root: `feedback-points/feedback-points-backlog.md`
+- canonical path: `/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md`
 - keep completed, archived, or non-active entries here
 
 Update rule:
@@ -19,3 +19,4 @@ Update rule:
 | FP-003 | `親判断` | 運用用語や出力項目名は、英語をそのまま残す前に自然な日本語表現を先に検討する。特に workflow や feedback の説明では、`next owner` のような曖昧な英語より `次アクション対応` のように役割が分かる日本語を優先する。issue 化後は active FP ではなく issue を正本として追跡する。 | `communication` | `prefer_clear_japanese_operational_terms` | 1 | `skill化済み` | `feedback-points-manager` | `対応済み` | `2026-04-18` | `2026-04-18` | `2026-04-21` | `issue #6 を正本として追跡` | `https://github.com/ssaattww/CodexSkill/issues/6`, `skills/feedback-points-manager/SKILL.md`, `skills/design/skill-hierarchy-design.md` |
 | FP-004 | `ユーザー指示` | mandatory な `sub-agent` 手順を current run で満たせない場合、親判断で代替して進めず、必ずユーザー確認で止まる。特に `review-enforcer` の mandatory `sub-agent` review は親レビューで黙って代替してはならない。issue 化後は active FP ではなく issue を正本として追跡する。 | `governance` | `stop_and_ask_when_mandatory_sub_agent_execution_is_blocked` | 2 | `skill化済み` | `feedback-autonomy-boundary-manager`, `review-enforcer` | `対応済み` | `2026-04-21` | `2026-04-21` | `2026-04-21` | `issue #9 を正本として追跡` | `https://github.com/ssaattww/CodexSkill/issues/9`, `skills/feedback-autonomy-boundary-manager/SKILL.md`, `skills/review-enforcer/SKILL.md`, `reports/issue3-skill-presence-guard-20260421092352.md`, `reports/issue3-review-20260421092352.md` |
 | FP-005 | `ユーザー指示` | ユーザーが `〜べきです` と述べた場合は 100% 指摘として扱い、指示待ちにせず即時 `feedback-points-manager` の記録対象にする。issue 化後は active FP ではなく issue を正本として追跡する。 | `governance` | `treat_user_should_statements_as_immediate_feedback_points` | 1 | `skill化済み` | `feedback-points-manager` | `対応済み` | `2026-04-21` | `2026-04-21` | `2026-04-21` | `issue #11 を正本として追跡` | `https://github.com/ssaattww/CodexSkill/issues/11`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `reports/fp-format-and-review-trigger-hardening-20260421094402.md` |
+| FP-006 | `ユーザー指示` | review 系 skill では reviewer の既定構成を `gpt-5.4` / `high` に固定し、親が作った report 雛形に reviewer 自身が穴埋めする。reviewer は report 形式を修正してはならない。さらに正常系が動く暫定版のリリースを優先し、正常系をまだ壊していない懸念は report に記録して保留できるようにする。ユーザーがやりたいことを careful use でも達成できない場合はユーザー確認を行い、正常系が壊れている場合は対応する。sub-agent は内部で `codex exec`、nested Codex、同等の agent-spawning workflow を実行してはならず、親が明示した task と supporting skill だけを処理し、`development-orchestrator` のような parent-owned workflow に自律再突入してはならない。feedback-point の canonical ledger は consuming repo ではなく SKILL repo 側 `/home/ibis/AI/CodexSkill/feedback-points/` に集約する。直接 skill へ反映したため、関連 commit 完了後はその commit を正本として追跡する。 | `review` | `standardize_reviewer_model_report_write_and_skill_repo_feedback_ledger` | 5 | `skill化済み` | `review-enforcer`, `sub-agent-task-manager`, `codex-delegation-executor`, `feedback-points-manager`, `development-orchestrator` | `対応中` | `2026-05-09` | `2026-05-09` | `2026-05-09` | `issue は不要。関連 skill 更新を commit した後、その commit を正本として追跡` | `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `feedback-points/README.md`, `reports/skills-review-policy-feedback-ledger-review-r5-20260509190627.md` |

--- a/feedback-points/feedback-points.md
+++ b/feedback-points/feedback-points.md
@@ -1,11 +1,11 @@
 # Feedback Points
 
-Canonical active feedback-point ledger.
+Canonical active feedback-point ledger for the SKILL repository.
 
 Location rule:
 
-- real repository root: `feedback-points/feedback-points.md`
-- do not keep the active ledger inside `skills/`
+- canonical path: `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
+- do not keep the active ledger in a consuming project repository
 
 Update rule:
 

--- a/reports/skills-review-policy-feedback-ledger-review-20260509184523.md
+++ b/reports/skills-review-policy-feedback-ledger-review-20260509184523.md
@@ -1,0 +1,59 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: SKILL repo の reviewer policy 強化と feedback-points canonical path 集約の差分をコードレビューする
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: completion 前に独立した reviewer による確認を必須化しているため
+
+## 対象範囲
+
+- 対象: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 対象外
+
+- 対象外: `/home/ibis/ssl/IbisDuck` 側の未コミット変更、TRACKER-007 の実装差分、今回の対象外 skill
+
+## 実行コマンド
+
+- 実行コマンド: `sed -n '1,220p' skills/development-orchestrator/SKILL.md`
+- 実行コマンド: `sed -n '1,220p' skills/review-enforcer/SKILL.md`
+- 実行コマンド: `sed -n '1,220p' skills/sub-agent-task-manager/SKILL.md`
+- 実行コマンド: `sed -n '1,220p' skills/codex-delegation-executor/SKILL.md`
+- 実行コマンド: `sed -n '1,240p' reports/skills-review-policy-feedback-ledger-review-20260509184523.md`
+- 実行コマンド: `git status --short`
+- 実行コマンド: `git diff -- <scope files>`
+- 実行コマンド: `nl -ba <scope files> | sed -n '1,260p'`
+- 実行コマンド: `rg -n "review-policy|feedback-points/feedback-points\\.md|feedback-points-backlog\\.md|canonical path|real repository root|consuming project repository" skills feedback-points`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `skills/review-enforcer/SKILL.md`
+- 変更または確認したファイル: `skills/sub-agent-task-manager/SKILL.md`
+- 変更または確認したファイル: `skills/codex-delegation-executor/SKILL.md`
+- 変更または確認したファイル: `skills/development-orchestrator/SKILL.md`
+- 変更または確認したファイル: `skills/restart-handover-manager/SKILL.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/SKILL.md`
+- 変更または確認したファイル: `skills/feedback-points-sanitizer/SKILL.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/references/skillization-operations.md`
+- 変更または確認したファイル: `feedback-points/README.md`
+- 変更または確認したファイル: `feedback-points/feedback-points.md`
+- 変更または確認したファイル: `feedback-points/feedback-points-backlog.md`
+
+## 指摘事項
+
+- Medium: `feedback-points/feedback-points-backlog.md:22` で今回追加した FP-006 の `カテゴリ` が `review-policy` になっていますが、canonical category 一覧は `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md:7-19` にある値だけを許可しており、この値は定義されていません。canonical ledger 集約をこの差分で進めるなら、新規行は既存 taxonomy に合わせて `review` などの正規値を使わないと ledger 自体が即座に規約違反になります。
+- Medium: `skills/feedback-points-manager/references/skillization-operations.md:39` だけ backlog の移動先が相対パス `feedback-points/feedback-points-backlog.md` のままです。他の更新箇所は canonical path を `/home/ibis/AI/CodexSkill/feedback-points/...` に統一しているため、この1箇所だけ旧挙動を残すと consuming repo 側の `feedback-points/` へ誤って戻す余地があり、今回の集約ポリシーと矛盾します。
+
+## 結果
+
+- 結果: 指摘 2 件。reviewer model の既定化と direct report write 方針の反映自体は `review-enforcer` / `sub-agent-task-manager` / `codex-delegation-executor` で概ね一貫していましたが、feedback ledger 集約まわりに上記 2 点の整合性崩れが残っています。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: canonical path 化の残り参照を追加で横断確認しないと、今後も relative path が混在して consuming repo 側へ ledger を誤記録する再発余地があります。

--- a/reports/skills-review-policy-feedback-ledger-review-r2-20260509185007.md
+++ b/reports/skills-review-policy-feedback-ledger-review-r2-20260509185007.md
@@ -1,0 +1,40 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: SKILL repo の reviewer policy 強化、review 保留方針追加、feedback-points canonical path 集約後の差分を再レビューする
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review 指摘対応後の差分を独立 reviewer で再確認するため
+
+## 対象範囲
+
+- 対象: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 対象外
+
+- 対象外: 既存 report の書式変更、`/home/ibis/ssl/IbisDuck` 側の変更、今回の対象外 skill
+
+## 実行コマンド
+
+- 実行コマンド: `sed -n '1,220p' skills/review-enforcer/SKILL.md`; `sed -n '1,260p' skills/sub-agent-task-manager/SKILL.md`; `sed -n '1,260p' skills/codex-delegation-executor/SKILL.md`; `sed -n '1,260p' skills/development-orchestrator/SKILL.md`; `sed -n '1,240p' reports/skills-review-policy-feedback-ledger-review-r2-20260509185007.md`; `git status --short`; `git diff --stat -- <scope>`; `git diff -- <scope>`; `rg -n "repo-root|feedback-points/feedback-points|this commit|この commit|gpt-5.4|high reasoning|normal path|保留|hold" skills feedback-points`; `nl -ba <changed-files>`; `git diff --check -- <scope>`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`, `reports/skills-review-policy-feedback-ledger-review-r2-20260509185007.md`
+
+## 指摘事項
+
+- 指摘要約: `blocking` 1件、`hold` 1件。
+- [blocking][high] [feedback-points/feedback-points-backlog.md:22] の FP-006 は `この commit を正本として追跡` として `対応済み` 扱いで backlog に移されていますが、現行ポリシーはまだ commit 単独での handoff を認めていません。[skills/feedback-points-manager/SKILL.md:115-128,154-155] は skill 改善ループを handoff 済みにする前に issue 作成結果を残すことを要求し、[skills/feedback-points-manager/references/skillization-operations.md:9-10,36-40,106] も issue 作成または明示的な skip 理由を前提にしています。今回の行には issue URL も skip 理由もなく、規範 skill と canonical ledger の記録が衝突しています。
+- [hold][medium] `/home/ibis/AI/CodexSkill/...` への固定絶対 path を複数 skill/ledger に埋め込んだため、repo を別 path に clone した環境や別ユーザー環境では手順参照先が壊れます。代表箇所: [skills/development-orchestrator/SKILL.md:31,38,45,51], [skills/restart-handover-manager/SKILL.md:27,34,75], [skills/feedback-points-manager/SKILL.md:8,26,32-33,86-87,105,115,155], [feedback-points/feedback-points.md:7], [feedback-points/feedback-points-backlog.md:7]。この端末では直ちに normal path を壊していないため hold で十分ですが、repo-local policy としては portability を落としています。
+
+## 結果
+
+- 結果: 未コミット差分を workspace から直接確認し、2件の指摘を記録した。`blocking` が残っているためこの差分はまだ review pass と判断しない。ユーザー指示により nested Codex は使わず、親エージェントが直接レビューした。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: FP-006 の handoff ルールを「issue 必須」のまま通すのか、「commit を正本にできる」方へ policy を更新するのかを先に一つに揃える必要がある。絶対 path の件は保留可能だが、後続で clone path や実行ユーザーが変わると skill の参照先誤りとして顕在化する。

--- a/reports/skills-review-policy-feedback-ledger-review-r3-20260509185626.md
+++ b/reports/skills-review-policy-feedback-ledger-review-r3-20260509185626.md
@@ -1,0 +1,81 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: SKILL repo の reviewer policy 強化、review 保留方針、codex exec 禁止、feedback-points canonical path 集約後の差分を再々レビューする
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: review 指摘対応と追加 user instruction 反映後の差分を独立 reviewer で再確認するため
+
+## 対象範囲
+
+- 対象: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 対象外
+
+- 対象外: 既存 report の書式変更、`/home/ibis/ssl/IbisDuck` 側の変更、今回の対象外 skill
+
+## 実行コマンド
+
+- 実行コマンド:
+  - `git -C /home/ibis/AI/CodexSkill status --short --untracked-files=no`
+  - `git -C /home/ibis/AI/CodexSkill diff -- skills/review-enforcer/SKILL.md skills/sub-agent-task-manager/SKILL.md skills/codex-delegation-executor/SKILL.md skills/development-orchestrator/SKILL.md skills/restart-handover-manager/SKILL.md skills/feedback-points-manager/SKILL.md skills/feedback-points-sanitizer/SKILL.md skills/feedback-points-manager/references/feedback-format-and-cleanup.md skills/feedback-points-manager/references/canonical-feedback-taxonomy.md skills/feedback-points-manager/references/skillization-operations.md feedback-points/README.md feedback-points/feedback-points.md feedback-points/feedback-points-backlog.md`
+  - `sed -n '1,260p' /home/ibis/AI/CodexSkill/reports/skills-review-policy-feedback-ledger-review-r3-20260509185626.md`
+  - `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+  - `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+  - `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/codex-delegation-executor/SKILL.md`
+  - `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/development-orchestrator/SKILL.md`
+  - `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/SKILL.md | sed -n '1,220p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/references/skillization-operations.md | sed -n '1,120p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md | sed -n '1,140p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md | sed -n '1,220p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/skills/codex-delegation-executor/SKILL.md | sed -n '1,180p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/skills/restart-handover-manager/SKILL.md | sed -n '1,120p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/skills/development-orchestrator/SKILL.md | sed -n '1,140p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/feedback-points/README.md | sed -n '1,80p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/feedback-points/feedback-points.md | sed -n '1,60p'`
+  - `nl -ba /home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md | sed -n '1,80p'`
+  - `rg -n "<repo-root>|real repository root|feedback-points/feedback-points\\.md|feedback-points/feedback-points-backlog\\.md|consuming project|canonical path" ...`
+  - `rg -n "gpt-5\\.4|high reasoning|normal path|careful use|held|hold|codex exec|nested Codex|agent-spawning|report file directly|parent-side|keep waiting|re-poll|reviewer" ...`
+  - `rg -n "tracked follow-up issue|create or confirm the follow-up issue|issue before considering the loop handed off|after issue creation" ...`
+
+## 対象ファイル
+
+- 変更または確認したファイル:
+  - `skills/review-enforcer/SKILL.md`
+  - `skills/sub-agent-task-manager/SKILL.md`
+  - `skills/codex-delegation-executor/SKILL.md`
+  - `skills/development-orchestrator/SKILL.md`
+  - `skills/restart-handover-manager/SKILL.md`
+  - `skills/feedback-points-manager/SKILL.md`
+  - `skills/feedback-points-sanitizer/SKILL.md`
+  - `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`
+  - `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`
+  - `skills/feedback-points-manager/references/skillization-operations.md`
+  - `feedback-points/README.md`
+  - `feedback-points/feedback-points.md`
+  - `feedback-points/feedback-points-backlog.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」:
+  - Blocking normal-path problems:
+    - `medium` `skills/feedback-points-manager/SKILL.md:64`, `skills/feedback-points-manager/SKILL.md:115-116`, `skills/feedback-points-manager/SKILL.md:128-130`, `skills/feedback-points-manager/references/skillization-operations.md:9`, `skills/feedback-points-manager/references/skillization-operations.md:44-49`, `skills/feedback-points-manager/references/skillization-operations.md:75` がまだ矛盾しています。今回の差分は「同一 skill commit で完全反映できた FP は issue 作成を skip 可」に広げていますが、同じ skill と reference に「handoff 前には tracked follow-up issue が必要」「after issue creation を報告する」と読める旧ルールが残っています。このままだと caller によって issue 必須/不要の判断が割れ、normal path で今回の新方針どおりに動けません。
+  - User-confirmation-required capability gaps:
+    - なし
+  - Non-blocking concerns that should only be recorded and held:
+    - なし
+
+## 結果
+
+- 結果:
+  - 1 件の指摘があります。
+  - reviewer model 固定、reviewer 自身による report 直接記入、`codex exec` / nested Codex 禁止、feedback ledger の canonical path 集約そのものは、確認した範囲では意図どおり反映されています。
+  - ただし FP loop の issue 要否だけは policy text が二重化したままなので、関連文を一本化するまでこの変更は policy consistency の観点で完了扱いにしない方が安全です。
+
+## リスク
+
+- 未解決のリスクまたは後続対応:
+  - 未修正のまま使うと、同じ FP を「同一 commit で完結したので backlog に移して終了」とする実行者と、「tracked follow-up issue を必ず作るべき」と解釈する実行者に分かれます。

--- a/reports/skills-review-policy-feedback-ledger-review-r4-20260509190057.md
+++ b/reports/skills-review-policy-feedback-ledger-review-r4-20260509190057.md
@@ -1,0 +1,89 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: SKILL repo の reviewer policy 強化、codex exec 禁止、feedback-point closure policy 整合、report revision naming rule 追加後の差分を再レビューする
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: 追加 user instruction と review 指摘反映後の差分を独立 reviewer で再確認するため
+
+## 対象範囲
+
+- 対象: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/report-output-manager/SKILL.md`, `skills/report-output-manager/references/report-filename-policy.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 対象外
+
+- 対象外: 既存 report の書式変更、`/home/ibis/ssl/IbisDuck` 側の変更、今回の対象外 skill
+
+## 実行コマンド
+
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/development-orchestrator/SKILL.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/codex-delegation-executor/SKILL.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/feedback-points-manager/SKILL.md`
+- `sed -n '1,220p' /home/ibis/AI/CodexSkill/skills/report-output-manager/SKILL.md`
+- `sed -n '1,260p' /home/ibis/AI/CodexSkill/reports/skills-review-policy-feedback-ledger-review-r4-20260509190057.md`
+- `git -C /home/ibis/AI/CodexSkill status --short`
+- `git -C /home/ibis/AI/CodexSkill diff --stat`
+- `git -C /home/ibis/AI/CodexSkill diff --name-only`
+- `git -C /home/ibis/AI/CodexSkill diff -- skills/review-enforcer/SKILL.md skills/sub-agent-task-manager/SKILL.md skills/codex-delegation-executor/SKILL.md skills/development-orchestrator/SKILL.md skills/restart-handover-manager/SKILL.md`
+- `git -C /home/ibis/AI/CodexSkill diff -- skills/feedback-points-manager/SKILL.md skills/feedback-points-sanitizer/SKILL.md skills/report-output-manager/SKILL.md skills/report-output-manager/references/report-filename-policy.md`
+- `git -C /home/ibis/AI/CodexSkill diff -- skills/feedback-points-manager/references/feedback-format-and-cleanup.md skills/feedback-points-manager/references/canonical-feedback-taxonomy.md skills/feedback-points-manager/references/skillization-operations.md feedback-points/README.md feedback-points/feedback-points.md feedback-points/feedback-points-backlog.md`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md | sed -n '1,240p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/codex-delegation-executor/SKILL.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/development-orchestrator/SKILL.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/restart-handover-manager/SKILL.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/SKILL.md | sed -n '1,260p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-sanitizer/SKILL.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/report-output-manager/SKILL.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/report-output-manager/references/report-filename-policy.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/references/feedback-format-and-cleanup.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/references/canonical-feedback-taxonomy.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/references/skillization-operations.md | sed -n '1,260p'`
+- `nl -ba /home/ibis/AI/CodexSkill/feedback-points/README.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/feedback-points/feedback-points.md | sed -n '1,220p'`
+- `nl -ba /home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md | sed -n '1,260p'`
+- `nl -ba /home/ibis/AI/CodexSkill/skills/report-output-manager/scripts/build_report_path.sh | sed -n '1,240p'`
+- `rg -n "feedback-points/feedback-points\\.md|feedback-points/feedback-points-backlog\\.md|real repository root|consuming project" /home/ibis/AI/CodexSkill/skills /home/ibis/AI/CodexSkill/feedback-points /home/ibis/AI/CodexSkill -g '!reports/**' -g '!node_modules/**'`
+- `rg -n "r<revision>|revision suffix|build_report_path|report filename" /home/ibis/AI/CodexSkill/skills /home/ibis/AI/CodexSkill -g '!reports/**'`
+
+## 対象ファイル
+
+- `skills/review-enforcer/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/codex-delegation-executor/SKILL.md`
+- `skills/development-orchestrator/SKILL.md`
+- `skills/restart-handover-manager/SKILL.md`
+- `skills/feedback-points-manager/SKILL.md`
+- `skills/feedback-points-sanitizer/SKILL.md`
+- `skills/report-output-manager/SKILL.md`
+- `skills/report-output-manager/references/report-filename-policy.md`
+- `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`
+- `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`
+- `skills/feedback-points-manager/references/skillization-operations.md`
+- `feedback-points/README.md`
+- `feedback-points/feedback-points.md`
+- `feedback-points/feedback-points-backlog.md`
+- `skills/report-output-manager/scripts/build_report_path.sh`
+- `reports/skills-review-policy-feedback-ledger-review-r4-20260509190057.md`
+
+## 指摘事項
+
+- [blocking][high] [feedback-points/feedback-points-backlog.md:22] は FP-006 を `対応済み` として backlog に移しつつ `この commit を正本として追跡` と書いていますが、このレビュー対象はまだ未コミット差分です。新ポリシーでも issue skip が許されるのは commit-backed な根拠が明示できる場合だけで、現時点ではその正本がまだ存在しません。[skills/feedback-points-manager/SKILL.md:115-116,146,158-159] と [skills/feedback-points-manager/references/skillization-operations.md:44-49] に合わせるなら、少なくとも actual commit ができるまでは「この commit」を closure 根拠にした `対応済み` 扱いへ進めるのは早すぎます。
+- [blocking][medium] [skills/report-output-manager/SKILL.md:43-44,56-58] と [skills/report-output-manager/references/report-filename-policy.md:19-29,58-60] は revision 付き report 名を正式ルールに追加していますが、参照先の [skills/report-output-manager/scripts/build_report_path.sh:13-24,33-66,124-135] は revision 入力を受けず、常に `${prefix}-${item_slug}-${timestamp}.md` を生成します。現状のままでは script を使う documented normal path で `-r2` / `-r3` を deterministic に作れず、caller が `item-name` に `r2` を埋め込むしかなくなって `item-name` を固定で再利用する新ルールともずれます。
+- [confirmation-required] なし
+- [hold] なし
+
+## 結果
+
+- 2 件の指摘あり。内訳は normal-path blocker 2 件、user-confirmation-required capability gap 0 件、hold concern 0 件。
+- reviewer はこの report を直接更新し、template の heading 順序・spacing・既存記述は維持した。
+
+## リスク
+
+- FP-006 の closure 記録をこのまま backlog 正本にすると、commit-backed である前提だけが先行して ledger の監査線がずれる。
+- revision 命名ルールと `build_report_path.sh` の乖離を放置すると、次回以降の再レビューや evidence 追補で revision report 名が手動運用依存になる。

--- a/reports/skills-review-policy-feedback-ledger-review-r5-20260509190627.md
+++ b/reports/skills-review-policy-feedback-ledger-review-r5-20260509190627.md
@@ -1,0 +1,73 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: SKILL repo の reviewer policy 強化、feedback-point closure policy、report revision naming rule、script limitation 文言反映後の差分を再レビューする
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: 追加修正で blocking が消えたかを独立 reviewer で確認するため
+
+## 対象範囲
+
+- 対象: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/report-output-manager/SKILL.md`, `skills/report-output-manager/references/report-filename-policy.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 対象外
+
+- 対象外: 既存 report の書式変更、`/home/ibis/ssl/IbisDuck` 側の変更、今回の対象外 skill
+
+## 実行コマンド
+
+- 実行コマンド: `sed -n '1,240p' /home/ibis/AI/CodexSkill/skills/development-orchestrator/SKILL.md`
+- 実行コマンド: `sed -n '1,240p' /home/ibis/AI/CodexSkill/skills/review-enforcer/SKILL.md`
+- 実行コマンド: `sed -n '1,240p' /home/ibis/AI/CodexSkill/skills/sub-agent-task-manager/SKILL.md`
+- 実行コマンド: `sed -n '1,240p' /home/ibis/AI/CodexSkill/skills/codex-delegation-executor/SKILL.md`
+- 実行コマンド: `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/feedback-points-manager/SKILL.md`
+- 実行コマンド: `sed -n '1,260p' /home/ibis/AI/CodexSkill/skills/report-output-manager/SKILL.md`
+- 実行コマンド: `sed -n '1,260p' /home/ibis/AI/CodexSkill/reports/skills-review-policy-feedback-ledger-review-r5-20260509190627.md`
+- 実行コマンド: `git -C /home/ibis/AI/CodexSkill status --short`
+- 実行コマンド: `git -C /home/ibis/AI/CodexSkill diff --stat -- ...`
+- 実行コマンド: `git -C /home/ibis/AI/CodexSkill diff --unified=40 -- skills/review-enforcer/SKILL.md skills/sub-agent-task-manager/SKILL.md skills/codex-delegation-executor/SKILL.md skills/development-orchestrator/SKILL.md skills/restart-handover-manager/SKILL.md`
+- 実行コマンド: `git -C /home/ibis/AI/CodexSkill diff --unified=40 -- skills/feedback-points-manager/SKILL.md skills/feedback-points-sanitizer/SKILL.md skills/report-output-manager/SKILL.md skills/report-output-manager/references/report-filename-policy.md skills/feedback-points-manager/references/feedback-format-and-cleanup.md skills/feedback-points-manager/references/canonical-feedback-taxonomy.md skills/feedback-points-manager/references/skillization-operations.md feedback-points/README.md feedback-points/feedback-points.md feedback-points/feedback-points-backlog.md`
+- 実行コマンド: `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/SKILL.md | sed -n '1,220p'`
+- 実行コマンド: `nl -ba /home/ibis/AI/CodexSkill/skills/feedback-points-manager/references/skillization-operations.md | sed -n '1,220p'`
+- 実行コマンド: `nl -ba /home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md | sed -n '1,120p'`
+- 実行コマンド: `nl -ba /home/ibis/AI/CodexSkill/feedback-points/feedback-points.md | sed -n '1,80p'`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `reports/skills-review-policy-feedback-ledger-review-r5-20260509190627.md`
+- 変更または確認したファイル: `skills/review-enforcer/SKILL.md`
+- 変更または確認したファイル: `skills/sub-agent-task-manager/SKILL.md`
+- 変更または確認したファイル: `skills/codex-delegation-executor/SKILL.md`
+- 変更または確認したファイル: `skills/development-orchestrator/SKILL.md`
+- 変更または確認したファイル: `skills/restart-handover-manager/SKILL.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/SKILL.md`
+- 変更または確認したファイル: `skills/feedback-points-sanitizer/SKILL.md`
+- 変更または確認したファイル: `skills/report-output-manager/SKILL.md`
+- 変更または確認したファイル: `skills/report-output-manager/references/report-filename-policy.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`
+- 変更または確認したファイル: `skills/feedback-points-manager/references/skillization-operations.md`
+- 変更または確認したファイル: `feedback-points/README.md`
+- 変更または確認したファイル: `feedback-points/feedback-points.md`
+- 変更または確認したファイル: `feedback-points/feedback-points-backlog.md`
+
+## 指摘事項
+
+- Blocking normal-path problems:
+  1. `feedback-points/feedback-points-backlog.md:22` で FP-006 を backlog に移し、active ledger を空にしていますが、この行自体の `次アクション対応` は「関連 skill 更新を commit した後、その commit を正本として追跡」となっており、まだ skip 条件が成立していません。`skills/feedback-points-manager/SKILL.md:64,115-116,141,158-159` は、issue を作らない場合でも commit-backed な skip rationale と system of record が揃うまで loop を handed off/closed 扱いしない前提です。現状は commit 証跡なしで active から消えているため、未完了の closure 項目が system-of-record から落ちます。commit ができるまで active に残すか、backlog 側に commit-backed evidence を入れてから移す必要があります。
+  2. `skills/feedback-points-manager/references/skillization-operations.md:44-49` は、issue skip 時の `根拠リンク` を「commit-backed or report-backed evidence」でよいとしていますが、親ポリシー本体は `skills/feedback-points-manager/SKILL.md:64,116,141,158` で commit-backed な skip rationale を要求しています。reference 側だけが report-backed でも閉じられるように見えるため、caller が active row を早期に外す誤運用を誘発します。reference も commit-backed 必須に揃えないと policy consistency が崩れます。
+- User-confirmation-required capability gaps:
+  - なし
+- Non-blocking concerns that should only be recorded and held:
+  - なし
+
+## 結果
+
+- 結果: 2 件の指摘あり。review sub-agent の既定 model 指定、report 直接穴埋め、normal path 優先、report revision 命名ルール自体には追加の blocking は見当たりませんでした。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: FP-006 の移送タイミングと skip-evidence 条件を修正しない限り、feedback ledger の closure policy は「commit 前に active から消えてもよい」という運用に戻り得ます。

--- a/reports/skills-review-policy-feedback-ledger-review-r6-20260509191205.md
+++ b/reports/skills-review-policy-feedback-ledger-review-r6-20260509191205.md
@@ -1,0 +1,44 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: SKILL repo の reviewer policy、feedback-point closure policy、report revision naming rule、sub-agent scope restriction 反映後の差分を再レビューする
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: 最新の process instruction 反映後に blocking が残っていないか独立 reviewer で確認するため
+
+## 対象範囲
+
+- 対象: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/report-output-manager/SKILL.md`, `skills/report-output-manager/references/report-filename-policy.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 対象外
+
+- 対象外: 既存 report の書式変更、`/home/ibis/ssl/IbisDuck` 側の変更、今回の対象外 skill
+
+## 実行コマンド
+
+- 実行コマンド: `sed -n '1,260p' /home/ibis/AI/CodexSkill/reports/skills-review-policy-feedback-ledger-review-r6-20260509191205.md`, `git -C /home/ibis/AI/CodexSkill status --short`, `git -C /home/ibis/AI/CodexSkill diff --stat -- <scope files>`, `git -C /home/ibis/AI/CodexSkill diff --unified=80 -- <scope files>`, `rg -n "<repo-root>/feedback-points|real repository root|feedback-points/feedback-points.md|feedback-points/feedback-points-backlog.md|build_report_path\\.sh|r<revision>|対応中" /home/ibis/AI/CodexSkill/skills /home/ibis/AI/CodexSkill/feedback-points`, `nl -ba <reviewed files>`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `/home/ibis/AI/CodexSkill/reports/skills-review-policy-feedback-ledger-review-r6-20260509191205.md`, `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/report-output-manager/SKILL.md`, `skills/report-output-manager/references/report-filename-policy.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 指摘事項
+
+- 指摘要約: 2 件
+- Blocking normal-path problem:
+  - `skills/feedback-points-manager/references/feedback-format-and-cleanup.md:37` still says the backlog "keeps completed or archived points", but the new policy now explicitly allows backlog rows in `対応中` while waiting for a commit-backed closure record (`skills/feedback-points-manager/SKILL.md:117,162`, `skills/feedback-points-manager/references/skillization-operations.md:51-56`, `feedback-points/feedback-points-backlog.md:8,22`). As written, the reference used for table/status guidance contradicts the newly introduced closure flow and can cause a normal compliant `対応中` backlog move to be treated as invalid.
+- User-confirmation-required capability gaps:
+  - なし
+- Non-blocking concerns that should be recorded and held:
+  - `feedback-points/feedback-points-backlog.md:22` packs reviewer model policy, report ownership, release/disposition policy, sub-agent execution boundaries, and feedback-ledger location into one FP row and one duplicate group. That conflicts with the taxonomy guidance to keep duplicate groups as one reusable intent (`skills/feedback-points-manager/references/canonical-feedback-taxonomy.md:23,36-38`), so future recurrence counting and follow-up routing for FP-006 will be ambiguous even if the current skill edits themselves are usable.
+
+## 結果
+
+- 結果: `skills/feedback-points-manager/references/feedback-format-and-cleanup.md` の backlog 説明を新しい `対応中` 運用に合わせて揃えるまでは `no findings` にはできない。現時点のレビュー結果は `2 findings`。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: blocker を直さないまま進めると、`feedback-points-manager` / `feedback-points-sanitizer` の実行者が backlog の `対応中` 行を方針違反と誤解する。FP-006 の粒度は今回は hold でよいが、次回同系統の feedback を追加する前に duplicate-group の分割方針を決めないと ledger の再利用性が落ちる。

--- a/reports/skills-review-policy-feedback-ledger-review-r7-20260509191616.md
+++ b/reports/skills-review-policy-feedback-ledger-review-r7-20260509191616.md
@@ -1,0 +1,38 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: SKILL repo の reviewer policy、feedback-point closure policy、report revision naming rule、sub-agent scope restriction 反映後の差分を最終レビューする
+- タスク種別: review
+
+## sub-agentを使う理由
+
+- 理由: blocker 解消後に残件が hold のみかを独立 reviewer で確認するため
+
+## 対象範囲
+
+- 対象: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/report-output-manager/SKILL.md`, `skills/report-output-manager/references/report-filename-policy.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 対象外
+
+- 対象外: 既存 report の書式変更、`/home/ibis/ssl/IbisDuck` 側の変更、今回の対象外 skill
+
+## 実行コマンド
+
+- 実行コマンド: `sed -n`, `nl -ba`, `git status --short`, `git diff -- <scope>`, `git diff --check -- <scope>`, `rg -n`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `skills/review-enforcer/SKILL.md`, `skills/sub-agent-task-manager/SKILL.md`, `skills/codex-delegation-executor/SKILL.md`, `skills/development-orchestrator/SKILL.md`, `skills/restart-handover-manager/SKILL.md`, `skills/feedback-points-manager/SKILL.md`, `skills/feedback-points-sanitizer/SKILL.md`, `skills/report-output-manager/SKILL.md`, `skills/report-output-manager/references/report-filename-policy.md`, `skills/feedback-points-manager/references/feedback-format-and-cleanup.md`, `skills/feedback-points-manager/references/canonical-feedback-taxonomy.md`, `skills/feedback-points-manager/references/skillization-operations.md`, `feedback-points/README.md`, `feedback-points/feedback-points.md`, `feedback-points/feedback-points-backlog.md`
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: 指摘なし。reviewer 既定構成、report 直接記入、hold/confirm 分岐、sub-agent の scope 制約、feedback-point canonical path 集約、report revision 命名規則は対象範囲内で相互に矛盾なく反映されている。
+
+## 結果
+
+- 結果: `no findings`。対象の未コミット変更は correctness / policy consistency の観点でこのまま進めて問題ない。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: blocker はなし。`feedback-points/feedback-points-backlog.md` の `FP-006` は新ポリシーどおり commit-backed closure 待ちの `対応中` と読めるため、関連 commit 作成後にその commit を `根拠リンク` に反映して閉じる前提だけ維持すればよい。

--- a/skills/codex-delegation-executor/SKILL.md
+++ b/skills/codex-delegation-executor/SKILL.md
@@ -55,6 +55,7 @@ The following work must be executed by a `sub-agent` now, not merely preferred:
 - standards detection or standards validation
 
 Use `sub-agent-task-manager` for these categories and require a report in `reports/`.
+Use `gpt-5.4` with `high` reasoning effort as the default reviewer configuration for review tasks unless the user explicitly overrides it for the current run.
 
 ## Executor selection
 
@@ -104,7 +105,11 @@ For each delegated task:
 - Instruct the `sub-agent` to read the pre-created report and preserve its format, filling only blank sections or placeholders.
 - Exclude noisy diffs and irrelevant generated files from the explicit focus, but do not block the `sub-agent` from reading broader workspace context when needed.
 - Require concrete evidence instead of verbal assurance.
+- Do not instruct a `sub-agent` to run `codex exec`, nested Codex, or equivalent agent-spawning workflows inside the delegated task.
+- Do not instruct a `sub-agent` to re-enter `development-orchestrator` or any other parent-owned workflow unless that orchestration work is itself the explicit delegated task.
 - For review tasks, instruct the `sub-agent` to use the built-in review behavior rather than a custom ad hoc review style.
+- For review tasks, instruct the `sub-agent` to edit the pre-created report directly and treat parent-side report transcription as fallback only.
+- For review tasks, instruct the reviewer to separate normal-path blockers, user-confirmation-required capability gaps, and non-blocking concerns that should only be recorded and held.
 - For review and investigation tasks, prefer workspace-direct inspection over parent-written excerpts when repository access is available.
 - For review tasks, do not accept chat-only review output; require the findings to be written into the report file.
 - When a delegated task depends on an existing skill, instruct the executor to read that skill file explicitly.

--- a/skills/development-orchestrator/SKILL.md
+++ b/skills/development-orchestrator/SKILL.md
@@ -35,7 +35,7 @@ Before running this skill, confirm:
 - the user's intended work for this run when it is not already explicit from the request or restart context
 - current `tasks-status.md` and `phases-status.md`
 - recent `reports/` relevant to the active issue or task
-- active `feedback-points/feedback-points.md`
+- active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
 - repository state needed to choose the next task
 
 ## Required flow
@@ -48,7 +48,7 @@ Follow this sequence:
 4. If the local skill repo is dirty, diverged, or otherwise unsafe to auto-update, stop and resolve that explicitly before trusting the workflow.
 5. When entering from a resumed or restarted session, call `restart-handover-manager` to reconstruct the current position before selecting the next task.
 6. When the intended work for this run is not already explicit, read [references/start-intake-policy.md](references/start-intake-policy.md) and confirm with the user what work should be done before selecting a task.
-7. Confirm current state from `tasks-status.md`, `phases-status.md`, recent `reports/`, and `feedback-points/feedback-points.md`.
+7. Confirm current state from `tasks-status.md`, `phases-status.md`, recent `reports/`, and `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`.
 8. Select exactly one next task.
 9. Call `task-consistency-manager`.
 10. Call `design-doc-maintainer` if design impact exists.
@@ -78,6 +78,7 @@ Follow this sequence:
 - Treat test authoring and code authoring as switchable implementation work under `codex-delegation-executor` with `implementation-executor`.
 - Do not downgrade skills that require mandatory `sub-agent` execution.
 - When work is delegated to a `sub-agent`, prefer making it read the relevant skill files instead of relying on a paraphrased prompt alone.
+- Do not make delegated `sub-agent` tasks re-enter this workflow entry skill unless the parent explicitly delegated orchestration analysis itself.
 - If any future skill remains `どちらでも良い`, resolve that ownership before work starts and batch the user confirmation up front.
 - Call `feedback-points-manager` whenever a reusable process problem, repeated instruction, or workflow failure is detected.
 - Call `feedback-points-manager` for reusable execution lessons discovered mid-task even when the user did not explicitly ask to register an `FP`.

--- a/skills/feedback-points-manager/SKILL.md
+++ b/skills/feedback-points-manager/SKILL.md
@@ -5,7 +5,7 @@ description: Maintain feedback-points.md as a cross-cutting record of reusable w
 
 # Feedback Points Manager
 
-Maintain `<repo-root>/feedback-points/feedback-points.md` as the system of record for reusable workflow lessons.
+Maintain `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md` as the system of record for reusable workflow lessons.
 
 ## Goal
 
@@ -23,14 +23,14 @@ Run this skill as: `parent`
 Before running this skill, gather:
 
 - candidate process lesson or repeated workflow problem
-- current active `feedback-points/feedback-points.md`
+- current active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
 - any existing duplicate group or related skill context
 - whether the trigger came from explicit user instruction, parent judgment, or sub-agent proposal
 
-The canonical files live in the real repository root, not inside the symlinked `skills/` tree:
+The canonical files live in the SKILL repository root, not inside the symlinked `skills/` tree of a consuming project:
 
-- active: `<repo-root>/feedback-points/feedback-points.md`
-- backlog: `<repo-root>/feedback-points/feedback-points-backlog.md`
+- active: `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
+- backlog: `/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md`
 
 If either file must be created from scratch, include a top-of-file rule stating that it may be updated only through `feedback-points-manager` or `feedback-points-sanitizer`.
 
@@ -61,7 +61,7 @@ Run this skill when:
 - you need to decide whether to recommend a new skill or update an existing one
 - a reusable execution lesson is discovered during work even if the user did not explicitly label it as an `FP`
 - an in-flight adjustment to tools, patch sizing, sequencing, or delegation proved necessary to keep execution stable
-- a commit-ready skill/process improvement needs a tracked follow-up issue before the loop can be considered handed off
+- a commit-ready skill/process improvement needs either a tracked follow-up issue or an explicit commit-backed skip rationale before the loop can be considered handed off
 
 ## Scope filter
 
@@ -83,8 +83,8 @@ Do not keep one-off feature specifications here if they belong in design docs, r
 
 Read in this order:
 
-1. active `feedback-points/feedback-points.md`
-2. `feedback-points/feedback-points-backlog.md` only if needed
+1. active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
+2. `/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md` only if needed
 3. related `tasks-status.md` and `phases-status.md` only if needed for context
 
 Open only one reference unless the situation clearly spans multiple decisions:
@@ -102,7 +102,7 @@ If the answer is obvious from the active row and current skill context, do not o
 
 If the active file is visibly noisy, mixed with issue-specific content, or hard to classify, call `feedback-points-sanitizer` first.
 
-Before writing to `feedback-points/feedback-points.md`, get a pre-write classification review when the point is new, materially rewritten, ambiguous, or potentially duplicative. Prefer an independent sub-agent pass via `feedback-points-sanitizer` when available. Only write directly when reusable-process classification is obvious.
+Before writing to `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`, get a pre-write classification review when the point is new, materially rewritten, ambiguous, or potentially duplicative. Prefer an independent sub-agent pass via `feedback-points-sanitizer` when available. Only write directly when reusable-process classification is obvious.
 
 Treat the classification as parent-direct only when the reusable-process nature is obvious. For non-obvious cases, request a classification pass from `feedback-points-sanitizer` first.
 
@@ -112,7 +112,9 @@ When writing or updating a feedback-point row, always record `記録起点` so t
 
 If the user says `〜べきです`, treat that statement as an explicit `指摘` by default, not as optional advice. Route it through this skill immediately unless it is clearly non-process content.
 
-When a skill-improvement loop has been committed or otherwise reached the point where follow-up should be tracked externally, create the corresponding issue, preserve the full FP content in that issue, and remove the active row from `feedback-points/feedback-points.md`.
+When a skill-improvement loop has been committed or otherwise reached the point where follow-up should be tracked externally, create the corresponding issue, preserve the full FP content in that issue, and remove the active row from `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`.
+If the point has been fully reflected in the same skill commit and no external follow-up remains, an issue may be skipped, but the skip rationale and commit-backed system of record must be stated explicitly in `次アクション対応` and supporting evidence before the loop is treated as closed.
+If the current run has finished the skill edits but the commit-backed closure record does not exist yet, you may move the point out of the active ledger into backlog as `対応中`, provided `次アクション対応` explicitly says the closure is waiting on the upcoming commit and does not claim closure early.
 
 ## Required output after each run
 
@@ -125,7 +127,9 @@ After running this skill, leave clear evidence in chat or report:
 - related skill update/new-skill decision
 - `次アクション対応`
 - issue creation result (issue URL/number, or draft file path)
-- whether the active FP row was removed or moved to backlog after issue creation
+- explicit skip rationale when no issue was created
+- whether the active FP row was removed or moved to backlog after issue creation or explicit skip closure
+- whether a point was moved to backlog as `対応中` while waiting for the commit-backed closure record
 
 ## Outputs
 
@@ -136,6 +140,8 @@ After this skill runs, there should be:
 - duplicate-group and skillization status rationale
 - clear evidence of `次アクション対応`
 - no stale active FP row for a point that has already been handed off to an issue
+- no ambiguous closure state when a point was closed without an issue; the commit-backed rationale must be explicit
+- no premature closure claim before the commit-backed record actually exists
 - no active FP row left behind at commit timing for points already reflected or handed off
 
 ## Completion condition
@@ -152,4 +158,6 @@ This skill is complete only when the feedback-point decision and its rationale a
 - When the user states `〜べきです`, do not defer classification or wait for an explicit `FP` request; treat it as a process finding immediately unless clearly out of scope.
 - When a feedback-point materially affects an existing skill, consider updating that skill even if the current thresholds or wording already exist.
 - When a follow-up issue has been created for a skill-improvement point, preserve the FP content in the issue body and remove that point from the active FP ledger.
-- By the time related work is committed, active `feedback-points.md` should be empty again unless a truly not-yet-handoffable point was created in the same run and cannot yet be issue-tracked.
+- When a feedback-point is fully resolved by the current skill commit and no external follow-up remains, you may skip issue creation only if the closure rationale is explicit and traceable.
+- Before that commit exists, a backlog row may remain `対応中`, but it must not claim final closure or a commit-backed system of record yet.
+- By the time related work is committed, active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md` should be empty again unless a truly not-yet-handoffable point was created in the same run and cannot yet be issue-tracked.

--- a/skills/feedback-points-manager/references/canonical-feedback-taxonomy.md
+++ b/skills/feedback-points-manager/references/canonical-feedback-taxonomy.md
@@ -2,7 +2,7 @@
 
 Open this only when you need a canonical category value or a stable duplicate-group name.
 
-`<repo-root>/feedback-points/feedback-points.md` uses a canonical `カテゴリ` value from this list.
+`/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md` uses a canonical `カテゴリ` value from this list.
 
 ## Categories
 

--- a/skills/feedback-points-manager/references/feedback-format-and-cleanup.md
+++ b/skills/feedback-points-manager/references/feedback-format-and-cleanup.md
@@ -6,7 +6,7 @@ Open this only when you need table format, status vocabulary, or legacy cleanup 
 
 When bootstrapping a new active or backlog file, include an update-rule note near the top stating that the file may be updated only through `feedback-points-manager` or `feedback-points-sanitizer`.
 
-Use this active table schema for `<repo-root>/feedback-points/feedback-points.md`:
+Use this active table schema for `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`:
 
 - `FP`
 - `記録起点`
@@ -23,7 +23,7 @@ Use this active table schema for `<repo-root>/feedback-points/feedback-points.md
 - `次アクション対応`
 - `根拠リンク`
 
-Use the same schema for `<repo-root>/feedback-points/feedback-points-backlog.md` unless a one-time legacy archive section is being preserved.
+Use the same schema for `/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md` unless a one-time legacy archive section is being preserved.
 
 ## Origin values
 
@@ -34,7 +34,7 @@ Use the same schema for `<repo-root>/feedback-points/feedback-points-backlog.md`
 - `sub-agent提案`: sub-agent の分類や提案を受けて親が記録した
 - `混合`: 複数の起点が明確に混ざっており、単一値に落とせない
 
-`<repo-root>/feedback-points/feedback-points-backlog.md` keeps completed or archived points.
+`/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md` keeps completed or archived points, and may temporarily hold `対応中` rows when active ledger items are waiting for commit-backed closure.
 It may contain a one-time `Legacy Archive` section in an older schema.
 
 ## Status values

--- a/skills/feedback-points-manager/references/skillization-operations.md
+++ b/skills/feedback-points-manager/references/skillization-operations.md
@@ -6,7 +6,7 @@ Open this only when you need issue creation flow, routing to another skill, or t
 
 When a duplicate group is reusable across repositories, create an issue in the skill repository.
 
-At commit timing for a skill/process improvement loop, do not stop at the commit alone. Create or confirm the follow-up issue in the skill repository before considering the loop handed off.
+At commit timing for a skill/process improvement loop, do not stop at the commit alone. Either create or confirm the follow-up issue in the skill repository, or record an explicit commit-backed skip rationale when the point is fully resolved by the same skill commit.
 
 Priority:
 
@@ -35,11 +35,25 @@ The issue body must preserve the full FP meaning, not just a short summary. Carr
 
 Once the issue exists:
 
-1. remove the active FP row from `feedback-points/feedback-points.md`
-2. move it to `feedback-points/feedback-points-backlog.md` or otherwise archive it outside the active ledger
+1. remove the active FP row from `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
+2. move it to `/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md` or otherwise archive it outside the active ledger
 3. include the created issue URL in `根拠リンク`
 
 Do not open duplicate issues for the same group unless scope materially changed.
+
+If no issue is needed because the point is fully resolved by the same skill commit:
+
+1. remove the active FP row from `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
+2. move it to `/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md` or otherwise archive it outside the active ledger
+3. state the skip rationale explicitly in `次アクション対応`
+4. include commit-backed evidence in `根拠リンク`
+
+If the skill edits are done but the commit-backed closure record does not exist yet:
+
+1. remove the active FP row from `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
+2. move it to `/home/ibis/AI/CodexSkill/feedback-points/feedback-points-backlog.md` as `対応中`
+3. state explicitly in `次アクション対応` that closure is waiting on the upcoming commit
+4. include report-backed progress evidence in `根拠リンク` until the commit exists
 
 ## Recommended routing
 
@@ -65,7 +79,7 @@ If classification is `existing skill update`:
 4. update the skill and any references/scripts
 5. collect evidence if behavior or routing changed
 6. commit the change
-7. create or confirm the follow-up issue if ongoing loop tracking still matters after the commit
+7. create or confirm the follow-up issue if ongoing loop tracking still matters after the commit; otherwise record an explicit skip rationale
 8. create a PR
 9. tell the user the PR is ready to review
 
@@ -76,7 +90,7 @@ Suggested supporting skills:
 
 ## Pre-write review for active ledger updates
 
-Before writing to `<repo-root>/feedback-points/feedback-points.md`, run a classification review with `feedback-points-sanitizer` when any are true:
+Before writing to `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`, run a classification review with `feedback-points-sanitizer` when any are true:
 
 - the point is new
 - the point is materially rewritten

--- a/skills/feedback-points-sanitizer/SKILL.md
+++ b/skills/feedback-points-sanitizer/SKILL.md
@@ -9,7 +9,7 @@ Keep feedback points actionable and reusable.
 
 ## Goal
 
-Ensure `<repo-root>/feedback-points/feedback-points.md` contains process-level reusable lessons, not mixed operational noise.
+Ensure `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md` contains process-level reusable lessons, not mixed operational noise.
 
 ## Execution owner
 

--- a/skills/report-output-manager/SKILL.md
+++ b/skills/report-output-manager/SKILL.md
@@ -40,6 +40,8 @@ Run this skill when:
 - Place reports in `<repo-root>/reports/`.
 - For new filenames, use:
   - `<issue-prefix>-<item-name>-<yyyymmddhhmmss>.md`
+- When the same logical report needs another revision, keep the same prefix and item name, then insert `-r<revision>` before the timestamp:
+  - `<issue-prefix>-<item-name>-r<revision>-<yyyymmddhhmmss>.md`
 - Prefer canonical issue-based prefixes over freeform labels.
 - Write report body text in Japanese unless the user explicitly requests another language.
 - Do not rename legacy reports unless explicitly requested.
@@ -54,6 +56,11 @@ Run this skill when:
 Use the script when you want a deterministic path:
 
 - [scripts/build_report_path.sh](scripts/build_report_path.sh)
+
+Current limitation:
+
+- `build_report_path.sh` generates the base `<issue-prefix>-<item-name>-<timestamp>.md` form.
+- When you need a revisioned filename with `-r<revision>-`, choose the final path manually unless the script has been extended for that case.
 
 ## Outputs
 

--- a/skills/report-output-manager/references/report-filename-policy.md
+++ b/skills/report-output-manager/references/report-filename-policy.md
@@ -16,11 +16,26 @@ Use this format for new report files:
 
 - `<issue-prefix>-<item-name>-<yyyymmddhhmmss>.md`
 
+If the same logical report needs another revision, use:
+
+- `<issue-prefix>-<item-name>-r<revision>-<yyyymmddhhmmss>.md`
+
+Revision rules:
+
+- first report uses no revision suffix
+- second revision uses `r2`
+- third revision uses `r3`
+- keep the same prefix and item name across revisions
+- increment the revision number only when the later file supersedes the earlier report for the same logical review/evidence thread
+- if the helper script does not yet support revision output, choose the revisioned filename manually instead of overloading `item-name`
+
 Examples:
 
 - `issue-128-review-summary-20260418153022.md`
 - `issue-128-test-evidence-20260418154409.md`
 - `task-phase-2-intake-note-20260418160140.md`
+- `task-tracker-006-review-r2-20260509150434.md`
+- `topic-skill-review-policy-review-r3-20260509185626.md`
 
 ## Prefix selection
 
@@ -42,6 +57,7 @@ Normalization rules:
 ## Consistency rules
 
 - If a report already exists for the same issue/task/topic, reuse the same prefix family.
+- If a report revision already exists for the same logical thread, reuse the same prefix family and item name, and only increment the `r<revision>` segment.
 - When an issue number exists, do not invent a natural-language prefix. Use `issue-<number>`.
 - Keep `item-name` short and descriptive:
   - `review-summary`

--- a/skills/restart-handover-manager/SKILL.md
+++ b/skills/restart-handover-manager/SKILL.md
@@ -24,14 +24,14 @@ Run this skill as: `parent`
 
 Before running this skill, gather:
 
-- current `feedback-points/feedback-points.md`
+- current `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
 - `phases-status.md`
 - `tasks-status.md`
 - recent `reports/`
 
 ## Read in this order
 
-1. `feedback-points/feedback-points.md`
+1. `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
 2. `phases-status.md`
 3. `tasks-status.md`
 4. recent `reports/`

--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -32,11 +32,17 @@ Before running this skill, gather:
 1. Prepare a task-scoped diff or changed-file set, but keep broader workspace context available for direct inspection by the reviewer.
 2. Run review for that task only as a `sub-agent` task through `sub-agent-task-manager`.
 3. Instruct the review `sub-agent` to use the built-in review behavior: findings first, severity-ordered, with file/line references when available.
-4. Materialize the built-in review result into the pre-created report file under `reports/` while preserving the existing template format and filling only the intended blank sections.
-5. If the review `sub-agent` does not write the report file directly, have the parent write it immediately from the returned review findings.
-6. Address findings if any.
-7. Re-run review if required.
-8. Only then allow progress sync and Git submission.
+4. Use `gpt-5.4` with `high` reasoning effort as the default review `sub-agent` unless the user explicitly overrides the reviewer model for the current run.
+5. Materialize the built-in review result into the pre-created report file under `reports/` while preserving the existing template format and filling only the intended blank sections.
+6. Prefer having the review `sub-agent` write the report file directly; treat parent-side report materialization as fallback only.
+7. If the review `sub-agent` does not write the report file directly, have the parent write it immediately from the returned review findings.
+8. Once review has been dispatched, keep waiting or re-polling until the review `sub-agent` finishes unless the user explicitly tells you to stop.
+9. Treat report structure as parent-owned. The reviewer may fill only blank sections or placeholder values and must not repair, reorder, rename, or reformat the template.
+10. Address findings that break the intended normal path.
+11. If a finding means the user still cannot do what they intend even with careful use, stop and confirm with the user before deciding whether to expand scope.
+12. If a finding is avoidable by careful use and the user can still achieve the intended goal, record it in the report and leave it on hold until a concrete problem appears or the user explicitly promotes it.
+13. Re-run review if required.
+14. Only then allow progress sync and Git submission.
 
 If step 2 cannot be executed because the current run lacks explicit user permission for delegation, stop and ask the user before continuing. Do not silently replace mandatory `sub-agent` review with parent review.
 
@@ -50,9 +56,16 @@ When creating a new review report file, call `report-output-manager`.
 - Distinguish between “no findings” and “review not run”.
 - Review is mandatory sub-agent work.
 - Reviewer assignment is never switchable to the parent.
+- Default reviewer model is `gpt-5.4` with `high` reasoning effort unless the user explicitly chooses another reviewer configuration.
 - If mandatory `sub-agent` review is blocked by permission or execution-mode constraints, ask the user explicitly instead of improvising a parent-side substitute.
 - Review requests should explicitly ask for a code review, not a generic diff summary.
 - Review requests should tell the `sub-agent` to read the pre-created report first and preserve its headings, order, spacing, and any prefilled text.
+- Review requests should explicitly allow and require the reviewer to fill the pre-created report file directly.
+- Report template ownership stays with the parent; the reviewer is not allowed to fix formatting, headings, spacing, or other report structure.
+- Prefer shipping a working normal path over delaying for a speculative full hardening pass.
+- If a review concern is real but avoidable by careful use, and the user can still achieve the intended goal, record it in the report and mark it as held rather than blocking release immediately.
+- If a review concern means the user cannot achieve the intended goal, stop and confirm with the user unless the intended normal path is already broken and should simply be fixed.
+- Do not cancel, replace, or abandon an in-flight review `sub-agent` only because it is slow or a wait timed out; keep waiting until it completes unless the user explicitly says to stop.
 - Do not constrain the reviewer to a parent-authored diff summary when surrounding workspace context matters.
 - Built-in review output alone is not sufficient; it must also exist in the report file.
 
@@ -67,6 +80,7 @@ Include:
 - file/line references for findings when available
 - explicit `no findings` statement when applicable
 - disposition of findings
+- explicit hold/disposition for non-blocking concerns when they are deferred
 - final outcome
 
 ## Outputs

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -60,6 +60,8 @@ Every sub-agent request must include:
 - task purpose
 - exact scope
 - explicit non-goals
+- explicit instruction not to run `codex exec`, nested Codex, or equivalent agent-spawning inside the sub-agent task
+- explicit instruction not to re-enter `development-orchestrator` or any other parent-owned workflow unless the parent explicitly named that workflow as part of the delegated task
 - skill names and file paths that must be read first
 - validation commands or evidence expectations
 - report path
@@ -69,12 +71,15 @@ Every sub-agent request must include:
 
 For review tasks also include:
 
+- instruction to use `gpt-5.4` with `high` reasoning effort by default unless the user explicitly overrides the reviewer model
 - explicit instruction to perform a code review using the built-in review behavior
 - instruction to return findings first, ordered by severity
 - instruction to include file/line references when available
 - instruction to say explicitly when no findings were found
+- instruction to treat the report template as immutable structure and fill only blank sections or placeholder values
+- instruction to distinguish blocking normal-path problems, user-confirmation-required capability gaps, and non-blocking concerns that should only be recorded and held
 - instruction to inspect the relevant workspace directly when surrounding code context is needed, instead of relying only on a parent-prepared diff summary
-- instruction to write those findings into the pre-created report file without changing the report format
+- explicit permission and requirement to write those findings into the pre-created report file without changing the report format
 
 For investigation tasks also include:
 
@@ -99,6 +104,9 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 - If the `sub-agent` cannot write the report directly, the parent agent must write it immediately from the returned evidence.
 - Do not ask a sub-agent for ad hoc investigation, review, or implementation without a report path.
 - For review tasks, the built-in review result must be materialized into the report file before the task is considered complete.
+- For review tasks, direct report editing by the reviewer is the default path; parent-side transcription is fallback only when direct editing is not possible.
+- For review tasks, a concern that does not break the intended normal path yet should still be written to the report, but may be held instead of blocking release immediately.
+- For review tasks, do not stop or replace an in-flight reviewer just because waiting took too long; keep waiting until completion unless the user explicitly says to stop.
 - Report text should be written in Japanese unless the user explicitly requests another language.
 - The `sub-agent` must preserve the existing report format: no heading renames, no section reordering, no blank-line cleanup, and no whole-file replacement.
 - Existing non-empty parent text in the report is immutable unless the parent explicitly marks it as editable.
@@ -153,6 +161,8 @@ This skill is complete only when:
 - Prefer one bounded request over one broad speculative request.
 - Reuse existing reports before dispatching duplicate work.
 - Use `execution-cost-stabilizer` if the delegation plan risks wasteful reruns or excessive parallelism.
+- Do not make a sub-agent run `codex exec`, nested Codex, or equivalent agent-spawning workflows inside the delegated task.
+- Do not let a sub-agent re-run `development-orchestrator` or other parent-owned workflow entry skills just because they exist in the repo; the sub-agent should execute only the delegated task and the explicitly named supporting skills.
 - Do not leave report structure up to the `sub-agent`.
 - For investigation and review tasks, prefer letting the `sub-agent` read the relevant workspace directly instead of over-constraining it to parent-curated excerpts.
 - For review tasks, prefer the model's native review behavior over inventing a custom review rubric in the prompt.


### PR DESCRIPTION
## Summary
- enforce the default reviewer sub-agent policy around `gpt-5.4` with `high`, parent-owned report templates, direct hole-filling only, and no report reformatting
- forbid sub-agents from running `codex exec`, nested Codex, or re-entering parent-owned workflows such as `development-orchestrator`
- centralize feedback-point ledgers in the SKILL repository and clarify backlog/closure handling, including commit-backed closure and `対応中` backlog rows
- define report revision naming with `-r<revision>-<timestamp>` and document the current helper-script limitation

## Issue
- No linked issue for this PR. This change directly reflects the FP-006 skill/process loop, and issue creation was intentionally skipped under the same-commit closure rule documented in `skills/feedback-points-manager/SKILL.md`.

## Validation
- final independent review: `reports/skills-review-policy-feedback-ledger-review-r7-20260509191616.md` (`gpt-5.4 high`, no findings)
- prior review iterations and follow-up trail are preserved in `reports/skills-review-policy-feedback-ledger-review-20260509184523.md` through `reports/skills-review-policy-feedback-ledger-review-r6-20260509191205.md`

## Notes
- the current report-path helper still generates the base filename form; revisioned filenames are documented and currently selected manually until the helper is extended
- no blocking findings remained in the final review