### PR TITLE
Add Markdown lint scripts to review-enforcer

### DIFF
--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -33,21 +33,23 @@ Before running this skill, gather:
 
 1. Prepare a task-scoped diff or changed-file set, but keep broader workspace context available for direct inspection by the reviewer.
 2. When the review touches source layout, naming, partial types, XML documentation, or test comments, read [references/session-review-shape-policy.md](references/session-review-shape-policy.md) before drafting the review request.
-3. Reuse the same review `sub-agent` for the session when one is already assigned and still available; otherwise select one reviewer and record that assignment in the report or parent progress note.
-4. Include task-specific review criteria from earlier audit/design decisions in the review request, and require the reviewer to evaluate the diff against those criteria.
-5. Run review for that task only as a `sub-agent` task through `sub-agent-task-manager`.
-6. Instruct the review `sub-agent` to use the built-in review behavior: findings first, severity-ordered, with file/line references when available.
-7. Use `gpt-5.4` with `high` reasoning effort as the default review `sub-agent` unless the user explicitly overrides the reviewer model for the current run.
-8. Materialize the built-in review result into the pre-created report file under `reports/` while preserving the existing template format and filling only the intended blank sections.
-9. Prefer having the review `sub-agent` write the report file directly; treat parent-side report materialization as fallback only.
-10. If the review `sub-agent` does not write the report file directly, have the parent write it immediately from the returned review findings.
-11. Once review has been dispatched, keep waiting or re-polling until the review `sub-agent` finishes unless the user explicitly tells you to stop.
-12. Treat report structure as parent-owned. The reviewer may fill only blank sections or placeholder values and must not repair, reorder, rename, or reformat the template.
-13. Address findings that break the intended normal path.
-14. If a finding means the user still cannot do what they intend even with careful use, stop and confirm with the user before deciding whether to expand scope.
-15. If a finding is avoidable by careful use and the user can still achieve the intended goal, record it in the report and leave it on hold until a concrete problem appears or the user explicitly promotes it.
-16. Re-run review if required, using the same session reviewer unless the reference policy allows a change.
-17. Only then allow progress sync and Git submission.
+3. When the task changes Markdown, markdown lint configuration, reports, task tracking, design documents, or review-facing text, run the repository Markdown lint gate before completion. Prefer `npm run lint:md` when the target repository provides it. If the repository uses the standard review-enforcer scripts, the shared implementation lives under [scripts/](scripts/) and the repository owns only its `tools/lint/markdown-whitelist.yaml`, `tools/lint/markdown-targets.json`, package wiring, and local setup memo.
+4. Treat Markdown lint failure as a blocking review gate unless the current task is explicitly to introduce a failing stricter gate and the failure is recorded as the intended current state in the implementation report and tracking.
+5. Reuse the same review `sub-agent` for the session when one is already assigned and still available; otherwise select one reviewer and record that assignment in the report or parent progress note.
+6. Include task-specific review criteria from earlier audit/design decisions in the review request, and require the reviewer to evaluate the diff against those criteria.
+7. Run review for that task only as a `sub-agent` task through `sub-agent-task-manager`.
+8. Instruct the review `sub-agent` to use the built-in review behavior: findings first, severity-ordered, with file/line references when available.
+9. Use `gpt-5.4` with `high` reasoning effort as the default review `sub-agent` unless the user explicitly overrides the reviewer model for the current run.
+10. Materialize the built-in review result into the pre-created report file under `reports/` while preserving the existing template format and filling only the intended blank sections.
+11. Prefer having the review `sub-agent` write the report file directly; treat parent-side report materialization as fallback only.
+12. If the review `sub-agent` does not write the report file directly, have the parent write it immediately from the returned review findings.
+13. Once review has been dispatched, keep waiting or re-polling until the review `sub-agent` finishes unless the user explicitly tells you to stop.
+14. Treat report structure as parent-owned. The reviewer may fill only blank sections or placeholder values and must not repair, reorder, rename, or reformat the template.
+15. Address findings that break the intended normal path.
+16. If a finding means the user still cannot do what they intend even with careful use, stop and confirm with the user before deciding whether to expand scope.
+17. If a finding is avoidable by careful use and the user can still achieve the intended goal, record it in the report and leave it on hold until a concrete problem appears or the user explicitly promotes it.
+18. Re-run review if required, using the same session reviewer unless the reference policy allows a change.
+19. Only then allow progress sync and Git submission.
 
 If mandatory review `sub-agent` dispatch cannot be executed because the current run lacks explicit user permission for delegation, stop and ask the user before continuing. Do not silently replace mandatory `sub-agent` review with parent review.
 
@@ -70,6 +72,11 @@ When creating a new review report file, call `report-output-manager`.
 - Review requests should tell the `sub-agent` to read the pre-created report first and preserve its headings, order, spacing, and any prefilled text.
 - Review requests should explicitly allow and require the reviewer to fill the pre-created report file directly.
 - Report template ownership stays with the parent; the reviewer is not allowed to fix formatting, headings, spacing, or other report structure.
+- Markdown text quality is part of the review gate. When a repository has Markdown lint wiring, do not treat Markdown changes as review-complete until that lint gate is either passing or explicitly documented as an intentionally failing stricter gate for the current task.
+- Repository-specific whitelist data must stay in the target repository. Do not put project terms into this skill; the shared scripts should read `tools/lint/markdown-whitelist.yaml` from the current repository.
+- Changes to `tools/lint/markdown-whitelist.yaml` require explicit user review before the task can be treated as complete. Do not add, remove, or rewrite whitelist entries and then close the task only through agent review; the user must explicitly review the whitelist content because it defines accepted terminology and meanings.
+- The standard Markdown lint scripts support explicit file review. `scripts/list-markdown-targets.js --files <path...>` lists only those Markdown files after repository ignore rules are applied. Pipe that output to `textlint` or `scripts/run-cspell-markdown.js` when focused validation is needed. `scripts/check-markdown-whitelist.js --files <path...>` checks only those Markdown files plus whitelist descriptions. Use explicit file mode for focused review evidence when full-scope lint is intentionally failing because the stricter gate is being introduced.
+- When Markdown lint excludes inline code or quoted identifiers, the reviewer must also check for lint evasion. Do not accept prose changes that merely wrap ordinary English words, katakana words, or unexplained terms in backticks or quotation marks to avoid the whitelist gate; backticks should be used only for real code, identifiers, commands, file paths, UI labels, or explicitly itemized terms.
 - Prefer shipping a working normal path over delaying for a speculative full hardening pass.
 - If a review concern is real but avoidable by careful use, and the user can still achieve the intended goal, record it in the report and mark it as held rather than blocking release immediately.
 - If a review concern means the user cannot achieve the intended goal, stop and confirm with the user unless the intended normal path is already broken and should simply be fixed.

--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -39,7 +39,7 @@ Before running this skill, gather:
 6. Include task-specific review criteria from earlier audit/design decisions in the review request, and require the reviewer to evaluate the diff against those criteria.
 7. Run review for that task only as a `sub-agent` task through `sub-agent-task-manager`.
 8. Instruct the review `sub-agent` to use the built-in review behavior: findings first, severity-ordered, with file/line references when available.
-9. Use `gpt-5.4` with `high` reasoning effort as the default review `sub-agent` unless the user explicitly overrides the reviewer model for the current run.
+9. Use `gpt-5.5` with `high` reasoning effort as the first-choice review `sub-agent` unless the user explicitly overrides the reviewer model for the current run. If `gpt-5.5` is unavailable, use `gpt-5.4` with `high` reasoning effort as the next choice.
 10. Materialize the built-in review result into the pre-created report file under `reports/` while preserving the existing template format and filling only the intended blank sections.
 11. Prefer having the review `sub-agent` write the report file directly; treat parent-side report materialization as fallback only.
 12. If the review `sub-agent` does not write the report file directly, have the parent write it immediately from the returned review findings.
@@ -66,7 +66,7 @@ When creating a new review report file, call `report-output-manager`.
 - A single session should normally use one reviewer `sub-agent` for initial review and re-review so review standards remain consistent.
 - If the reviewer must change because the original reviewer is unavailable, conflicted, or explicitly replaced by the user, record the reason in the review report.
 - When a session has established concrete review criteria, such as naming, placement, XML comment, test-comment, or design-consistency rules, later reviews in that session must apply those criteria unless the user supersedes them.
-- Default reviewer model is `gpt-5.4` with `high` reasoning effort unless the user explicitly chooses another reviewer configuration.
+- Default reviewer model priority is `gpt-5.5 high` first, then `gpt-5.4 high` if `gpt-5.5` is unavailable, unless the user explicitly chooses another reviewer configuration.
 - If mandatory `sub-agent` review is blocked by permission or execution-mode constraints, ask the user explicitly instead of improvising a parent-side substitute.
 - Review requests should explicitly ask for a code review, not a generic diff summary.
 - Review requests should tell the `sub-agent` to read the pre-created report first and preserve its headings, order, spacing, and any prefilled text.

--- a/skills/review-enforcer/scripts/check-markdown-whitelist.js
+++ b/skills/review-enforcer/scripts/check-markdown-whitelist.js
@@ -1,0 +1,260 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const { createRequire } = require("module");
+
+const root = process.cwd();
+const requireFromRepo = createRequire(path.join(root, "package.json"));
+const YAML = requireFromRepo("yaml");
+const whitelistPath = path.join(root, "tools", "lint", "markdown-whitelist.yaml");
+const targetConfig = readTargetConfig();
+const ignoreDirectories = new Set(targetConfig.ignoreDirectories);
+const ignoredPrefixes = targetConfig.ignoredPrefixes;
+const readsStdin = process.argv[2] === "--stdin";
+
+const whitelist = readWhitelist(whitelistPath);
+const inputs = readInputs().concat(readsStdin ? [] : readWhitelistDescriptionInputs(whitelist.entries));
+const violations = [];
+const unknownWords = new Map();
+
+for (const input of inputs) {
+  const relativePath = input.relativePath;
+  const text = input.text;
+  const cleaned = maskWhitelistValues(stripMarkdownNoise(text), whitelist.valuePattern);
+
+  checkTokens(relativePath, cleaned, /(?<![A-Za-z0-9])[A-Za-z][A-Za-z0-9]*(?:[._-][A-Za-z0-9]+)*/g, shouldCheckEnglishToken);
+  checkTokens(relativePath, cleaned, /(?<![\u30A0-\u30FF])[\u30A0-\u30FF]+(?:[・ー][\u30A0-\u30FF]+)*(?![\u30A0-\u30FF])/gu, shouldCheckKatakanaToken);
+}
+
+if (process.argv.includes("--list-unknown")) {
+  for (const [, item] of [...unknownWords.entries()].sort((left, right) => left[0].localeCompare(right[0]))) {
+    console.log(`${item.word}\t${item.count}`);
+  }
+
+  process.exit(violations.length > 0 ? 1 : 0);
+}
+
+if (violations.length > 0) {
+  console.error("Markdown whitelist violations:");
+  for (const violation of violations.slice(0, 200)) {
+    console.error(`- ${violation}`);
+  }
+
+  if (violations.length > 200) {
+    console.error(`- ... ${violations.length - 200} more violations`);
+  }
+
+  process.exit(1);
+}
+
+function readInputs() {
+  if (readsStdin) {
+    const relativePath = process.argv[3] || "<stdin>";
+    return [{ relativePath, text: fs.readFileSync(0, "utf8") }];
+  }
+
+  const filePaths = readExplicitMarkdownFiles() || (process.argv.includes("--changed") ? listChangedMarkdownFiles() : listMarkdownFiles(root));
+  return filePaths.map((filePath) => ({
+    relativePath: path.relative(root, filePath).replaceAll(path.sep, "/"),
+    text: fs.readFileSync(filePath, "utf8")
+  }));
+}
+
+function readExplicitMarkdownFiles() {
+  const filesIndex = process.argv.indexOf("--files");
+  if (filesIndex === -1) {
+    return null;
+  }
+
+  const explicitFiles = process.argv.slice(filesIndex + 1).filter((arg) => !arg.startsWith("--"));
+  return explicitFiles
+    .map((file) => file.replaceAll(path.sep, "/"))
+    .filter((file) => file.endsWith(".md") && !isIgnored(file) && fs.existsSync(path.join(root, file)))
+    .sort((left, right) => left.localeCompare(right))
+    .map((file) => path.join(root, file));
+}
+
+function readWhitelistDescriptionInputs(entries) {
+  return entries.map((entry) => ({
+    relativePath: `${path.relative(root, whitelistPath)}:${entry.term} [whitelist description]`,
+    text: entry.description
+  }));
+}
+
+function listChangedMarkdownFiles() {
+  const candidates = new Set();
+  addGitFiles(candidates, ["diff", "--name-only", "--diff-filter=ACMR", "--", "*.md"]);
+  addGitFiles(candidates, ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "--", "*.md"]);
+  addGitFiles(candidates, ["ls-files", "--others", "--exclude-standard", "--", "*.md"]);
+
+  return [...candidates]
+    .filter((file) => file.endsWith(".md") && !isIgnored(file) && fs.existsSync(path.join(root, file)))
+    .sort((left, right) => left.localeCompare(right))
+    .map((file) => path.join(root, file));
+}
+
+function addGitFiles(candidates, args) {
+  const result = execFileSync("git", args, { cwd: root, encoding: "utf8" });
+  for (const line of result.split(/\r?\n/)) {
+    const file = line.trim();
+    if (file) {
+      candidates.add(file);
+    }
+  }
+}
+
+function listMarkdownFiles(directory) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    const relativePath = path.relative(root, fullPath).replaceAll(path.sep, "/");
+
+    if (entry.isDirectory()) {
+      if (ignoreDirectories.has(entry.name) || ignoredPrefixes.some((prefix) => `${relativePath}/`.startsWith(prefix))) {
+        continue;
+      }
+
+      files.push(...listMarkdownFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".md") && !isIgnored(relativePath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function isIgnored(relativePath) {
+  const normalizedPath = relativePath.replaceAll(path.sep, "/");
+  const pathSegments = normalizedPath.split("/");
+  return ignoredPrefixes.some((prefix) => normalizedPath.startsWith(prefix)) || pathSegments.some((segment) => ignoreDirectories.has(segment));
+}
+
+function readTargetConfig() {
+  const configPath = path.join(root, "tools", "lint", "markdown-targets.json");
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  return {
+    ignoreDirectories: config.ignoreDirectories || [],
+    ignoredPrefixes: config.ignoredPrefixes || []
+  };
+}
+
+function readWhitelist(filePath) {
+  const data = YAML.parse(fs.readFileSync(filePath, "utf8"));
+  const terms = new Set();
+  const values = new Set();
+  const entries = Array.isArray(data.entries) ? data.entries : [];
+
+  for (const entry of entries) {
+    if (!entry.term || !entry.description) {
+      throw new Error(`${filePath}: each whitelist entry must include term and description.`);
+    }
+
+    for (const value of entryValues(entry)) {
+      terms.add(normalizeTerm(value));
+      values.add(value);
+    }
+  }
+
+  return { terms, entries, valuePattern: buildWhitelistValuePattern([...values]) };
+}
+
+function entryValues(entry) {
+  return [entry.term, ...normalizeAliases(entry.aliases)].filter(Boolean);
+}
+
+function normalizeAliases(aliases) {
+  if (!aliases) {
+    return [];
+  }
+
+  return Array.isArray(aliases) ? aliases : [aliases];
+}
+
+function stripMarkdownNoise(text) {
+  return text
+    .replace(/^```[\s\S]*?^```/gm, blankPreserving)
+    .replace(/`[^`\n]+`/g, blankPreserving)
+    .replace(/^\[\^[^\]]+\]:.*$/gm, blankPreserving)
+    .replace(/https?:\/\/[^\s)]+/g, blankPreserving)
+    .replace(/mailto:[^\s)]+/g, blankPreserving)
+    .replace(/<!--[\s\S]*?-->/g, blankPreserving)
+    .replace(/\[[^\]\n]+\]\([^)]+\)/g, (value) => value.replace(/\([^)]+\)/g, ""));
+}
+
+function blankPreserving(value) {
+  return value.replace(/[^\n]/g, " ");
+}
+
+function maskWhitelistValues(text, valuePattern) {
+  if (!valuePattern) {
+    return text;
+  }
+
+  return text.replace(valuePattern, blankPreserving);
+}
+
+function buildWhitelistValuePattern(values) {
+  const alternatives = values
+    .filter((value) => value.length > 1)
+    .sort((left, right) => right.length - left.length)
+    .map((value) => escapeRegExp(value).replace(/\s+/g, "\\s+"));
+
+  if (alternatives.length === 0) {
+    return null;
+  }
+
+  return new RegExp(`(^|[^A-Za-z0-9\\u30A0-\\u30FF])(${alternatives.join("|")})(?=$|[^A-Za-z0-9\\u30A0-\\u30FF])`, "giu");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function checkTokens(relativePath, cleaned, pattern, shouldCheck) {
+  for (const match of cleaned.matchAll(pattern)) {
+    const word = match[0];
+    if (!shouldCheck(word)) {
+      continue;
+    }
+
+    const normalized = normalizeTerm(word);
+    if (!whitelist.terms.has(normalized)) {
+      const line = lineNumberAt(cleaned, match.index);
+      violations.push(`${relativePath}:${line}: '${word}' is not in tools/lint/markdown-whitelist.yaml.`);
+      const current = unknownWords.get(normalized) || { word, count: 0 };
+      current.count += 1;
+      unknownWords.set(normalized, current);
+    }
+  }
+}
+
+function shouldCheckEnglishToken(word) {
+  return word.length > 1 && !/\d/.test(word);
+}
+
+function shouldCheckKatakanaToken(word) {
+  const normalized = word.normalize("NFKC").replace(/[・ー._-]/g, "");
+  return normalized.length > 1 && /[\u30A0-\u30FF]/u.test(normalized);
+}
+
+function normalizeTerm(term) {
+  return term.normalize("NFKC").toLowerCase();
+}
+
+function lineNumberAt(text, index) {
+  let line = 1;
+  for (let cursor = 0; cursor < index; cursor += 1) {
+    if (text.charCodeAt(cursor) === 10) {
+      line += 1;
+    }
+  }
+
+  return line;
+}

--- a/skills/review-enforcer/scripts/list-markdown-targets.js
+++ b/skills/review-enforcer/scripts/list-markdown-targets.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const root = process.cwd();
+const targetConfig = readTargetConfig();
+const ignoreDirectories = new Set(targetConfig.ignoreDirectories);
+const ignoredPrefixes = targetConfig.ignoredPrefixes;
+
+const print0 = process.argv.includes("--print0");
+const files = readExplicitMarkdownFiles() || (process.argv.includes("--changed") ? listChangedMarkdownFiles() : listAllMarkdownFiles(root));
+const output = files.map((file) => path.relative(root, file).replaceAll(path.sep, "/"));
+
+process.stdout.write(output.join(print0 ? "\0" : "\n"));
+if (output.length > 0) {
+  process.stdout.write(print0 ? "\0" : "\n");
+}
+
+function listChangedMarkdownFiles() {
+  const candidates = new Set();
+  addGitFiles(candidates, ["diff", "--name-only", "--diff-filter=ACMR", "--", "*.md"]);
+  addGitFiles(candidates, ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "--", "*.md"]);
+  addGitFiles(candidates, ["ls-files", "--others", "--exclude-standard", "--", "*.md"]);
+
+  return [...candidates]
+    .filter((file) => file.endsWith(".md") && !isIgnored(file) && fs.existsSync(path.join(root, file)))
+    .sort((left, right) => left.localeCompare(right))
+    .map((file) => path.join(root, file));
+}
+
+function readExplicitMarkdownFiles() {
+  const filesIndex = process.argv.indexOf("--files");
+  if (filesIndex === -1) {
+    return null;
+  }
+
+  const explicitFiles = process.argv.slice(filesIndex + 1).filter((arg) => !arg.startsWith("--"));
+  return explicitFiles
+    .map((file) => file.replaceAll(path.sep, "/"))
+    .filter((file) => file.endsWith(".md") && !isIgnored(file) && fs.existsSync(path.join(root, file)))
+    .sort((left, right) => left.localeCompare(right))
+    .map((file) => path.join(root, file));
+}
+
+function addGitFiles(candidates, args) {
+  const result = execFileSync("git", args, { cwd: root, encoding: "utf8" });
+  for (const line of result.split(/\r?\n/)) {
+    const file = line.trim();
+    if (file) {
+      candidates.add(file);
+    }
+  }
+}
+
+function listAllMarkdownFiles(directory) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    const relativePath = path.relative(root, fullPath).replaceAll(path.sep, "/");
+
+    if (entry.isDirectory()) {
+      if (ignoreDirectories.has(entry.name) || ignoredPrefixes.some((prefix) => `${relativePath}/`.startsWith(prefix))) {
+        continue;
+      }
+
+      files.push(...listAllMarkdownFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".md") && !isIgnored(relativePath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
+function isIgnored(relativePath) {
+  const normalizedPath = relativePath.replaceAll(path.sep, "/");
+  const pathSegments = normalizedPath.split("/");
+  return ignoredPrefixes.some((prefix) => normalizedPath.startsWith(prefix)) || pathSegments.some((segment) => ignoreDirectories.has(segment));
+}
+
+function readTargetConfig() {
+  const configPath = path.join(root, "tools", "lint", "markdown-targets.json");
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  return {
+    ignoreDirectories: config.ignoreDirectories || [],
+    ignoredPrefixes: config.ignoredPrefixes || []
+  };
+}

--- a/skills/review-enforcer/scripts/run-cspell-markdown.js
+++ b/skills/review-enforcer/scripts/run-cspell-markdown.js
@@ -1,0 +1,84 @@
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+const { createRequire } = require("module");
+
+const root = process.cwd();
+const requireFromRepo = createRequire(path.join(root, "package.json"));
+const YAML = requireFromRepo("yaml");
+const whitelistPath = path.join(root, "tools", "lint", "markdown-whitelist.yaml");
+const baseConfigPath = path.join(root, "cspell.config.jsonc");
+const baseConfig = JSON.parse(fs.readFileSync(baseConfigPath, "utf8"));
+
+const whitelist = YAML.parse(fs.readFileSync(whitelistPath, "utf8"));
+const entries = Array.isArray(whitelist.entries) ? whitelist.entries : [];
+const values = entries.flatMap(entryValues).filter(Boolean);
+const dictionaryTerms = values.filter((value) => !/\s/.test(value));
+const ignoredValues = values.filter((value) => /\s|[._-]/.test(value));
+
+if (values.length === 0) {
+  throw new Error(`${whitelistPath}: entries must contain at least one term.`);
+}
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codexskill-cspell-"));
+const dictionaryPath = path.join(tempDir, "markdown-whitelist.txt");
+const configPath = path.join(tempDir, "cspell.config.json");
+
+fs.writeFileSync(dictionaryPath, `${dictionaryTerms.join("\n")}\n`, "utf8");
+fs.writeFileSync(
+  configPath,
+  JSON.stringify(
+    {
+      ...baseConfig,
+      dictionaryDefinitions: [
+        ...(baseConfig.dictionaryDefinitions || []),
+        {
+          name: "markdown-whitelist",
+          path: dictionaryPath,
+          addWords: true
+        }
+      ],
+      dictionaries: [...(baseConfig.dictionaries || []), "markdown-whitelist"],
+      ignoreRegExpList: [
+        ...ignoredValues.map((value) => whitelistValuePattern(value)),
+        ...(baseConfig.ignoreRegExpList || [])
+      ]
+    },
+    null,
+    2
+  ),
+  "utf8"
+);
+
+const cspellBin = path.join(root, "node_modules", ".bin", process.platform === "win32" ? "cspell.cmd" : "cspell");
+const result = spawnSync(cspellBin, ["--no-default-configuration", "--config", configPath, ...process.argv.slice(2)], {
+  cwd: root,
+  stdio: "inherit"
+});
+
+fs.rmSync(tempDir, { recursive: true, force: true });
+process.exit(result.status === null ? 1 : result.status);
+
+function entryValues(entry) {
+  return [entry.term, ...normalizeAliases(entry.aliases)].filter(Boolean);
+}
+
+function normalizeAliases(aliases) {
+  if (!aliases) {
+    return [];
+  }
+
+  return Array.isArray(aliases) ? aliases : [aliases];
+}
+
+function whitelistValuePattern(value) {
+  const escaped = escapeRegExp(value).replace(/\s+/g, "\\s+");
+  return `/${escaped}/giu`;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/skills/review-enforcer/scripts/textlint-rules/no-fullwidth-space.js
+++ b/skills/review-enforcer/scripts/textlint-rules/no-fullwidth-space.js
@@ -1,0 +1,21 @@
+"use strict";
+
+module.exports = function noFullwidthSpace(context) {
+  const { Syntax, RuleError, report, getSource } = context;
+
+  return {
+    [Syntax.Str](node) {
+      const text = getSource(node);
+      const index = text.indexOf("\u3000");
+
+      if (index !== -1) {
+        report(
+          node,
+          new RuleError("全角スペースではなく、通常の空白または Markdown の構造で余白を表現してください。", {
+            index
+          })
+        );
+      }
+    }
+  };
+};

--- a/skills/review-enforcer/scripts/textlint-rules/no-unresolved-placeholder-marker.js
+++ b/skills/review-enforcer/scripts/textlint-rules/no-unresolved-placeholder-marker.js
@@ -1,0 +1,27 @@
+"use strict";
+
+module.exports = function noUnresolvedPlaceholderMarker(context, options = {}) {
+  const { Syntax, RuleError, report, getSource } = context;
+  const markers = options.markers || ["TBD", "WIP"];
+  const markerPattern = new RegExp(`\\b(${markers.map(escapeRegExp).join("|")})\\b`);
+
+  return {
+    [Syntax.Str](node) {
+      const text = getSource(node);
+      const match = markerPattern.exec(text);
+
+      if (match) {
+        report(
+          node,
+          new RuleError(`未解決 placeholder marker '${match[1]}' を解消してください。`, {
+            index: match.index
+          })
+        );
+      }
+    }
+  };
+};
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- add shared Markdown target listing, whitelist checking, cspell wrapper, and textlint rules under review-enforcer scripts
- document Markdown lint review gate, explicit file mode, repository-owned whitelist, and required user review for whitelist changes
- keep repository-specific whitelist data out of the skill

## Validation
- IbisDuck smoke: explicit --files target listing
- IbisDuck smoke: whitelist alias forms pass and component words fail
- IbisDuck smoke: direct-file textlint command succeeds
- git diff --check