### PR TITLE
feat: task単位のroutineとhook gateを追加する

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "codexskill",
+  "version": "0.1.0",
+  "description": "Development workflow skills with a persistent one-task routine gate",
+  "keywords": [
+    "development-workflow",
+    "task-routine",
+    "hooks",
+    "skills"
+  ],
+  "skills": "./skills",
+  "hooks": "./hooks/hooks.json",
+  "interface": {
+    "displayName": "CodexSkill",
+    "shortDescription": "Run development through persistent task routines and reusable skills",
+    "developerName": "ssaattww",
+    "category": "developer-tools",
+    "capabilities": [
+      "skills",
+      "hooks"
+    ],
+    "defaultPrompt": "Use the development-orchestrator and its task routine before changing a Git repository."
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,7 @@
 
 - 作業前と作業中は、該当する skill が既にあるかを必ず確認しながら進めること。
 - 判断に迷いが出たら、まず skill 不足を疑い、既存 skill の再確認または skill の追加・更新要否を先に検討すること。
-- 上記 2 点はこのリポジトリ内で最大優先の制約として扱うこと。
+- Git リポジトリを変更する作業は、`development-orchestrator/scripts/task_routine.py` で 1 task の routine を開始し、現在 step と証拠を永続化してから進めること。
+- task 完了前に、既存 skill 改善の要否と、agent が直接繰り返している出力の tool/script 化要否を必ず記録すること。既存責務内の低リスクで可逆な改善は自動実施し、新規 skill や外部公開 tool は確認境界を維持すること。
+- GitHub Issue と feedback point は履歴・重複・follow-up の正本として使うが、実行を思い出す唯一の trigger にしないこと。現在の次工程は local task routine state と hook を正本とすること。
+- 上記制約はこのリポジトリ内で最大優先の制約として扱うこと。

--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -8,6 +8,7 @@
 - 親 agent から見た呼び出し関係
 - 親が実行する skill と、親が呼び出して sub-agent が実行する skill の区別
 - 標準開発フローにおける責務分担
+- 1 task ごとの永続 routine と hook による実行漏れ防止
 
 運用中のレポートよりも、この設計書を正本として扱う。
 
@@ -25,11 +26,12 @@
 
 - `親が実行` の skill でも、内部の一部工程を `sub-agent-task-manager` 経由で sub-agent に委譲する場合がある。
 - その場合でも skill 全体の責務と完了判定は親が持つ。
+- `development-orchestrator` の `scripts/task_routine.py`、state helper、hook helper は独立 skill ではなく、同 skill が所有する内部 tool とする。
 
 ## 標準開発フローの呼び出しツリー
 
 ```text
-development-orchestrator [親が実行]
+development-orchestrator [親が実行, task routine owner]
 ├─ restart-handover-manager [親が実行, 再開時のみ]
 ├─ task-consistency-manager [親が実行]
 ├─ design-doc-maintainer [親が実行]
@@ -49,6 +51,8 @@ development-orchestrator [親が実行]
 │  ├─ markdown-word-checker [親が実行, Markdown関連変更時]
 │  ├─ sub-agent-task-manager [親が実行, reviewerは常にsub-agent]
 │  └─ report-output-manager [親が実行]
+├─ feedback-points-manager [親が実行, durable tracking]
+│  └─ feedback-points-sanitizer [親が呼び出し、sub-agent が実行]
 ├─ progress-sync-manager [親が実行]
 ├─ git-workflow-manager [親が実行]
 │  ├─ git-branch-starter [親が実行]
@@ -59,9 +63,17 @@ development-orchestrator [親が実行]
 │     ├─ codex-delegation-executor [親が実行]
 │     │  └─ implementation-executor [親が実行, 実作業は切替対象]
 │     └─ report-output-manager [親が実行]
-├─ feedback-points-manager [親が実行]
-│  └─ feedback-points-sanitizer [親が呼び出し、sub-agent が実行]
-└─ skill-authoring-wrapper [親が実行, issue完了時の親判断でlocal skill作成/更新が必要な場合]
+└─ skill-authoring-wrapper [親が実行, 既存skill更新または新規skill提案の採用時]
+```
+
+`development-orchestrator` は上記 skill 呼び出しに加え、内部 tool として次を所有する。
+
+```text
+skills/development-orchestrator/scripts/task_routine.py
+skills/development-orchestrator/scripts/task_routine_state.py
+skills/development-orchestrator/scripts/task_routine_hooks.py
+skills/development-orchestrator/tests/test_task_routine.py
+hooks/hooks.json
 ```
 
 ## 補助フローの呼び出し関係
@@ -116,6 +128,8 @@ development-orchestrator [親が実行]
    └─ `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` を同期更新する
 ```
 
+既存 skill の責務内に収まる内部的、可逆、低リスクな更新は、task routine の `skill_reflection=update-existing` と証跡を残して自動実施できる。新規 skill は利用者へ提案してから作成する。
+
 ## Markdown資料チェックフローの呼び出しツリー
 
 ```text
@@ -138,20 +152,27 @@ handover-memo-writer [親が実行]
 通常の task は、親が次の順番で進める。
 
 1. workflow 冒頭で `/home/ibis/AI/CodexSkill` が最新か確認し、安全に更新できるなら最新取得してから先へ進む。
-2. 再開セッションなら `restart-handover-manager` を呼び、再開文脈を復元してから同じ workflow に戻る。
-3. 新規着手で今回の作業対象がまだ曖昧なら、`development-orchestrator` がユーザーに何の作業をするか確認してから task 選定へ進む。
-4. `development-orchestrator` が現在状態を確認し、次の task を 1 つ選ぶ。
-5. `task-consistency-manager` で task と phase の追跡状態を整える。
-6. 設計影響がある場合は `design-doc-maintainer` を呼ぶ。
-7. 設計文書の実編集が必要なら、`codex-delegation-executor` を通して `design-executor` に流す。
-8. `tdd-executor` で最小の testable behavior と failing test 方針を定める。
-9. テスト作成やコード作成が必要なら、`codex-delegation-executor` を通して `implementation-executor` に流す。
-10. build、test、environment verification のような証拠作業が必要なら、`codex-delegation-executor` から `sub-agent-task-manager` を使って sub-agent に流す。
-11. 実装が一段落したら `review-enforcer` を呼び、セッション内で原則固定したレビュー専用 sub-agent を実行する。セッション内で監査・設計・ユーザー指示により決まったレビュー指針がある場合は、その指針を review request に含める。
-12. 指摘があれば `git-review-followup-manager` または通常の実装フローに戻して修正する。
-13. `progress-sync-manager` で report と tracking を同期する。
-14. `git-workflow-manager` で branch、commit、PR まで進める。
-15. issue または task が完了したら、親が skill 化判断を行い、必要に応じて `feedback-points-manager` を呼び、commit 時点で skill 改善 loop を issue へ引き継ぐ。
+2. repo root `AGENTS.md` と `development-orchestrator` を確認する。
+3. `task_routine.py status` で active routine と次 step を確認する。
+4. 再開セッションなら `restart-handover-manager` を呼び、復元結果を active routine と照合する。
+5. 新規着手で今回の作業対象がまだ曖昧なら、利用者に作業対象を確認する。
+6. active routine がなければ 1 task だけを開始し、`intake`、`skill_scan`、`task_definition`、`plan` の証跡を順番に記録する。
+7. `task-consistency-manager` で task と phase の追跡状態を整える。
+8. 設計影響がある場合は `design-doc-maintainer` を呼ぶ。
+9. 設計文書の実編集が必要なら、`codex-delegation-executor` を通して `design-executor` に流す。
+10. `tdd-executor` で最小の testable behavior と failing test 方針を定める。
+11. テスト作成やコード作成が必要なら、`codex-delegation-executor` を通して `implementation-executor` に流す。
+12. build、test、environment verification のような証拠作業が必要なら、`codex-delegation-executor` から `sub-agent-task-manager` を使って sub-agent に流す。
+13. 実装が一段落したら `review-enforcer` を呼び、セッション内で原則固定したレビュー専用 sub-agent を実行する。セッション内で監査・設計・ユーザー指示により決まったレビュー指針がある場合は、その指針を review request に含める。
+14. 指摘があれば `git-review-followup-manager` または通常の実装フローに戻し、`implementation` 以降の routine step を reopen して修正する。
+15. 親が `skill_reflection` を行い、`none`、`update-existing`、`propose-new` のいずれかと証跡を記録する。
+16. 既存 skill の責務内に収まる内部的、可逆、低リスクな更新は `skill-authoring-wrapper` 経由でその task 内に反映する。新規 skill は利用者へ提案する。
+17. 親が `tool_reflection` を行い、`none`、`update-existing`、`create-internal`、`propose-external` のいずれかと証跡を記録する。
+18. agent が繰り返し直接生成、変換、検証している決定的出力は、既存 skill 内の internal helper として安全に閉じる場合に自動化する。standalone external tool は利用者へ提案する。
+19. reusable process feedback、重複、残作業がある場合は `feedback-points-manager` を呼び、`feedback_tracking` の disposition を記録する。
+20. `progress-sync-manager` で report と tracking を同期し、`progress_sync` の証跡を記録する。
+21. review、両 reflection、feedback disposition、progress sync が完了した後だけ `git-workflow-manager` で branch、commit、PR まで進める。
+22. Git 提出の証跡を記録して routine を完了・archive し、次の task 確認へ戻る。
 
 大きい task では、`task-breakdown-planner`、`task-consistency-manager`、`design-doc-maintainer`、`restart-handover-manager`、`git-pr-submitter` の内部作業の一部を `sub-agent-task-manager` 経由で draft/audit/scan へ切り出してよい。ただし最終判断と反映は親が持つ。
 
@@ -168,7 +189,35 @@ handover-memo-writer [親が実行]
 - `tdd-executor` の test authoring 部分: 追加・更新する test 3 件以上、test file 3 本以上、または事前確認が必要な既存 test file 4 本以上
 - `git-review-followup-manager`: 対応 finding 3 件以上、対象 file 4 本以上、対象 behavior area 2 つ以上
 
-### 2. sub-agent を使うときの内部順
+### 2. task routine と hook
+
+`development-orchestrator` は対象 repository ごとに routine state を Git directory 内へ保存する。
+
+```text
+<git-dir>/codex-task-routine/state.json
+<git-dir>/codex-task-routine/history/*.json
+```
+
+routine の必須 step は次のとおりである。
+
+1. `intake`
+2. `skill_scan`
+3. `task_definition`
+4. `plan`
+5. `implementation`
+6. `verification`
+7. `review`
+8. `skill_reflection`
+9. `tool_reflection`
+10. `feedback_tracking`
+11. `progress_sync`
+12. `git_submission`
+
+`SessionStart` と `UserPromptSubmit` は active task と次 step を model context へ再注入する。`PreToolUse` は active task や前提 step がない編集と、完了前の Git 提出を拒否する。`Stop` は active task が未完了なら具体的な次 step を continuation prompt として返す。
+
+GitHub Issue と feedback point は履歴、重複、follow-up の正本として使う。実行中の次工程は local routine state と hook を正本とし、Issue を見たこと自体を実行条件にしない。
+
+### 3. sub-agent を使うときの内部順
 
 sub-agent を使う作業は、親が必ず次の順番で準備してから実行する。
 
@@ -181,7 +230,7 @@ sub-agent を使う作業は、親が必ず次の順番で準備してから実�
 7. sub-agent が作業し、既存 report の見出し順、空行、既存記述を保持したまま結果を書く。
 8. 親が report を確認し、完了条件を満たしているか判定する。
 
-### 3. レビュー差し戻し時の再入フロー
+### 4. レビュー差し戻し時の再入フロー
 
 レビューで指摘が出た場合は、次の順番で元の実装フローへ戻す。
 
@@ -189,24 +238,27 @@ sub-agent を使う作業は、親が必ず次の順番で準備してから実�
 2. `git-review-followup-manager` が、その指摘を現 task で直すか、新 task に切るかを決める。
 3. tracking 変更が必要なら `task-consistency-manager` を呼ぶ。
 4. 修正作業は `codex-delegation-executor` を通し、必要に応じて `implementation-executor` に流す。
-5. 修正後は再度 `review-enforcer` に戻し、再レビューを通す。
-6. 問題がなければ `progress-sync-manager` と `git-workflow-manager` に進む。
+5. active routine の `implementation` 以降を reopen する。
+6. 修正後は再度 `review-enforcer` に戻し、再レビューを通す。
+7. 問題がなければ reflection、feedback、progress、Git 提出へ進む。
 
-### 4. skill 作成・更新フロー
+### 5. skill 作成・更新フロー
 
 local skill を新規作成または実質更新するときは、親が次の順番で進める。
 
-1. `development-orchestrator` が end-of-issue の親判断として local skill 作成または更新が必要だと決め、`skill-authoring-wrapper` を呼ぶ。
-2. `skill-authoring-wrapper` を入口にして、対象 skill の目的、配置先、new/update 区分を定める。
-3. built-in `skill-creator` を読み、初期化に使う部分と、repo 標準へ補正する部分を切り分ける。
-4. 新規 skill の場合は built-in `skill-creator` の初期化フローを使って skill directory を作る。
-5. 既存 skill の更新の場合は、既存 `SKILL.md` の意図を残すべき部分と、repo 標準へ正規化すべき部分を分ける。
-6. `skill-authoring-wrapper` が `SKILL.md` を repo 標準の section と契約粒度へ揃える。
-7. 実行委譲や switchable な実装系があるなら、`codex-delegation-executor` 前提の書き方と暫定数値基準を入れる。
-8. canonical file の更新経路制約が必要なら、その skill からしか触らないことを `SKILL.md` に明記する。
-9. 実在する canonical skill inventory または registry file がある場合だけ、それを最終的な skill 意図に合わせて更新する。
-10. skill inventory、呼び出しツリー、役割、契約一覧のどれかが変わるなら `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` を同期更新する。
-11. skill 設計が repo 標準に揃ったら、その skill を採用対象として扱う。
+1. `development-orchestrator` が task routine の skill reflection として local skill 作成または更新要否を決める。
+2. 既存 skill 更新なら、内部的、可逆、低リスクで既存責務内かを確認し、該当する場合は `skill-authoring-wrapper` を呼ぶ。
+3. 新規 skill 候補なら、既存 skill では責務を置けない理由と owner scope を利用者へ提案し、採用後に `skill-authoring-wrapper` を呼ぶ。
+4. `skill-authoring-wrapper` を入口にして、対象 skill の目的、配置先、new/update 区分を定める。
+5. built-in `skill-creator` を読み、初期化に使う部分と、repo 標準へ補正する部分を切り分ける。
+6. 新規 skill の場合は built-in `skill-creator` の初期化フローを使って skill directory を作る。
+7. 既存 skill の更新の場合は、既存 `SKILL.md` の意図を残すべき部分と、repo 標準へ正規化すべき部分を分ける。
+8. `skill-authoring-wrapper` が `SKILL.md` を repo 標準の section と契約粒度へ揃える。
+9. 実行委譲や switchable な実装系があるなら、`codex-delegation-executor` 前提の書き方と暫定数値基準を入れる。
+10. canonical file の更新経路制約が必要なら、その skill からしか触らないことを `SKILL.md` に明記する。
+11. 実在する canonical skill inventory または registry file がある場合だけ、それを最終的な skill 意図に合わせて更新する。
+12. skill inventory、呼び出しツリー、役割、契約一覧のどれかが変わるなら `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` を同期更新する。
+13. skill 設計が repo 標準に揃ったら、task routine に更新証跡を記録する。
 
 ## skillと役割
 
@@ -216,7 +268,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `development-orchestrator` | 全体フローの入口として、task 選定から設計、TDD、委譲、レビュー、進捗同期、Git、issue 完了時の振り返りまでを統括する。 | `親が実行` |
+| `development-orchestrator` | 全体フローの入口として、永続 task routine、task 選定、設計、TDD、委譲、レビュー、skill/tool reflection、feedback disposition、進捗同期、Git 提出までを統括する。 | `親が実行` |
 | `codex-delegation-executor` | 実装・検証・調査を誰が実行するかを決め、sub-agent 必須カテゴリを正しく委譲する。 | `親が実行` |
 | `sub-agent-task-manager` | sub-agent へ渡す task の範囲、読むべき skill、report path、report template 保持ルール、完了条件を固定する。 | `親が実行` |
 | `execution-cost-stabilizer` | 無駄な再実行や過剰並列を抑え、委譲実行のコストと不安定さを下げる。 | `親が実行` |
@@ -256,11 +308,11 @@ local skill を新規作成または実質更新するときは、親が次の�
 | `feedback-coding-standards-enforcer` | API ドキュメント、命名、解析ルールなどのコーディング規約を review/commit 前に強制する。 | `親が実行` |
 | `feedback-issue-intake-fallback-manager` | issue 要件の取得が失敗したときに、代替経路で authoritative な要件を確保する。 | `親が実行` |
 
-### Feedback ガバナンスと skill 化
+### Feedback ガバナンスと skill/tool 化
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `feedback-points-manager` | 再利用可能な workflow lesson を `feedback-points.md` で管理し、skill 化するかどうかを判断する。 | `親が実行` |
+| `feedback-points-manager` | 再利用可能な workflow lesson と tool automation finding を管理し、重複、再発、commit-backed closure、follow-up issue を記録する。runtime の次 step は task routine が所有する。 | `親が実行` |
 | `feedback-points-sanitizer` | noisy な feedback points を独立した立場で整理し、親が判断しやすい状態に整える。 | `親が呼び出し、sub-agent が実行` |
 
 ### Git 提出フロー
@@ -281,13 +333,13 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 ## skill契約一覧
 
-この章では、各 skill の入力、出力、完了条件を設計レベルで要約する。
+この章では、各 skill について入力、出力、完了条件を設計レベルで要約する。
 
 ### 入口と全体統括
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `development-orchestrator` | tasks/phases、recent reports、feedback-points、repo state | 現在 task と次の実行経路 | 1 task 分の標準サイクル完了または明確な blocking 状態 |
+| `development-orchestrator` | task routine state、tasks/phases、recent reports、feedback-points、repo state | active task、次 step、各 step の証跡、skill/tool decision、Git 提出経路 | routine の全 step が証跡付きで完了・archive、または明確な paused/aborted/blocking 状態 |
 | `codex-delegation-executor` | 実行対象の work item、scope、evidence 要件 | executor 決定、委譲結果、report evidence | executor 決定と結果記録が完了 |
 | `sub-agent-task-manager` | task purpose、scope、読むべき skill、report path 要件、workspace context 方針 | dispatch 済み sub-agent task、pre-created report、review 済み evidence | report 作成と review 済み evidence の確認完了 |
 | `execution-cost-stabilizer` | delegated task plan、retry pressure、parallelism 候補 | 安定化された実行計画 | 次アクションが無駄なく scoped されている |
@@ -301,7 +353,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 | `task-breakdown-planner` | issue/request scope、constraints、existing tasks/phases | tasks、phases、dependencies、exit criteria | 次 task を他 agent が推測なしで実行できる。大きい分解では sub-agent draft を parent が採用する |
 | `task-consistency-manager` | current work item、tasks/phases、new scope | 更新済み tracking、明確な next step | tracking が実 scope と一致。大きい監査では sub-agent audit を parent が確認する |
 | `progress-sync-manager` | 最新の task/review/verification/git 結果、reports | 同期済み tracking と references | canonical tracking が実状態と一致 |
-| `restart-handover-manager` | feedback-points、tasks/phases、recent reports | current position、next task、open deps | 再開時の次アクションが明示されている。大きい文脈では sub-agent summary を parent が採用する |
+| `restart-handover-manager` | feedback-points、tasks/phases、recent reports | current position、next task、open deps | 再開位置が active routine と照合され、次アクションが明示されている。大きい文脈では sub-agent summary を parent が採用する |
 | `handover-memo-writer` | current chat history、agreed constraints、repo/report/git state、user format request、作成Markdown report path | next-chat ready handover memo、handover report、`markdown-word-checker` focused lint結果 | 新しい chat が旧会話なしでも再開可能な handover と report が完成し、作成Markdownのcheck結果が記録されている |
 
 ### 設計
@@ -327,18 +379,18 @@ local skill を新規作成または実質更新するときは、親が次の�
 | `feedback-coding-standards-enforcer` | changed files、API diff、repo standards | standards evidence、violation fixes または rationale | standards-sensitive change の確認と記録が完了 |
 | `feedback-issue-intake-fallback-manager` | issue id/URL、available retrieval paths、partial context | authoritative requirements report、confidence、gaps | requirements と confidence が report に明示済み |
 
-### Feedback ガバナンスと skill 化
+### Feedback ガバナンスと skill/tool 化
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `feedback-points-manager` | candidate process lesson、active FP ledger、duplicate context | FP add/merge/skip 判断、skillization status、次アクション対応 | FP 判断と rationale が ledger か report に残る |
+| `feedback-points-manager` | candidate process/tool lesson、task-routine decision、active FP ledger、duplicate context | FP add/merge/skip、skill/tool status、commit-backed closure または follow-up issue | durable tracking と rationale が残り、commit-ready point が active ledger に残っていない |
 | `feedback-points-sanitizer` | active FP set、cleanup scope、duplicate references | cleanup report、classification result、candidate groups | parent review 用の cleanup evidence が report に残る |
 
 ### Git 提出フロー
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `git-workflow-manager` | branch/commit/PR state、task readiness | selected Git actions、submission path、commit shape decision | branch/commit/PR の必要アクション完了と、その task の commit 形が決定済み |
+| `git-workflow-manager` | branch/commit/PR state、task readiness、routine prerequisites | selected Git actions、submission path、commit shape decision | review、reflection、feedback、progress の証跡後に branch/commit/PR の必要アクションが完了 |
 | `git-branch-starter` | task or issue scope、branch state、naming basis | active branch context | 適切な branch に作業が隔離されている |
 | `git-commit-manager` | scoped changes、review/validation state、commit convention | coherent commit(s)、formatted commit message | task に対応した commit 作成完了 |
 | `git-pr-submitter` | branch、task scope、review/validation evidence、report refs | reviewable PR | 必要コンテキスト付きの PR 作成完了。大きい PR 文脈では sub-agent draft を parent が確定する |
@@ -353,6 +405,11 @@ local skill を新規作成または実質更新するときは、親が次の�
 ## 主要な設計判断
 
 - workflow 入口は `development-orchestrator` の一箇所に固定し、再開時も `restart-handover-manager` から直接始めず `development-orchestrator` へ戻して続行する。
+- `development-orchestrator` は 1 task ごとの永続 routine と hook gate を所有し、active task と次 step を agent の記憶ではなく local state から再提示する。
+- GitHub Issue と feedback point は履歴、重複、follow-up の正本とし、runtime の次 step を思い出す唯一の trigger にはしない。
+- task 完了前に skill reflection と tool reflection を必須化し、該当なしの場合も理由を証跡として残す。
+- 既存 skill の責務内に収まる内部的、可逆、低リスクな改善と internal helper は、発生回数を hard gate にせず task 内で自動実施できる。
+- 新規 skill、standalone external tool、外部公開契約、破壊的変更、credential・法務・組織承認が必要な変更は利用者確認境界を維持する。
 - `restart-handover-manager` は recorded state から再開位置を復元する skill とし、会話内容そのものを次チャットへ移送する handover 文面の作成は `handover-memo-writer` に分離する。
 - レビューは親がゲートを持つが、レビュワー実行は必ず sub-agent とする。1 セッションでは基本的に同じ reviewer sub-agent を継続し、セッション内で決まったレビュー指針を後続 review に引き継ぐ。
 - 設計文書編集とコード/テスト作成は、判断系 skill から分離し、`design-executor` と `implementation-executor` に寄せる。
@@ -364,11 +421,13 @@ local skill を新規作成または実質更新するときは、親が次の�
 - `skill-authoring-wrapper` の既定 caller は `development-orchestrator` とし、宙ぶらりんな local skill authoring を作らない。
 - 判断責務を上位 skill に寄せるのは、その判断が固定 caller を持つサブツリー内部で閉じる場合に限る。`1対多` 構造や単独利用されうる下位 skill では、上位に寄せすぎず、下位は参照先を明示して従う形を基本とする。
 - local skill 群の最新維持責任は workflow 入口の `development-orchestrator` が持ち、作業着手前に `/home/ibis/AI/CodexSkill` の鮮度確認を行う。
-- skill 改善ループの継続確認は active FP ではなく issue を正本とし、issue 作成後の FP は active ledger から外す。
-- commit 時点では active `feedback-points.md` が再び空になる運用を既定とし、skill 改善ループは issue 側へ引き継いでから commit を通す。
+- skill/tool 改善ループの継続確認は active FP ではなく issue を正本とし、issue 作成後の FP は active ledger から外す。
+- commit 時点では active `feedback-points.md` が再び空になる運用を既定とし、残作業は issue 側へ引き継いでから commit を通す。
 
 ## 保守ルール
 
 - 新しい skill を追加したら、この設計書のツリーと一覧を更新する。
+- task routine の step、hook event、skill/tool reflection contract が変わったら、この設計書と `design/task-routine-hook-design.md` を同期更新する。
 - 呼び出し関係が変わったら、まずこの設計書を更新してから関連 report を更新する。
+- `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` は同一内容を維持する。
 - 実行方式の表現は `親が実行` と `親が呼び出し、sub-agent が実行` に統一する。

--- a/design/task-routine-hook-design.md
+++ b/design/task-routine-hook-design.md
@@ -32,6 +32,7 @@ skills/development-orchestrator/scripts/task_routine.py
 skills/development-orchestrator/scripts/task_routine_state.py
 skills/development-orchestrator/scripts/task_routine_hooks.py
 skills/development-orchestrator/tests/test_task_routine.py
+skills/development-orchestrator/tests/test_task_routine_pr_body.py
 hooks/hooks.json
 .codex-plugin/plugin.json
 ```
@@ -130,15 +131,30 @@ session の startup、resume、clear、compact 後に local state を読み、ac
 - active task がない状態での file/repository mutation
 - `intake`、`skill_scan`、`task_definition`、`plan` より前の実編集
 - `verification`、`review`、両 reflection、feedback tracking、progress sync より前の commit、push、PR 作成
+- task routine、skill action、tool action の証拠が本文にない PR 作成
 - 壊れた routine state のままの mutation
 
 read-only command と task routine CLI 自身は許可する。
 
 shell command の mutation 判定は、Git/GitHub submission command、既知の file mutation command、output redirection を対象にする。任意 script の内部副作用を完全には判定できないため、これは最終 security sandbox ではなく workflow omission gate とする。
 
+PR 作成時は本文に次の見出しと非placeholderの証拠を要求する。
+
+```markdown
+## Task routine evidence
+
+## Skill action
+
+## Tool action
+```
+
+`none` を選ぶ場合も、単語だけで済ませず、その判断理由を記録する。
+
 ### `Stop`
 
 active task に未完了 step がある場合、`decision: block` と具体的な continuation prompt を返す。
+
+Codex が continuation 後に `stop_hook_active: true` で同じ Stop hook を再実行した場合は、無限再入を避けるため再度 block しない。最初の continuation で次工程を実行できない場合は、`pause` または `abort` を明示的に記録する。
 
 外部依存や利用者判断待ちで終了する必要がある場合は、silent bypass ではなく次のいずれかを状態へ残す。
 
@@ -210,7 +226,8 @@ python3 skills/development-orchestrator/scripts/task_routine.py \
 - step の順序違反が拒否される。
 - active task なしの mutation が拒否される。
 - review と reflection 未完了の Git submission が拒否される。
-- incomplete task の `Stop` が continuation を返す。
+- 必須のroutine/skill/tool証跡がないPR作成が拒否される。
+- incomplete task の `Stop` が continuation を返し、再入時は無限loopを起こさない。
 - restart/compact 後に next step が再注入される。
 - 既存 hooks 設定を保持して install/uninstall できる。
 - unit test が状態遷移、gate、hook output、installer の主要経路を検証する。

--- a/design/task-routine-hook-design.md
+++ b/design/task-routine-hook-design.md
@@ -1,0 +1,216 @@
+# task routine hook 設計
+
+## 目的
+
+開発 agent が、skill の確認、検証、レビュー、skill 改善判断、tool 化判断、feedback/issue の重複確認、進捗同期、Git 提出を忘れないようにする。
+
+手順を自然言語の注意書きだけに置かず、1 task ごとの永続状態と Codex hook によって実行順を維持する。
+
+## 問題
+
+既存の `AGENTS.md`、`development-orchestrator`、`feedback-points-manager` には必要な手順が書かれている。しかし、これらは agent が作業中に読み直し、必要なタイミングで思い出すことを前提としている。
+
+GitHub Issue は次の用途には適している。
+
+- 再発内容の保存
+- 重複の統合
+- skill 改善作業の追跡
+- PR との紐付け
+
+一方、Issue は agent が参照しなければ実行されないため、task runtime の記憶装置にはしない。
+
+## 所有者
+
+`development-orchestrator` が task routine の所有者になる。
+
+新しい独立 skill は作成しない。task 選定から Git 提出までの lifecycle は既に `development-orchestrator` の責務であり、routine state、hook gate、skill/tool reflection を同 skill の内部 tool として持つ。
+
+実装は次に置く。
+
+```text
+skills/development-orchestrator/scripts/task_routine.py
+skills/development-orchestrator/scripts/task_routine_state.py
+skills/development-orchestrator/scripts/task_routine_hooks.py
+skills/development-orchestrator/tests/test_task_routine.py
+hooks/hooks.json
+.codex-plugin/plugin.json
+```
+
+## 状態の正本
+
+状態は対象リポジトリの Git directory 内に保存する。
+
+```text
+<git-dir>/codex-task-routine/state.json
+<git-dir>/codex-task-routine/history/*.json
+```
+
+この配置には次の性質がある。
+
+- session restart、context compaction、chat 移動後も残る。
+- project の tracked file を汚さない。
+- repository ごとに分離される。
+- worktree では `git rev-parse --git-path` の結果に従う。
+
+Issue と FP は履歴・重複・follow-up の正本であり、実行中の次工程は local routine state が正本である。
+
+## 1 task の routine
+
+routine は次の順序を持つ。
+
+1. `intake`
+2. `skill_scan`
+3. `task_definition`
+4. `plan`
+5. `implementation`
+6. `verification`
+7. `review`
+8. `skill_reflection`
+9. `tool_reflection`
+10. `feedback_tracking`
+11. `progress_sync`
+12. `git_submission`
+
+通常 step は `complete <step> --evidence ...` で完了する。該当しない工程は `skip <step> --reason ...` で `not_applicable` にできる。
+
+`skill_reflection`、`tool_reflection`、`feedback_tracking` は generic な完了を禁止し、structured command を必須にする。
+
+### skill reflection
+
+許可する判断は次のとおり。
+
+- `none`
+- `update-existing`
+- `propose-new`
+
+既存 skill の責務内に収まる低リスクで可逆な改善は、発見した task 内で更新してよい。`update-existing` は、変更候補を記録しただけでは完了せず、更新済み file、commit、report 等の証拠を残す。
+
+新規 skill は責務分割と trigger 増加を伴うため、従来どおり利用者への提案を境界とする。
+
+### tool reflection
+
+許可する判断は次のとおり。
+
+- `none`
+- `update-existing`
+- `create-internal`
+- `propose-external`
+
+agent が毎回直接生成、変換、検証、整形している出力に、決定的で再利用可能な部分がある場合は helper script または tool 化を検討する。
+
+既存 skill の内部 helper として閉じる低リスクな tool は `create-internal` で自動作成できる。外部公開 interface、破壊的処理、credential、組織承認を伴う standalone tool は `propose-external` とする。
+
+### feedback tracking
+
+許可する判断は次のとおり。
+
+- `none`
+- `merged`
+- `issue`
+- `commit-backed`
+
+GitHub Issue を runtime trigger にはしないが、task 完了前に重複確認と追跡先の証拠は必須にする。
+
+## hook
+
+Codex が提供する次の lifecycle event を使う。
+
+### `SessionStart`
+
+session の startup、resume、clear、compact 後に local state を読み、active task と次 step を model context へ再注入する。
+
+### `UserPromptSubmit`
+
+各 user turn の開始時に同じ state を再注入する。長い作業中に instruction が context の後方へ流れても、現在位置を再提示できる。
+
+### `PreToolUse`
+
+次を拒否できる gate とする。
+
+- active task がない状態での file/repository mutation
+- `intake`、`skill_scan`、`task_definition`、`plan` より前の実編集
+- `verification`、`review`、両 reflection、feedback tracking、progress sync より前の commit、push、PR 作成
+- 壊れた routine state のままの mutation
+
+read-only command と task routine CLI 自身は許可する。
+
+shell command の mutation 判定は、Git/GitHub submission command、既知の file mutation command、output redirection を対象にする。任意 script の内部副作用を完全には判定できないため、これは最終 security sandbox ではなく workflow omission gate とする。
+
+### `Stop`
+
+active task に未完了 step がある場合、`decision: block` と具体的な continuation prompt を返す。
+
+外部依存や利用者判断待ちで終了する必要がある場合は、silent bypass ではなく次のいずれかを状態へ残す。
+
+- `pause --reason ...`
+- `abort --reason ...`
+
+## Codex plugin と直接導入
+
+repository root に `.codex-plugin/plugin.json` と `hooks/hooks.json` を置き、plugin として導入した場合は `$PLUGIN_ROOT` を使って hook helper を起動する。
+
+plugin を使わない構成では、次の command で既存 `.codex/hooks.json` を保持したまま task routine handler を追加できる。
+
+```bash
+python3 skills/development-orchestrator/scripts/task_routine.py install-hooks --scope project
+python3 skills/development-orchestrator/scripts/task_routine.py install-hooks --scope user
+```
+
+installer は同じ handler を重複追加しない。削除は `uninstall-hooks` を使う。
+
+## 主な CLI
+
+```bash
+# 1 task を開始する
+python3 skills/development-orchestrator/scripts/task_routine.py \
+  start --id issue-47 --summary "task routine hookを実装する"
+
+# 状態を確認する
+python3 skills/development-orchestrator/scripts/task_routine.py status
+
+# 通常 step を完了する
+python3 skills/development-orchestrator/scripts/task_routine.py \
+  complete verification --evidence "python3 -m unittest: 15 tests passed"
+
+# skill 改善判断を記録する
+python3 skills/development-orchestrator/scripts/task_routine.py \
+  reflect skill --decision update-existing \
+  --target development-orchestrator \
+  --evidence "SKILL.mdとtask_routine.pyを更新"
+
+# tool 化判断を記録する
+python3 skills/development-orchestrator/scripts/task_routine.py \
+  reflect tool --decision create-internal \
+  --target task_routine.py \
+  --evidence "反復確認をCLIとhookへ移した"
+
+# reviewで差し戻された工程以降を再度未完了にする
+python3 skills/development-orchestrator/scripts/task_routine.py \
+  reopen implementation --reason "review findingを修正する"
+```
+
+## 安全境界
+
+自動実施してよい範囲は、内部、可逆、低リスクで、既存責務の中に閉じる変更である。
+
+次は利用者確認を維持する。
+
+- 外部公開契約の変更
+- 破壊的または不可逆な操作
+- credential、法務、組織承認が必要な操作
+- acceptance criteria を変える曖昧な判断
+- 新規 skill による責務分割
+- standalone external tool の導入
+
+## 完了条件
+
+次をすべて満たしたときに実装完了とする。
+
+- task state が repository ごとに永続化される。
+- step の順序違反が拒否される。
+- active task なしの mutation が拒否される。
+- review と reflection 未完了の Git submission が拒否される。
+- incomplete task の `Stop` が continuation を返す。
+- restart/compact 後に next step が再注入される。
+- 既存 hooks 設定を保持して install/uninstall できる。
+- unit test が状態遷移、gate、hook output、installer の主要経路を検証する。

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,53 @@
+{
+  "description": "Persist and enforce the development-orchestrator one-task routine.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$PLUGIN_ROOT/skills/development-orchestrator/scripts/task_routine.py\" hook",
+            "timeout": 10,
+            "statusMessage": "task routineを復元しています"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$PLUGIN_ROOT/skills/development-orchestrator/scripts/task_routine.py\" hook",
+            "timeout": 10,
+            "statusMessage": "task routineを確認しています"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$PLUGIN_ROOT/skills/development-orchestrator/scripts/task_routine.py\" hook",
+            "timeout": 10,
+            "statusMessage": "task routine gateを確認しています"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$PLUGIN_ROOT/skills/development-orchestrator/scripts/task_routine.py\" hook",
+            "timeout": 10,
+            "statusMessage": "task routine完了状態を確認しています"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/reports/issue-47-task-routine-review-20260711115502.md
+++ b/reports/issue-47-task-routine-review-20260711115502.md
@@ -1,0 +1,111 @@
+# Issue #47 task routine hook 最終レビュー
+
+## 対象
+
+- repository: `ssaattww/CodexSkill`
+- branch: `agent/issue-47-task-routine-hooks`
+- base: `main`
+- review基準: Issue #47 の acceptance criteria
+- GitHub操作経路: GitHub connectorのみ
+- 未使用: clone、`gh`
+
+## 実装概要
+
+`development-orchestrator` の内部toolとして、repositoryごとの永続task routineとCodex lifecycle hookを追加した。
+
+- `SessionStart` / `UserPromptSubmit`: active taskと次工程を再注入
+- `PreToolUse`: 前提工程未完了の編集・提出を拒否
+- `Stop`: 未完了taskに継続promptを返す
+- skill reflection / tool reflection / feedback trackingを必須化
+- Issue/FPを履歴・重複・follow-upの正本とし、runtimeの次工程はlocal stateを正本化
+- plugin導入とproject/user hooks installerを追加
+
+## レビュー結果
+
+### 修正済み finding 1: Stop hookの再入loop
+
+初回の`decision: block`後、Codexは`stop_hook_active: true`でStop hookを再実行する。再入時にも同じblockを返すと無限継続になり得るため、再入時は再blockしないよう修正した。
+
+### 修正済み finding 2: GitHub Contents APIの提出gate迂回
+
+`create_file`、`update_file`、`delete_file`はfile editと同時にcommitを作成する。そのため通常editではなくsubmissionとして扱い、verification、review、両reflection、feedback、progress syncの証拠が揃うまで拒否するよう修正した。
+
+Issue作成・更新・コメント・PR review投稿はrepository contentのcommitではないため、routine未開始でもdurable trackingを残せるようgate対象外とした。
+
+### 修正済み finding 3: PR本文の証跡が未強制
+
+Issue #47はPR本文にroutine、skill action、tool actionの証跡を要求している。従来実装はPR作成時の前提stepだけを確認し、本文内容を検証していなかった。
+
+`create_pull_request` / `open_pull_request`に対して、次の見出しと非placeholder内容を必須化した。
+
+```markdown
+## Task routine evidence
+
+## Skill action
+
+## Tool action
+```
+
+`TODO`、`TBD`、`N/A`、理由のない`none`、`未記入`等は証跡として認めない。
+
+## 検証
+
+- connectorから取得した`.codex-plugin/plugin.json`と`hooks/hooks.json`をJSON parse: 成功
+- 最終hook変更のPython AST parse: 成功
+- 最新hook/stateを使ったtargeted unittest 6件: pass
+  - Contents API提出gate
+  - tracking tool除外
+  - Stop再入防止
+  - PR本文section不足
+  - PR本文placeholder
+  - PR本文の証跡あり
+- 初期版のtask routine unittest 11件: pass
+- checked-in test総数: 17件
+- head commit `243cf276f16d85700715d21f9ae48eb5d062ec84`に紐づくGitHub Actions run: なし
+
+最新差分を含む17件を単一commandでまとめて実行する確認は、clone可能なrunnerがこの作業環境にないため未実行である。初期11件と最新差分に直接関係する6件はそれぞれ成功している。PRはDraftとして作成し、CIまたはlocal runnerでの全17件一括実行をmerge前の確認事項とする。
+
+## 残存リスク
+
+- shellや任意script内部の副作用を完全には分類できない。hookはsecurity sandboxではなくworkflow omission gateである。
+- Stop hookは無限再入防止のため1回のcontinuation後は再blockしない。継続できない場合は`pause`または`abort`を明示記録する必要がある。
+- repositoryにPR向けGitHub Actions runが確認できないため、自動CIの有無はPR作成後に再確認する。
+
+## task routine evidence
+
+- intake: Issue #47と利用者の追加指示を確認
+- skill scan: development-orchestrator、feedback-points-manager、git-pr-submitter、関連設計を確認
+- task definition: 1 task routineとhook gateの実装、検証、PR提出
+- plan: state、CLI、hook、test、skill/design、review、PRの順で実施
+- implementation: branch上に実装・policy・設計・testを追加
+- verification: JSON parse、AST parse、targeted helper検証、既存11 unittest成功記録
+- review: 本reportでfindingを裁定
+- feedback tracking: Issue #47をdurable recordとして継続
+- progress sync: 本report、Draft PR、Issue commentへ同期
+
+## skill action
+
+`update-existing`
+
+- `development-orchestrator`: task routine ownerとskill/tool reflectionを追加
+- `feedback-points-manager`: Issue/FPとruntime triggerの責務を分離
+- `git-pr-submitter`: PR本文のroutine/skill/tool証跡を必須化
+
+新規skillは作成しない。既存skillの責務内で閉じる。
+
+## tool action
+
+`create-internal`
+
+- `task_routine.py`
+- `task_routine_state.py`
+- `task_routine_hooks.py`
+- plugin hook設定
+- installer
+- unit tests
+
+反復確認と出力判定を、`development-orchestrator`所有の決定的な内部toolへ移した。
+
+## disposition
+
+Draft PRを作成し、Issue #47へPRと本reportを紐付ける。merge前に最新branchでunittest全件を実行する。

--- a/reports/issue-47-task-routine-review-r2-20260711121600.md
+++ b/reports/issue-47-task-routine-review-r2-20260711121600.md
@@ -1,0 +1,111 @@
+# Issue #47 task routine hook 最終レビュー r2
+
+## 対象
+
+- repository: `ssaattww/CodexSkill`
+- branch: `agent/issue-47-task-routine-hooks`
+- base: `main`
+- Draft PR: #48
+- review基準: Issue #47 の acceptance criteria
+- GitHub操作経路: GitHub connectorのみ
+- 未使用: clone、`gh`
+
+## r1以降の追加finding
+
+### 修正済み finding 4: MCP canonical tool名を分類できない
+
+Codexの公式実装では、MCP toolの`PreToolUse`入力に`mcp__<server>__<tool>`形式のcanonical名が渡される。公式testでも`tool_name`が`mcp__rmcp__echo`になることが検証されている。
+
+従来の`tool_token`は`.`区切りだけを除去していたため、次のようなGitHub connector操作を既知toolとして分類できなかった。
+
+```text
+mcp__github__create_pull_request
+mcp__github__update_file
+```
+
+この状態では、PR本文証跡gateやContents APIのsubmission gateを迂回できる可能性があった。
+
+判定前に`.`、`/`、`:`のnamespaceを除去し、`__`区切りがある場合は最後の要素を実tool名として扱うよう修正した。
+
+```text
+mcp__github__create_pull_request -> create_pull_request
+mcp__github__update_file -> update_file
+```
+
+確認元:
+
+- `openai/codex/codex-rs/hooks/src/events/common.rs`
+- `openai/codex/codex-rs/core/tests/suite/hooks_mcp.rs`
+
+## 全findingの状態
+
+1. Stop hookの再入loop: 修正済み
+2. GitHub Contents APIの提出gate迂回: 修正済み
+3. PR本文のroutine/skill/tool証跡が未強制: 修正済み
+4. MCP canonical tool名によるgate迂回: 修正済み
+
+## 検証
+
+- connectorから取得した`.codex-plugin/plugin.json`と`hooks/hooks.json`をJSON parse: 成功
+- 最終hook変更と追加testのPython AST parse: 成功
+- 初期版のtask routine unittest 11件: pass
+- 最新hook/stateを使ったtargeted unittest 8件: pass
+  - Contents API提出gate
+  - tracking tool除外
+  - Stop再入防止
+  - PR本文section不足
+  - PR本文placeholder
+  - PR本文の証跡あり
+  - MCP形式PR tool名の正規化と本文gate
+  - MCP形式Contents API tool名のsubmission gate
+- checked-in test総数: 19件
+- Draft PR作成前head commit `6f3b531aefceea414a559bb537222068726c0ed1`に紐づくGitHub Actions run: なし
+
+最新差分を含む19件を単一commandでまとめて実行する確認は、clone可能なrunnerがこの作業環境にないため未実行である。初期11件と最新差分に直接関係する8件はそれぞれ成功している。Draft PR #48は、CIまたはlocal runnerでの全19件一括実行をmerge前の確認事項とする。
+
+## 残存リスク
+
+- shellや任意script内部の副作用を完全には分類できない。hookはsecurity sandboxではなくworkflow omission gateである。
+- 未知のnamespace表現が将来追加された場合は`tool_token`の正規化規則を更新する必要がある。
+- Stop hookは無限再入防止のため1回のcontinuation後は再blockしない。継続できない場合は`pause`または`abort`を明示記録する必要がある。
+- repositoryにPR向けGitHub Actions runが確認できないため、自動CIの有無は引き続きmerge前確認事項である。
+
+## Task routine evidence
+
+- intake: Issue #47と利用者の追加指示を確認
+- skill scan: development-orchestrator、feedback-points-manager、git-pr-submitter、Codex公式hook実装を確認
+- task definition: 1 task routine、hook gate、connector tool名正規化、検証、PR提出
+- plan: state、CLI、hook、test、skill/design、review、PRの順で実施
+- implementation: branch上に実装・policy・設計・testを追加
+- verification: JSON parse、AST parse、初期11 unittest、最新差分targeted 8 unittest
+- review: r1と本r2でfindingを裁定
+- feedback tracking: Issue #47をdurable recordとして継続
+- progress sync: review report、Draft PR #48、Issue commentへ同期
+
+## Skill action
+
+`update-existing`
+
+- `development-orchestrator`: task routine ownerとskill/tool reflectionを追加
+- `feedback-points-manager`: Issue/FPとruntime triggerの責務を分離
+- `git-pr-submitter`: PR本文のroutine/skill/tool証跡を必須化
+
+新規skillは作成しない。既存skillの責務内で閉じる。
+
+## Tool action
+
+`create-internal`
+
+- `task_routine.py`
+- `task_routine_state.py`
+- `task_routine_hooks.py`
+- plugin hook設定
+- installer
+- unit tests
+- MCP canonical tool名の正規化
+
+反復確認と出力判定を、`development-orchestrator`所有の決定的な内部toolへ移した。
+
+## disposition
+
+Draft PR #48へ本修正とr2 reportを追加し、Issue #47のコメントを最新状態へ更新する。merge前に最新branchでunittest全19件を一括実行する。

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -8,6 +8,7 @@
 - 親 agent から見た呼び出し関係
 - 親が実行する skill と、親が呼び出して sub-agent が実行する skill の区別
 - 標準開発フローにおける責務分担
+- 1 task ごとの永続 routine と hook による実行漏れ防止
 
 運用中のレポートよりも、この設計書を正本として扱う。
 
@@ -25,11 +26,12 @@
 
 - `親が実行` の skill でも、内部の一部工程を `sub-agent-task-manager` 経由で sub-agent に委譲する場合がある。
 - その場合でも skill 全体の責務と完了判定は親が持つ。
+- `development-orchestrator` の `scripts/task_routine.py`、state helper、hook helper は独立 skill ではなく、同 skill が所有する内部 tool とする。
 
 ## 標準開発フローの呼び出しツリー
 
 ```text
-development-orchestrator [親が実行]
+development-orchestrator [親が実行, task routine owner]
 ├─ restart-handover-manager [親が実行, 再開時のみ]
 ├─ task-consistency-manager [親が実行]
 ├─ design-doc-maintainer [親が実行]
@@ -49,6 +51,8 @@ development-orchestrator [親が実行]
 │  ├─ markdown-word-checker [親が実行, Markdown関連変更時]
 │  ├─ sub-agent-task-manager [親が実行, reviewerは常にsub-agent]
 │  └─ report-output-manager [親が実行]
+├─ feedback-points-manager [親が実行, durable tracking]
+│  └─ feedback-points-sanitizer [親が呼び出し、sub-agent が実行]
 ├─ progress-sync-manager [親が実行]
 ├─ git-workflow-manager [親が実行]
 │  ├─ git-branch-starter [親が実行]
@@ -59,9 +63,17 @@ development-orchestrator [親が実行]
 │     ├─ codex-delegation-executor [親が実行]
 │     │  └─ implementation-executor [親が実行, 実作業は切替対象]
 │     └─ report-output-manager [親が実行]
-├─ feedback-points-manager [親が実行]
-│  └─ feedback-points-sanitizer [親が呼び出し、sub-agent が実行]
-└─ skill-authoring-wrapper [親が実行, issue完了時の親判断でlocal skill作成/更新が必要な場合]
+└─ skill-authoring-wrapper [親が実行, 既存skill更新または新規skill提案の採用時]
+```
+
+`development-orchestrator` は上記 skill 呼び出しに加え、内部 tool として次を所有する。
+
+```text
+skills/development-orchestrator/scripts/task_routine.py
+skills/development-orchestrator/scripts/task_routine_state.py
+skills/development-orchestrator/scripts/task_routine_hooks.py
+skills/development-orchestrator/tests/test_task_routine.py
+hooks/hooks.json
 ```
 
 ## 補助フローの呼び出し関係
@@ -116,6 +128,8 @@ development-orchestrator [親が実行]
    └─ `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` を同期更新する
 ```
 
+既存 skill の責務内に収まる内部的、可逆、低リスクな更新は、task routine の `skill_reflection=update-existing` と証跡を残して自動実施できる。新規 skill は利用者へ提案してから作成する。
+
 ## Markdown資料チェックフローの呼び出しツリー
 
 ```text
@@ -138,20 +152,27 @@ handover-memo-writer [親が実行]
 通常の task は、親が次の順番で進める。
 
 1. workflow 冒頭で `/home/ibis/AI/CodexSkill` が最新か確認し、安全に更新できるなら最新取得してから先へ進む。
-2. 再開セッションなら `restart-handover-manager` を呼び、再開文脈を復元してから同じ workflow に戻る。
-3. 新規着手で今回の作業対象がまだ曖昧なら、`development-orchestrator` がユーザーに何の作業をするか確認してから task 選定へ進む。
-4. `development-orchestrator` が現在状態を確認し、次の task を 1 つ選ぶ。
-5. `task-consistency-manager` で task と phase の追跡状態を整える。
-6. 設計影響がある場合は `design-doc-maintainer` を呼ぶ。
-7. 設計文書の実編集が必要なら、`codex-delegation-executor` を通して `design-executor` に流す。
-8. `tdd-executor` で最小の testable behavior と failing test 方針を定める。
-9. テスト作成やコード作成が必要なら、`codex-delegation-executor` を通して `implementation-executor` に流す。
-10. build、test、environment verification のような証拠作業が必要なら、`codex-delegation-executor` から `sub-agent-task-manager` を使って sub-agent に流す。
-11. 実装が一段落したら `review-enforcer` を呼び、セッション内で原則固定したレビュー専用 sub-agent を実行する。セッション内で監査・設計・ユーザー指示により決まったレビュー指針がある場合は、その指針を review request に含める。
-12. 指摘があれば `git-review-followup-manager` または通常の実装フローに戻して修正する。
-13. `progress-sync-manager` で report と tracking を同期する。
-14. `git-workflow-manager` で branch、commit、PR まで進める。
-15. issue または task が完了したら、親が skill 化判断を行い、必要に応じて `feedback-points-manager` を呼び、commit 時点で skill 改善 loop を issue へ引き継ぐ。
+2. repo root `AGENTS.md` と `development-orchestrator` を確認する。
+3. `task_routine.py status` で active routine と次 step を確認する。
+4. 再開セッションなら `restart-handover-manager` を呼び、復元結果を active routine と照合する。
+5. 新規着手で今回の作業対象がまだ曖昧なら、利用者に作業対象を確認する。
+6. active routine がなければ 1 task だけを開始し、`intake`、`skill_scan`、`task_definition`、`plan` の証跡を順番に記録する。
+7. `task-consistency-manager` で task と phase の追跡状態を整える。
+8. 設計影響がある場合は `design-doc-maintainer` を呼ぶ。
+9. 設計文書の実編集が必要なら、`codex-delegation-executor` を通して `design-executor` に流す。
+10. `tdd-executor` で最小の testable behavior と failing test 方針を定める。
+11. テスト作成やコード作成が必要なら、`codex-delegation-executor` を通して `implementation-executor` に流す。
+12. build、test、environment verification のような証拠作業が必要なら、`codex-delegation-executor` から `sub-agent-task-manager` を使って sub-agent に流す。
+13. 実装が一段落したら `review-enforcer` を呼び、セッション内で原則固定したレビュー専用 sub-agent を実行する。セッション内で監査・設計・ユーザー指示により決まったレビュー指針がある場合は、その指針を review request に含める。
+14. 指摘があれば `git-review-followup-manager` または通常の実装フローに戻し、`implementation` 以降の routine step を reopen して修正する。
+15. 親が `skill_reflection` を行い、`none`、`update-existing`、`propose-new` のいずれかと証跡を記録する。
+16. 既存 skill の責務内に収まる内部的、可逆、低リスクな更新は `skill-authoring-wrapper` 経由でその task 内に反映する。新規 skill は利用者へ提案する。
+17. 親が `tool_reflection` を行い、`none`、`update-existing`、`create-internal`、`propose-external` のいずれかと証跡を記録する。
+18. agent が繰り返し直接生成、変換、検証している決定的出力は、既存 skill 内の internal helper として安全に閉じる場合に自動化する。standalone external tool は利用者へ提案する。
+19. reusable process feedback、重複、残作業がある場合は `feedback-points-manager` を呼び、`feedback_tracking` の disposition を記録する。
+20. `progress-sync-manager` で report と tracking を同期し、`progress_sync` の証跡を記録する。
+21. review、両 reflection、feedback disposition、progress sync が完了した後だけ `git-workflow-manager` で branch、commit、PR まで進める。
+22. Git 提出の証跡を記録して routine を完了・archive し、次の task 確認へ戻る。
 
 大きい task では、`task-breakdown-planner`、`task-consistency-manager`、`design-doc-maintainer`、`restart-handover-manager`、`git-pr-submitter` の内部作業の一部を `sub-agent-task-manager` 経由で draft/audit/scan へ切り出してよい。ただし最終判断と反映は親が持つ。
 
@@ -168,7 +189,35 @@ handover-memo-writer [親が実行]
 - `tdd-executor` の test authoring 部分: 追加・更新する test 3 件以上、test file 3 本以上、または事前確認が必要な既存 test file 4 本以上
 - `git-review-followup-manager`: 対応 finding 3 件以上、対象 file 4 本以上、対象 behavior area 2 つ以上
 
-### 2. sub-agent を使うときの内部順
+### 2. task routine と hook
+
+`development-orchestrator` は対象 repository ごとに routine state を Git directory 内へ保存する。
+
+```text
+<git-dir>/codex-task-routine/state.json
+<git-dir>/codex-task-routine/history/*.json
+```
+
+routine の必須 step は次のとおりである。
+
+1. `intake`
+2. `skill_scan`
+3. `task_definition`
+4. `plan`
+5. `implementation`
+6. `verification`
+7. `review`
+8. `skill_reflection`
+9. `tool_reflection`
+10. `feedback_tracking`
+11. `progress_sync`
+12. `git_submission`
+
+`SessionStart` と `UserPromptSubmit` は active task と次 step を model context へ再注入する。`PreToolUse` は active task や前提 step がない編集と、完了前の Git 提出を拒否する。`Stop` は active task が未完了なら具体的な次 step を continuation prompt として返す。
+
+GitHub Issue と feedback point は履歴、重複、follow-up の正本として使う。実行中の次工程は local routine state と hook を正本とし、Issue を見たこと自体を実行条件にしない。
+
+### 3. sub-agent を使うときの内部順
 
 sub-agent を使う作業は、親が必ず次の順番で準備してから実行する。
 
@@ -181,7 +230,7 @@ sub-agent を使う作業は、親が必ず次の順番で準備してから実�
 7. sub-agent が作業し、既存 report の見出し順、空行、既存記述を保持したまま結果を書く。
 8. 親が report を確認し、完了条件を満たしているか判定する。
 
-### 3. レビュー差し戻し時の再入フロー
+### 4. レビュー差し戻し時の再入フロー
 
 レビューで指摘が出た場合は、次の順番で元の実装フローへ戻す。
 
@@ -189,24 +238,27 @@ sub-agent を使う作業は、親が必ず次の順番で準備してから実�
 2. `git-review-followup-manager` が、その指摘を現 task で直すか、新 task に切るかを決める。
 3. tracking 変更が必要なら `task-consistency-manager` を呼ぶ。
 4. 修正作業は `codex-delegation-executor` を通し、必要に応じて `implementation-executor` に流す。
-5. 修正後は再度 `review-enforcer` に戻し、再レビューを通す。
-6. 問題がなければ `progress-sync-manager` と `git-workflow-manager` に進む。
+5. active routine の `implementation` 以降を reopen する。
+6. 修正後は再度 `review-enforcer` に戻し、再レビューを通す。
+7. 問題がなければ reflection、feedback、progress、Git 提出へ進む。
 
-### 4. skill 作成・更新フロー
+### 5. skill 作成・更新フロー
 
 local skill を新規作成または実質更新するときは、親が次の順番で進める。
 
-1. `development-orchestrator` が end-of-issue の親判断として local skill 作成または更新が必要だと決め、`skill-authoring-wrapper` を呼ぶ。
-2. `skill-authoring-wrapper` を入口にして、対象 skill の目的、配置先、new/update 区分を定める。
-3. built-in `skill-creator` を読み、初期化に使う部分と、repo 標準へ補正する部分を切り分ける。
-4. 新規 skill の場合は built-in `skill-creator` の初期化フローを使って skill directory を作る。
-5. 既存 skill の更新の場合は、既存 `SKILL.md` の意図を残すべき部分と、repo 標準へ正規化すべき部分を分ける。
-6. `skill-authoring-wrapper` が `SKILL.md` を repo 標準の section と契約粒度へ揃える。
-7. 実行委譲や switchable な実装系があるなら、`codex-delegation-executor` 前提の書き方と暫定数値基準を入れる。
-8. canonical file の更新経路制約が必要なら、その skill からしか触らないことを `SKILL.md` に明記する。
-9. 実在する canonical skill inventory または registry file がある場合だけ、それを最終的な skill 意図に合わせて更新する。
-10. skill inventory、呼び出しツリー、役割、契約一覧のどれかが変わるなら `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` を同期更新する。
-11. skill 設計が repo 標準に揃ったら、その skill を採用対象として扱う。
+1. `development-orchestrator` が task routine の skill reflection として local skill 作成または更新要否を決める。
+2. 既存 skill 更新なら、内部的、可逆、低リスクで既存責務内かを確認し、該当する場合は `skill-authoring-wrapper` を呼ぶ。
+3. 新規 skill 候補なら、既存 skill では責務を置けない理由と owner scope を利用者へ提案し、採用後に `skill-authoring-wrapper` を呼ぶ。
+4. `skill-authoring-wrapper` を入口にして、対象 skill の目的、配置先、new/update 区分を定める。
+5. built-in `skill-creator` を読み、初期化に使う部分と、repo 標準へ補正する部分を切り分ける。
+6. 新規 skill の場合は built-in `skill-creator` の初期化フローを使って skill directory を作る。
+7. 既存 skill の更新の場合は、既存 `SKILL.md` の意図を残すべき部分と、repo 標準へ正規化すべき部分を分ける。
+8. `skill-authoring-wrapper` が `SKILL.md` を repo 標準の section と契約粒度へ揃える。
+9. 実行委譲や switchable な実装系があるなら、`codex-delegation-executor` 前提の書き方と暫定数値基準を入れる。
+10. canonical file の更新経路制約が必要なら、その skill からしか触らないことを `SKILL.md` に明記する。
+11. 実在する canonical skill inventory または registry file がある場合だけ、それを最終的な skill 意図に合わせて更新する。
+12. skill inventory、呼び出しツリー、役割、契約一覧のどれかが変わるなら `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` を同期更新する。
+13. skill 設計が repo 標準に揃ったら、task routine に更新証跡を記録する。
 
 ## skillと役割
 
@@ -216,7 +268,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `development-orchestrator` | 全体フローの入口として、task 選定から設計、TDD、委譲、レビュー、進捗同期、Git、issue 完了時の振り返りまでを統括する。 | `親が実行` |
+| `development-orchestrator` | 全体フローの入口として、永続 task routine、task 選定、設計、TDD、委譲、レビュー、skill/tool reflection、feedback disposition、進捗同期、Git 提出までを統括する。 | `親が実行` |
 | `codex-delegation-executor` | 実装・検証・調査を誰が実行するかを決め、sub-agent 必須カテゴリを正しく委譲する。 | `親が実行` |
 | `sub-agent-task-manager` | sub-agent へ渡す task の範囲、読むべき skill、report path、report template 保持ルール、完了条件を固定する。 | `親が実行` |
 | `execution-cost-stabilizer` | 無駄な再実行や過剰並列を抑え、委譲実行のコストと不安定さを下げる。 | `親が実行` |
@@ -256,11 +308,11 @@ local skill を新規作成または実質更新するときは、親が次の�
 | `feedback-coding-standards-enforcer` | API ドキュメント、命名、解析ルールなどのコーディング規約を review/commit 前に強制する。 | `親が実行` |
 | `feedback-issue-intake-fallback-manager` | issue 要件の取得が失敗したときに、代替経路で authoritative な要件を確保する。 | `親が実行` |
 
-### Feedback ガバナンスと skill 化
+### Feedback ガバナンスと skill/tool 化
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `feedback-points-manager` | 再利用可能な workflow lesson を `feedback-points.md` で管理し、skill 化するかどうかを判断する。 | `親が実行` |
+| `feedback-points-manager` | 再利用可能な workflow lesson と tool automation finding を管理し、重複、再発、commit-backed closure、follow-up issue を記録する。runtime の次 step は task routine が所有する。 | `親が実行` |
 | `feedback-points-sanitizer` | noisy な feedback points を独立した立場で整理し、親が判断しやすい状態に整える。 | `親が呼び出し、sub-agent が実行` |
 
 ### Git 提出フロー
@@ -281,13 +333,13 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 ## skill契約一覧
 
-この章では、各 skill の入力、出力、完了条件を設計レベルで要約する。
+この章では、各 skill について入力、出力、完了条件を設計レベルで要約する。
 
 ### 入口と全体統括
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `development-orchestrator` | tasks/phases、recent reports、feedback-points、repo state | 現在 task と次の実行経路 | 1 task 分の標準サイクル完了または明確な blocking 状態 |
+| `development-orchestrator` | task routine state、tasks/phases、recent reports、feedback-points、repo state | active task、次 step、各 step の証跡、skill/tool decision、Git 提出経路 | routine の全 step が証跡付きで完了・archive、または明確な paused/aborted/blocking 状態 |
 | `codex-delegation-executor` | 実行対象の work item、scope、evidence 要件 | executor 決定、委譲結果、report evidence | executor 決定と結果記録が完了 |
 | `sub-agent-task-manager` | task purpose、scope、読むべき skill、report path 要件、workspace context 方針 | dispatch 済み sub-agent task、pre-created report、review 済み evidence | report 作成と review 済み evidence の確認完了 |
 | `execution-cost-stabilizer` | delegated task plan、retry pressure、parallelism 候補 | 安定化された実行計画 | 次アクションが無駄なく scoped されている |
@@ -301,7 +353,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 | `task-breakdown-planner` | issue/request scope、constraints、existing tasks/phases | tasks、phases、dependencies、exit criteria | 次 task を他 agent が推測なしで実行できる。大きい分解では sub-agent draft を parent が採用する |
 | `task-consistency-manager` | current work item、tasks/phases、new scope | 更新済み tracking、明確な next step | tracking が実 scope と一致。大きい監査では sub-agent audit を parent が確認する |
 | `progress-sync-manager` | 最新の task/review/verification/git 結果、reports | 同期済み tracking と references | canonical tracking が実状態と一致 |
-| `restart-handover-manager` | feedback-points、tasks/phases、recent reports | current position、next task、open deps | 再開時の次アクションが明示されている。大きい文脈では sub-agent summary を parent が採用する |
+| `restart-handover-manager` | feedback-points、tasks/phases、recent reports | current position、next task、open deps | 再開位置が active routine と照合され、次アクションが明示されている。大きい文脈では sub-agent summary を parent が採用する |
 | `handover-memo-writer` | current chat history、agreed constraints、repo/report/git state、user format request、作成Markdown report path | next-chat ready handover memo、handover report、`markdown-word-checker` focused lint結果 | 新しい chat が旧会話なしでも再開可能な handover と report が完成し、作成Markdownのcheck結果が記録されている |
 
 ### 設計
@@ -327,18 +379,18 @@ local skill を新規作成または実質更新するときは、親が次の�
 | `feedback-coding-standards-enforcer` | changed files、API diff、repo standards | standards evidence、violation fixes または rationale | standards-sensitive change の確認と記録が完了 |
 | `feedback-issue-intake-fallback-manager` | issue id/URL、available retrieval paths、partial context | authoritative requirements report、confidence、gaps | requirements と confidence が report に明示済み |
 
-### Feedback ガバナンスと skill 化
+### Feedback ガバナンスと skill/tool 化
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `feedback-points-manager` | candidate process lesson、active FP ledger、duplicate context | FP add/merge/skip 判断、skillization status、次アクション対応 | FP 判断と rationale が ledger か report に残る |
+| `feedback-points-manager` | candidate process/tool lesson、task-routine decision、active FP ledger、duplicate context | FP add/merge/skip、skill/tool status、commit-backed closure または follow-up issue | durable tracking と rationale が残り、commit-ready point が active ledger に残っていない |
 | `feedback-points-sanitizer` | active FP set、cleanup scope、duplicate references | cleanup report、classification result、candidate groups | parent review 用の cleanup evidence が report に残る |
 
 ### Git 提出フロー
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `git-workflow-manager` | branch/commit/PR state、task readiness | selected Git actions、submission path、commit shape decision | branch/commit/PR の必要アクション完了と、その task の commit 形が決定済み |
+| `git-workflow-manager` | branch/commit/PR state、task readiness、routine prerequisites | selected Git actions、submission path、commit shape decision | review、reflection、feedback、progress の証跡後に branch/commit/PR の必要アクションが完了 |
 | `git-branch-starter` | task or issue scope、branch state、naming basis | active branch context | 適切な branch に作業が隔離されている |
 | `git-commit-manager` | scoped changes、review/validation state、commit convention | coherent commit(s)、formatted commit message | task に対応した commit 作成完了 |
 | `git-pr-submitter` | branch、task scope、review/validation evidence、report refs | reviewable PR | 必要コンテキスト付きの PR 作成完了。大きい PR 文脈では sub-agent draft を parent が確定する |
@@ -353,6 +405,11 @@ local skill を新規作成または実質更新するときは、親が次の�
 ## 主要な設計判断
 
 - workflow 入口は `development-orchestrator` の一箇所に固定し、再開時も `restart-handover-manager` から直接始めず `development-orchestrator` へ戻して続行する。
+- `development-orchestrator` は 1 task ごとの永続 routine と hook gate を所有し、active task と次 step を agent の記憶ではなく local state から再提示する。
+- GitHub Issue と feedback point は履歴、重複、follow-up の正本とし、runtime の次 step を思い出す唯一の trigger にはしない。
+- task 完了前に skill reflection と tool reflection を必須化し、該当なしの場合も理由を証跡として残す。
+- 既存 skill の責務内に収まる内部的、可逆、低リスクな改善と internal helper は、発生回数を hard gate にせず task 内で自動実施できる。
+- 新規 skill、standalone external tool、外部公開契約、破壊的変更、credential・法務・組織承認が必要な変更は利用者確認境界を維持する。
 - `restart-handover-manager` は recorded state から再開位置を復元する skill とし、会話内容そのものを次チャットへ移送する handover 文面の作成は `handover-memo-writer` に分離する。
 - レビューは親がゲートを持つが、レビュワー実行は必ず sub-agent とする。1 セッションでは基本的に同じ reviewer sub-agent を継続し、セッション内で決まったレビュー指針を後続 review に引き継ぐ。
 - 設計文書編集とコード/テスト作成は、判断系 skill から分離し、`design-executor` と `implementation-executor` に寄せる。
@@ -364,11 +421,13 @@ local skill を新規作成または実質更新するときは、親が次の�
 - `skill-authoring-wrapper` の既定 caller は `development-orchestrator` とし、宙ぶらりんな local skill authoring を作らない。
 - 判断責務を上位 skill に寄せるのは、その判断が固定 caller を持つサブツリー内部で閉じる場合に限る。`1対多` 構造や単独利用されうる下位 skill では、上位に寄せすぎず、下位は参照先を明示して従う形を基本とする。
 - local skill 群の最新維持責任は workflow 入口の `development-orchestrator` が持ち、作業着手前に `/home/ibis/AI/CodexSkill` の鮮度確認を行う。
-- skill 改善ループの継続確認は active FP ではなく issue を正本とし、issue 作成後の FP は active ledger から外す。
-- commit 時点では active `feedback-points.md` が再び空になる運用を既定とし、skill 改善ループは issue 側へ引き継いでから commit を通す。
+- skill/tool 改善ループの継続確認は active FP ではなく issue を正本とし、issue 作成後の FP は active ledger から外す。
+- commit 時点では active `feedback-points.md` が再び空になる運用を既定とし、残作業は issue 側へ引き継いでから commit を通す。
 
 ## 保守ルール
 
 - 新しい skill を追加したら、この設計書のツリーと一覧を更新する。
+- task routine の step、hook event、skill/tool reflection contract が変わったら、この設計書と `design/task-routine-hook-design.md` を同期更新する。
 - 呼び出し関係が変わったら、まずこの設計書を更新してから関連 report を更新する。
+- `skills/design/skill-hierarchy-design.md` と `design/skill-hierarchy-design.md` は同一内容を維持する。
 - 実行方式の表現は `親が実行` と `親が呼び出し、sub-agent が実行` に統一する。

--- a/skills/development-orchestrator/SKILL.md
+++ b/skills/development-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: development-orchestrator
-description: Orchestrate iterative development work from task selection through design update, test-first execution, Codex delegation, review, progress reflection, commit, and PR creation. Use when resuming development, starting a new issue/task, or continuing implementation across multiple tasks and phases. This skill acts as the parent coordinator and calls specialized child skills rather than performing detailed work itself.
+description: Orchestrate iterative development work through a persistent one-task routine, from task selection through design update, test-first execution, Codex delegation, review, skill/tool reflection, progress synchronization, commit, and PR creation. Use when resuming development, starting a new issue/task, or continuing implementation across multiple tasks and phases. This skill acts as the parent coordinator and calls specialized child skills rather than performing detailed work itself.
 ---
 
 # Development Orchestrator
@@ -20,7 +20,8 @@ This is the single workflow entry point for implementation and resume flows.
 Run this skill as: `parent`
 
 - This skill owns task selection, completion flow, and final lifecycle decisions.
-- End-of-issue skill-gap reflection is parent work, not sub-agent work.
+- This skill owns the persistent task routine state and decides when each routine step is complete.
+- End-of-issue skill-gap and tool-automation reflection are parent work, not sub-agent work.
 - This skill owns the start-of-workflow check that repo-local skills are current enough to trust.
 - This skill is the only standard workflow entry point; restart and handover should re-enter through this skill.
 
@@ -32,6 +33,7 @@ Before running this skill, confirm:
 - repo root `AGENTS.md` exists and explicitly says both of the following:
   - always confirm whether a relevant skill already exists while working
   - when unsure, suspect skill insufficiency before improvising
+- active task routine state from `scripts/task_routine.py status`
 - the user's intended work for this run when it is not already explicit from the request or restart context
 - current `tasks-status.md` and `phases-status.md`
 - recent `reports/` relevant to the active issue or task
@@ -46,32 +48,37 @@ Follow this sequence:
 2. Check `AGENTS.md` before trusting the workflow entry. If either required instruction is missing, notify the user explicitly before selecting a task.
 3. If the local skill repo is clean and behind its intended source, update it before continuing the workflow.
 4. If the local skill repo is dirty, diverged, or otherwise unsafe to auto-update, stop and resolve that explicitly before trusting the workflow.
-5. When entering from a resumed or restarted session, call `restart-handover-manager` to reconstruct the current position before selecting the next task.
-6. When the intended work for this run is not already explicit, read [references/start-intake-policy.md](references/start-intake-policy.md) and confirm with the user what work should be done before selecting a task.
-7. Confirm current state from `tasks-status.md`, `phases-status.md`, recent `reports/`, and `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`.
-8. Select exactly one next task.
-9. Call `task-consistency-manager`.
-10. Call `design-doc-maintainer` if design impact exists.
-11. Call `tdd-executor`.
-12. Call `codex-delegation-executor` to choose executor and run implementation/verification work.
-13. Call `review-enforcer`.
-14. Call `progress-sync-manager`.
-15. Call `git-workflow-manager`.
-16. When an issue or task reaches done, make an explicit parent-side decision: `no skill action needed`, `update an existing skill`, or `propose a new skill`.
-17. If the decision is `update an existing skill` or `propose a new skill` and the local skill work should be executed now, call `skill-authoring-wrapper`.
-18. Call `feedback-points-manager` when that decision should be recorded as reusable process feedback, when skillization state changed, or when a follow-up issue must be created at commit timing.
-19. Return to task confirmation.
+5. Read the task routine state with `scripts/task_routine.py status`.
+6. When entering from a resumed or restarted session, call `restart-handover-manager` and reconcile its result with the active routine before selecting the next task.
+7. When the intended work for this run is not already explicit, read [references/start-intake-policy.md](references/start-intake-policy.md) and confirm with the user what work should be done before selecting a task.
+8. Confirm current state from `tasks-status.md`, `phases-status.md`, recent `reports/`, and `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`.
+9. Start exactly one task routine when none is active, then select exactly one next task.
+10. Record evidence for `intake`, `skill_scan`, `task_definition`, and `plan` before repository mutation begins.
+11. Call `task-consistency-manager`.
+12. Call `design-doc-maintainer` if design impact exists.
+13. Call `tdd-executor`.
+14. Call `codex-delegation-executor` to choose executor and run implementation/verification work.
+15. Call `review-enforcer`.
+16. Record one explicit skill decision: `none`, `update-existing`, or `propose-new`.
+17. When the skill decision is `update-existing` and the change is internal, reversible, low-risk, and within an existing skill's ownership, execute it now through `skill-authoring-wrapper`. Recommend a new skill to the user before creating it.
+18. Record one explicit tool decision: `none`, `update-existing`, `create-internal`, or `propose-external`. Create or update an internal helper now when it automates deterministic repeated agent output within the current skill ownership and remains reversible and low-risk.
+19. Call `feedback-points-manager` when reusable process feedback, duplicate tracking, skillization state, or follow-up issue handling is required.
+20. Call `progress-sync-manager`.
+21. Call `git-workflow-manager` only after review, both reflections, feedback disposition, and progress synchronization have routine evidence.
+22. Archive or close the completed routine, then return to task confirmation.
 
 ## Core rules
 
 - Work on one task at a time.
+- Do not mutate a repository without an active task routine.
+- Do not advance a routine step without evidence or an explicit not-applicable reason.
+- Do not use GitHub Issue lookup as the only runtime trigger; issues and feedback points are history and duplicate-tracking records, while the local routine state owns the next executable step.
 - Do not start implementation or restart flows from any other standard entry point.
 - Do not select a task before clarifying the run target when the user's intended work is still ambiguous.
 - Do not treat implementation as complete before commit and PR creation.
-- Do not skip task reconciliation, design reflection, review, or progress updates.
+- Do not skip task reconciliation, design reflection, review, skill reflection, tool reflection, feedback disposition, or progress updates.
 - Do not enter the implementation workflow on stale local skills when a safe latest-sync was available at the start.
 - Do not trust the workflow entry until `AGENTS.md` is present and contains the required skill-first constraints, or the user has been explicitly notified that it does not.
-- Do not skip parent-owned end-of-issue skill-gap reflection when an issue reaches done.
 - Do not leave local skill creation or substantial local skill updates floating without an explicit caller; use `development-orchestrator` as the default caller when the need is discovered through normal task completion.
 - Do not decide `main agent` vs `sub-agent` for implementation outside `codex-delegation-executor`.
 - Treat design-document editing as switchable implementation work under `codex-delegation-executor` with `design-executor`.
@@ -88,9 +95,11 @@ Follow this sequence:
 
 After this skill runs, the workflow should have:
 
-- one explicitly selected current task
+- one explicitly selected current task and active routine
 - a concrete next-step path through the child skills
-- evidence of completion or a clear blocking condition for the current cycle
+- evidence for every completed or skipped routine step
+- explicit skill and tool automation decisions
+- evidence of completion or a clear paused, aborted, or blocking condition for the current cycle
 
 ## Completion condition
 
@@ -100,10 +109,13 @@ A task cycle is complete only when all of the following are true:
 - tests have been run
 - review has been completed
 - reports have been written
+- skill reflection has an evidence-backed decision
+- tool reflection has an evidence-backed decision
+- feedback and duplicate tracking have an explicit disposition
 - progress files have been updated
 - commit has been created
 - PR has been created
-- end-of-issue skill candidate decision has been made
+- the routine has been archived or closed
 
 ## What this skill must not do
 

--- a/skills/development-orchestrator/scripts/task_routine.py
+++ b/skills/development-orchestrator/scripts/task_routine.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Persistent one-task routine CLI and Codex hook entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from task_routine_state import *
+from task_routine_hooks import *
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    subs = result.add_subparsers(dest="command", required=True)
+    def common(item: argparse.ArgumentParser) -> None:
+        item.add_argument("--repo-root")
+    start_p = subs.add_parser("start"); start_p.add_argument("--id", required=True); start_p.add_argument("--summary", required=True); common(start_p)
+    status_p = subs.add_parser("status"); status_p.add_argument("--json", action="store_true"); common(status_p)
+    for command in ("complete", "skip"):
+        item = subs.add_parser(command); item.add_argument("step", choices=STEPS); item.add_argument("--evidence" if command == "complete" else "--reason", required=True); common(item)
+    reflect_p = subs.add_parser("reflect"); reflect_p.add_argument("kind", choices=("skill", "tool")); reflect_p.add_argument("--decision", required=True); reflect_p.add_argument("--target"); reflect_p.add_argument("--evidence", required=True); common(reflect_p)
+    feedback_p = subs.add_parser("feedback"); feedback_p.add_argument("--decision", choices=sorted(FEEDBACK_DECISIONS), required=True); feedback_p.add_argument("--target"); feedback_p.add_argument("--evidence", required=True); common(feedback_p)
+    for command in ("pause", "abort"):
+        item = subs.add_parser(command); item.add_argument("--reason", required=True); common(item)
+    resume_p = subs.add_parser("resume"); common(resume_p)
+    reopen_p = subs.add_parser("reopen"); reopen_p.add_argument("step", choices=STEPS); reopen_p.add_argument("--reason", required=True); common(reopen_p)
+    subs.add_parser("hook")
+    for command in ("install-hooks", "uninstall-hooks"):
+        item = subs.add_parser(command); item.add_argument("--scope", choices=("project", "user"), default="project"); item.add_argument("--target", type=Path); item.add_argument("--script-path", type=Path); common(item)
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.command == "hook":
+            payload = json.load(sys.stdin)
+            output = handle_hook(payload)
+            if output is not None:
+                print(json.dumps(output, ensure_ascii=False))
+            return 0
+        if args.command in {"install-hooks", "uninstall-hooks"}:
+            candidate = Path(args.repo_root or os.getcwd())
+            root = repo_root(candidate)
+            path, changed = install(args.scope, root, args.target, args.script_path, args.command == "uninstall-hooks")
+            print(f"hooks: {path} ({'changed' if changed else 'unchanged'})")
+            return 0
+        root = require_root(args.repo_root)
+        if args.command == "start":
+            state = start(root, args.id.strip(), args.summary.strip())
+        elif args.command == "status":
+            state = load(root)
+            print(json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) if args.json else render(state, root))
+            return 0
+        else:
+            state = require_state(root)
+            if args.command == "complete":
+                state = mark(root, state, args.step, "done", args.evidence)
+            elif args.command == "skip":
+                state = mark(root, state, args.step, "not_applicable", args.reason)
+            elif args.command == "reflect":
+                state = reflection(root, state, args.kind, args.decision, args.target, args.evidence)
+            elif args.command == "feedback":
+                state = feedback(root, state, args.decision, args.target, args.evidence)
+            elif args.command == "pause":
+                state = pause(root, state, args.reason)
+            elif args.command == "abort":
+                state = pause(root, state, args.reason, abort=True)
+            elif args.command == "resume":
+                state = resume(root, state)
+            elif args.command == "reopen":
+                state = reopen_step(root, state, args.step, args.reason)
+            else:
+                raise RoutineError(f"未対応commandです: {args.command}")
+        print(render(state, root))
+        return 0
+    except (RoutineError, json.JSONDecodeError) as exc:
+        print(f"task-routine error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/development-orchestrator/scripts/task_routine_hooks.py
+++ b/skills/development-orchestrator/scripts/task_routine_hooks.py
@@ -29,7 +29,12 @@ PR_BODY_PLACEHOLDERS = {"", "-", "n/a", "none", "tbd", "todo", "未記入", "未
 
 
 def tool_token(name: Any) -> str:
-    return str(name or "").split(".")[-1].lower().replace("-", "_")
+    token = str(name or "")
+    for separator in (".", "/", ":"):
+        token = token.split(separator)[-1]
+    if "__" in token:
+        token = token.rsplit("__", 1)[-1]
+    return token.lower().replace("-", "_")
 
 
 def strings(value: Any) -> list[str]:

--- a/skills/development-orchestrator/scripts/task_routine_hooks.py
+++ b/skills/development-orchestrator/scripts/task_routine_hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import tempfile
 from pathlib import Path
@@ -18,6 +19,13 @@ TRACKING_TOOLS = {
     "add_comment_to_issue",
     "add_review_to_pr",
 }
+PR_CREATE_TOOLS = {"create_pull_request", "open_pull_request"}
+PR_BODY_REQUIRED_SECTIONS = {
+    "task routine": "## Task routine evidence",
+    "skill action": "## Skill action",
+    "tool action": "## Tool action",
+}
+PR_BODY_PLACEHOLDERS = {"", "-", "n/a", "none", "tbd", "todo", "未記入", "未定"}
 
 
 def tool_token(name: Any) -> str:
@@ -55,6 +63,30 @@ def mutation(event: Mapping[str, Any]) -> str | None:
     command = "\n".join(strings(event.get("tool_input", {})))
     classified = classify_shell_command(command)
     return None if classified == "other" else classified
+
+
+def pr_body_missing_sections(event: Mapping[str, Any]) -> list[str]:
+    if tool_token(event.get("tool_name")) not in PR_CREATE_TOOLS:
+        return []
+    tool_input = event.get("tool_input")
+    if not isinstance(tool_input, Mapping):
+        return list(PR_BODY_REQUIRED_SECTIONS)
+    body = tool_input.get("body")
+    if not isinstance(body, str):
+        return list(PR_BODY_REQUIRED_SECTIONS)
+
+    missing: list[str] = []
+    for label, heading in PR_BODY_REQUIRED_SECTIONS.items():
+        match = re.search(rf"(?mi)^\s*{re.escape(heading)}\s*$", body)
+        if match is None:
+            missing.append(label)
+            continue
+        remainder = body[match.end():]
+        next_heading = re.search(r"(?m)^\s*##\s+", remainder)
+        evidence = remainder[: next_heading.start() if next_heading else None].strip()
+        if evidence.casefold() in PR_BODY_PLACEHOLDERS:
+            missing.append(label)
+    return missing
 
 
 def context(root: Path, state: Mapping[str, Any] | None) -> str:
@@ -104,6 +136,15 @@ def handle_hook(event_data: Mapping[str, Any]) -> dict[str, Any] | None:
         elif kind == "submission" and any(not complete(state, name) for name in SUBMISSION_PREREQUISITES):
             missing = [name for name in SUBMISSION_PREREQUISITES if not complete(state, name)]
             reason = f"submission前stepが未完了です: {', '.join(missing)}"
+        elif tool_token(event_data.get("tool_name")) in PR_CREATE_TOOLS:
+            missing_sections = pr_body_missing_sections(event_data)
+            if missing_sections:
+                reason = (
+                    "PR本文の必須証跡が不足しています: "
+                    f"{', '.join(missing_sections)}。"
+                    "## Task routine evidence / ## Skill action / ## Tool action "
+                    "を記入してください。"
+                )
         if reason:
             return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}
         return None

--- a/skills/development-orchestrator/scripts/task_routine_hooks.py
+++ b/skills/development-orchestrator/scripts/task_routine_hooks.py
@@ -11,6 +11,15 @@ from typing import Any, Mapping
 
 from task_routine_state import *
 
+CONTENTS_API_COMMIT_TOOLS = {"create_file", "update_file", "delete_file"}
+TRACKING_TOOLS = {
+    "create_issue",
+    "update_issue",
+    "add_comment_to_issue",
+    "add_review_to_pr",
+}
+
+
 def tool_token(name: Any) -> str:
     return str(name or "").split(".")[-1].lower().replace("-", "_")
 
@@ -35,8 +44,10 @@ def classify_shell_command(command: str) -> str:
 
 def mutation(event: Mapping[str, Any]) -> str | None:
     token = tool_token(event.get("tool_name"))
-    if token in SUBMIT_TOOLS:
+    if token in CONTENTS_API_COMMIT_TOOLS or token in SUBMIT_TOOLS:
         return "submission"
+    if token in TRACKING_TOOLS:
+        return None
     if token in EDIT_TOOLS:
         return "edit"
     if token not in SHELL_TOOLS:
@@ -50,8 +61,10 @@ def context(root: Path, state: Mapping[str, Any] | None) -> str:
     if state is None:
         return "TASK ROUTINE: active taskなし。repositoryを変更する前に task_routine.py start を実行すること。"
     task, nxt = state["task"], next_step(state)
+    if task["status"] == "paused":
+        return f"TASK ROUTINE: task {task['id']} は paused。変更前にresumeが必要。"
     if task["status"] != "active":
-        return f"TASK ROUTINE: task {task['id']} は {task['status']}。変更前にresumeまたは新task開始が必要。"
+        return f"TASK ROUTINE: task {task['id']} は {task['status']}。変更前に新しいtaskの開始が必要。"
     return f"TASK ROUTINE: {task['id']} / {task['summary']}。next required step: {nxt or 'none'}。skill/tool/feedback判定を省略しないこと。state={state_path(root)}"
 
 
@@ -93,6 +106,10 @@ def handle_hook(event_data: Mapping[str, Any]) -> dict[str, Any] | None:
             reason = f"submission前stepが未完了です: {', '.join(missing)}"
         if reason:
             return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}
+        return None
+    if event_name == "Stop" and bool(event_data.get("stop_hook_active")):
+        if state_error:
+            return {"systemMessage": f"task routine state error remains after continuation: {state_error}"}
         return None
     if event_name == "Stop" and state_error:
         return {"decision": "block", "reason": f"task routine stateが壊れています: {state_error}. stateを修復してください。"}
@@ -178,5 +195,3 @@ def require_state(root: Path) -> dict[str, Any]:
     if state is None:
         raise RoutineError("active task routine stateがありません")
     return state
-
-

--- a/skills/development-orchestrator/scripts/task_routine_hooks.py
+++ b/skills/development-orchestrator/scripts/task_routine_hooks.py
@@ -1,0 +1,182 @@
+"""Codex hook handling and hook configuration for the task routine."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+from task_routine_state import *
+
+def tool_token(name: Any) -> str:
+    return str(name or "").split(".")[-1].lower().replace("-", "_")
+
+
+def strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [text for item in value.values() for text in strings(item)]
+    if isinstance(value, list):
+        return [text for item in value for text in strings(item)]
+    return []
+
+
+def classify_shell_command(command: str) -> str:
+    if GIT_SUBMIT.search(command):
+        return "submission"
+    if any(pattern.search(command) for pattern in (GIT_MUTATE, FILE_MUTATE, GH_MUTATE, REDIRECT)):
+        return "edit"
+    return "other"
+
+
+def mutation(event: Mapping[str, Any]) -> str | None:
+    token = tool_token(event.get("tool_name"))
+    if token in SUBMIT_TOOLS:
+        return "submission"
+    if token in EDIT_TOOLS:
+        return "edit"
+    if token not in SHELL_TOOLS:
+        return None
+    command = "\n".join(strings(event.get("tool_input", {})))
+    classified = classify_shell_command(command)
+    return None if classified == "other" else classified
+
+
+def context(root: Path, state: Mapping[str, Any] | None) -> str:
+    if state is None:
+        return "TASK ROUTINE: active taskなし。repositoryを変更する前に task_routine.py start を実行すること。"
+    task, nxt = state["task"], next_step(state)
+    if task["status"] != "active":
+        return f"TASK ROUTINE: task {task['id']} は {task['status']}。変更前にresumeまたは新task開始が必要。"
+    return f"TASK ROUTINE: {task['id']} / {task['summary']}。next required step: {nxt or 'none'}。skill/tool/feedback判定を省略しないこと。state={state_path(root)}"
+
+
+def hook_output(event_name: str, additional: str) -> dict[str, Any]:
+    return {"hookSpecificOutput": {"hookEventName": event_name, "additionalContext": additional}}
+
+
+def handle_hook(event_data: Mapping[str, Any]) -> dict[str, Any] | None:
+    event_name = str(event_data.get("hook_event_name") or "")
+    root = repo_root(Path(str(event_data.get("cwd") or os.getcwd())))
+    if root is None:
+        return None
+    try:
+        state = load(root)
+        state_error = None
+    except RoutineError as exc:
+        state = None
+        state_error = str(exc)
+    if event_name in {"SessionStart", "UserPromptSubmit"}:
+        if state_error:
+            return hook_output(event_name, f"TASK ROUTINE state error: {state_error}. 変更を開始せずstateを修復すること。")
+        return hook_output(event_name, context(root, state))
+    if event_name == "PreToolUse":
+        kind = mutation(event_data)
+        if not kind:
+            return None
+        reason: str | None = None
+        if state_error:
+            reason = f"task routine stateが壊れています: {state_error}"
+        elif state is None:
+            reason = "active task routineがありません。task_routine.py start --id <id> --summary <summary> を先に実行してください。"
+        elif state["task"]["status"] != "active":
+            reason = f"task routineは {state['task']['status']} です。resumeまたは新task開始が必要です。"
+        elif kind == "edit" and any(not complete(state, name) for name in EARLY):
+            missing = [name for name in EARLY if not complete(state, name)]
+            reason = f"編集前stepが未完了です: {', '.join(missing)}"
+        elif kind == "submission" and any(not complete(state, name) for name in SUBMISSION_PREREQUISITES):
+            missing = [name for name in SUBMISSION_PREREQUISITES if not complete(state, name)]
+            reason = f"submission前stepが未完了です: {', '.join(missing)}"
+        if reason:
+            return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}
+        return None
+    if event_name == "Stop" and state_error:
+        return {"decision": "block", "reason": f"task routine stateが壊れています: {state_error}. stateを修復してください。"}
+    if event_name == "Stop" and state and state["task"]["status"] == "active" and next_step(state):
+        nxt = next_step(state)
+        return {"decision": "block", "reason": f"task {state['task']['id']} は未完了です。次に {nxt}: {DESCRIPTIONS[nxt]} を実施し、証跡を記録してください。pause/abort時は専用commandを使ってください。"}
+    return None
+
+
+def hook_groups(command: str) -> dict[str, list[dict[str, Any]]]:
+    handler = {"type": "command", "command": command, "timeout": 10, "statusMessage": "task routineを確認中"}
+    return {name: [{"hooks": [handler]}] for name in ("SessionStart", "UserPromptSubmit", "PreToolUse", "Stop")}
+
+
+def handler_commands(group: Any) -> list[str]:
+    if not isinstance(group, dict):
+        return []
+    return [str(item.get("command", "")) for item in group.get("hooks", []) if isinstance(item, dict)]
+
+
+def install(scope: str, root: Path | None, target: Path | None, script: Path | None, remove: bool = False) -> tuple[Path, bool]:
+    if target:
+        path = target.expanduser().resolve(strict=False)
+    elif scope == "project":
+        if root is None:
+            raise RoutineError("project hook installにはGit repositoryが必要です")
+        path = root / ".codex" / "hooks.json"
+    else:
+        path = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))).expanduser() / "hooks.json"
+    try:
+        config = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {"hooks": {}}
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RoutineError(f"hooks.jsonを読めません: {exc}") from exc
+    hooks = config.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        raise RoutineError("hooks.jsonのhooksがobjectではありません")
+    changed = False
+    for name in list(hooks):
+        groups = hooks[name]
+        if isinstance(groups, list) and remove:
+            kept = [group for group in groups if not any("task_routine.py" in cmd for cmd in handler_commands(group))]
+            changed |= len(kept) != len(groups)
+            if kept:
+                hooks[name] = kept
+            else:
+                hooks.pop(name, None)
+    if not remove:
+        script_command = f"python3 {shlex.quote(str((script or Path(__file__).with_name('task_routine.py')).expanduser().resolve()))} hook"
+        for name, groups in hook_groups(script_command).items():
+            current = hooks.setdefault(name, [])
+            if not isinstance(current, list):
+                raise RoutineError(f"hooks.{name}がarrayではありません")
+            if not any(any("task_routine.py" in cmd for cmd in handler_commands(group)) for group in current):
+                current.extend(groups)
+                changed = True
+    if changed or not path.exists():
+        write_json(path, config)
+    return path, changed
+
+
+def install_hooks(scope: str, root: Path | None, target: Path | None, script: Path | None, dry_run: bool) -> tuple[Path, bool, dict[str, Any]]:
+    if dry_run:
+        # Merge through a temporary copy to preserve the real target.
+        with tempfile.TemporaryDirectory() as tmp:
+            preview = Path(tmp) / "hooks.json"
+            if target and target.exists():
+                preview.write_text(target.read_text(encoding="utf-8"), encoding="utf-8")
+            path, changed = install(scope, root, preview, script)
+            return target or path, changed, json.loads(preview.read_text(encoding="utf-8"))
+    path, changed = install(scope, root, target, script)
+    return path, changed, json.loads(path.read_text(encoding="utf-8"))
+
+
+def require_root(value: str | None) -> Path:
+    root = repo_root(Path(value or os.getcwd()))
+    if root is None:
+        raise RoutineError("Git repositoryを特定できません")
+    return root
+
+
+def require_state(root: Path) -> dict[str, Any]:
+    state = load(root)
+    if state is None:
+        raise RoutineError("active task routine stateがありません")
+    return state
+
+

--- a/skills/development-orchestrator/scripts/task_routine_state.py
+++ b/skills/development-orchestrator/scripts/task_routine_state.py
@@ -1,0 +1,324 @@
+"""Persistent state and ordered operations for one development task."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+STEPS = (
+    "intake",
+    "skill_scan",
+    "task_definition",
+    "plan",
+    "implementation",
+    "verification",
+    "review",
+    "skill_reflection",
+    "tool_reflection",
+    "feedback_tracking",
+    "progress_sync",
+    "git_submission",
+)
+STEP_NAMES = STEPS
+
+DESCRIPTIONS = {
+    "intake": "依頼、issue要件、確認境界を確定する",
+    "skill_scan": "関連skillと既存自動化手段を確認する",
+    "task_definition": "今回の1 taskの範囲と完了条件を固定する",
+    "plan": "実装、検証、レビュー、提出の順序を決める",
+    "implementation": "設計・コード・資料の変更を実施する",
+    "verification": "test、lint、build等の証拠を取得する",
+    "review": "独立レビューと指摘の裁定を完了する",
+    "skill_reflection": "skill改善要否を判定し、必要なら反映する",
+    "tool_reflection": "反復出力のtool化要否を判定し、必要なら反映する",
+    "feedback_tracking": "FP/issueの重複確認と追跡先を記録する",
+    "progress_sync": "reportと進捗管理を実状態へ同期する",
+    "git_submission": "commit、push、PR作成まで完了する",
+}
+STRUCTURED = {"skill_reflection", "tool_reflection", "feedback_tracking"}
+EARLY = STEPS[:4]
+SUBMISSION_PREREQUISITES = STEPS[:-1]
+DONE = {"done", "not_applicable"}
+SKILL_DECISIONS = {"none", "update-existing", "propose-new"}
+TOOL_DECISIONS = {"none", "update-existing", "create-internal", "propose-external"}
+FEEDBACK_DECISIONS = {"none", "merged", "issue", "commit-backed"}
+
+EDIT_TOOLS = {
+    "apply_patch", "edit", "write", "edit_file", "write_file", "create_file",
+    "update_file", "delete_file", "replace_file", "move_file", "rename_file",
+    "multi_edit", "multiedit", "notebook_edit", "create_blob", "create_tree",
+    "create_branch", "delete_branch", "create_issue", "update_issue",
+    "add_comment_to_issue", "add_review_to_pr",
+}
+SUBMIT_TOOLS = {
+    "create_pull_request", "open_pull_request", "merge_pull_request",
+    "mark_pull_request_ready", "create_commit", "push_branch", "update_ref",
+    "update_pull_request", "enable_auto_merge",
+}
+SHELL_TOOLS = {"bash", "shell", "exec", "exec_command", "command", "terminal"}
+GIT_SUBMIT = re.compile(r"(?:^|[;&|]\s*)(?:git\s+(?:add|commit|push|tag)|gh\s+pr\s+(?:create|ready|merge))\b", re.I)
+GIT_MUTATE = re.compile(r"(?:^|[;&|]\s*)git\s+(?:checkout|switch|branch|merge|rebase|reset|restore|stash|cherry-pick|revert|clean|worktree)\b", re.I)
+FILE_MUTATE = re.compile(
+    r"(?:^|[;&|]\s*)(?:rm|mv|cp|mkdir|rmdir|touch|truncate|install|ln|chmod|chown|tee)\b"
+    r"|\bsed\s+-[^\n;]*i\b|\b(?:npm|pnpm|yarn)\s+(?:install|add|remove|uninstall|version)\b"
+    r"|\b(?:cargo\s+fmt|go\s+fmt|gofmt|ruff\s+format|black|prettier\s+--write)\b",
+    re.I,
+)
+GH_MUTATE = re.compile(r"(?:^|[;&|]\s*)gh\s+(?:issue\s+(?:create|edit|close|reopen|comment)|release\s+create)\b", re.I)
+REDIRECT = re.compile(r"(?<![<>])(?:>>|>)\s*(?!&?\d\b)(?!/dev/null\b)\S+", re.I)
+
+
+class RoutineError(RuntimeError):
+    pass
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", "-C", str(cwd), *args], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+
+
+def repo_root(cwd: Path) -> Path | None:
+    result = git(cwd.expanduser().resolve(), "rev-parse", "--show-toplevel")
+    return Path(result.stdout.strip()).resolve() if result.returncode == 0 and result.stdout.strip() else None
+
+
+def git_path(root: Path, relative: str) -> Path:
+    result = git(root, "rev-parse", "--git-path", relative)
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RoutineError(f"Git state pathを解決できません: {result.stderr.strip()}")
+    path = Path(result.stdout.strip())
+    return (path if path.is_absolute() else root / path).resolve(strict=False)
+
+
+def state_path(root: Path) -> Path:
+    return git_path(root, "codex-task-routine/state.json")
+
+
+def routine_state_path(root: Path) -> Path:
+    return state_path(root)
+
+
+def routine_history_dir(root: Path) -> Path:
+    return git_path(root, "codex-task-routine/history")
+
+
+def write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        handle.write(text)
+        temp = Path(handle.name)
+    os.chmod(temp, 0o600)
+    temp.replace(path)
+
+
+def validate(state: Any) -> dict[str, Any]:
+    if not isinstance(state, dict) or state.get("version") != 1:
+        raise RoutineError("task routine stateの形式またはversionが不正です")
+    task, steps = state.get("task"), state.get("steps")
+    if not isinstance(task, dict) or not isinstance(steps, dict):
+        raise RoutineError("task routine stateのtask/stepsが不正です")
+    for name in STEPS:
+        if not isinstance(steps.get(name), dict) or steps[name].get("status") not in {"pending", *DONE}:
+            raise RoutineError(f"step {name}の状態が不正です")
+    return state
+
+
+def load(root: Path) -> dict[str, Any] | None:
+    path = state_path(root)
+    if not path.exists():
+        return None
+    try:
+        return validate(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RoutineError(f"task routine stateを読めません: {exc}") from exc
+
+
+def save(root: Path, state: dict[str, Any]) -> None:
+    state["task"]["updated_at"] = now()
+    write_json(state_path(root), validate(state))
+
+
+def event(state: dict[str, Any], event_type: str, **detail: Any) -> None:
+    state.setdefault("events", []).append({"at": now(), "type": event_type, "detail": detail})
+    state["events"] = state["events"][-200:]
+
+
+def fresh(task_id: str, summary: str) -> dict[str, Any]:
+    timestamp = now()
+    return {
+        "version": 1,
+        "task": {"id": task_id, "summary": summary, "status": "active", "started_at": timestamp, "updated_at": timestamp},
+        "steps": {name: {"status": "pending", "evidence": None, "metadata": {}, "updated_at": None} for name in STEPS},
+        "events": [{"at": timestamp, "type": "task-started", "detail": {"id": task_id, "summary": summary}}],
+    }
+
+
+def complete(state: Mapping[str, Any], name: str) -> bool:
+    return state["steps"][name]["status"] in DONE
+
+
+def step_is_complete(state: Mapping[str, Any], name: str) -> bool:
+    return complete(state, name)
+
+
+def next_step(state: Mapping[str, Any]) -> str | None:
+    return next((name for name in STEPS if not complete(state, name)), None)
+
+
+def prior_incomplete(state: Mapping[str, Any], name: str) -> list[str]:
+    return [item for item in STEPS[: STEPS.index(name)] if not complete(state, item)]
+
+
+def require_active(state: Mapping[str, Any]) -> None:
+    if state["task"]["status"] != "active":
+        raise RoutineError(f"task statusがactiveではありません: {state['task']['status']}")
+
+
+def archive(root: Path, state: Mapping[str, Any]) -> None:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", str(state["task"]["id"])).strip("-.") or "task"
+    stamp = now().replace(":", "").replace("-", "")
+    write_json(git_path(root, f"codex-task-routine/history/{stamp}-{safe}.json"), state)
+
+
+def start(root: Path, task_id: str, summary: str) -> dict[str, Any]:
+    old = load(root)
+    if old and old["task"]["status"] not in {"completed", "aborted"}:
+        raise RoutineError(f"未完了taskが既にあります: {old['task']['id']}")
+    if old:
+        archive(root, old)
+    state = fresh(task_id, summary)
+    save(root, state)
+    return state
+
+
+def mark(root: Path, state: dict[str, Any], name: str, status: str, evidence: str, metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    require_active(state)
+    if name in STRUCTURED:
+        raise RoutineError(f"{name}は専用commandで記録してください")
+    missing = prior_incomplete(state, name)
+    if missing:
+        raise RoutineError(f"先に完了すべきstepがあります: {', '.join(missing)}")
+    state["steps"][name] = {"status": status, "evidence": evidence, "metadata": dict(metadata or {}), "updated_at": now()}
+    event(state, "step-updated", step=name, status=status, evidence=evidence)
+    if next_step(state) is None:
+        state["task"]["status"] = "completed"
+        state["task"]["completed_at"] = now()
+        event(state, "task-completed")
+    save(root, state)
+    return state
+
+
+def reopen_step(root: Path, state: dict[str, Any], name: str, reason: str) -> dict[str, Any]:
+    if name not in STEPS:
+        raise RoutineError(f"unknown step: {name}")
+    require_active(state)
+    for item in STEPS[STEPS.index(name):]:
+        state["steps"][item] = {"status": "pending", "evidence": None, "metadata": {}, "updated_at": None}
+    state["task"].pop("completed_at", None)
+    event(state, "step-reopened", step=name, reason=reason)
+    save(root, state)
+    return state
+
+
+def start_task(root: Path, task_id: str, summary: str) -> dict[str, Any]:
+    return start(root, task_id, summary)
+
+
+def load_state(root: Path) -> dict[str, Any] | None:
+    return load(root)
+
+
+def complete_step(root: Path, state: dict[str, Any], name: str, evidence: str) -> dict[str, Any]:
+    return mark(root, state, name, "done", evidence)
+
+
+def reflect(root: Path, state: dict[str, Any], kind: str, decision: str, target: str | None, evidence: str) -> dict[str, Any]:
+    return reflection(root, state, kind, decision, target, evidence)
+
+
+def record_feedback(root: Path, state: dict[str, Any], decision: str, target: str | None, evidence: str) -> dict[str, Any]:
+    return feedback(root, state, decision, target, evidence)
+
+
+def pause_task(root: Path, state: dict[str, Any], reason: str) -> dict[str, Any]:
+    return pause(root, state, reason)
+
+
+def reflection(root: Path, state: dict[str, Any], kind: str, decision: str, target: str | None, evidence: str) -> dict[str, Any]:
+    name = f"{kind}_reflection"
+    allowed = SKILL_DECISIONS if kind == "skill" else TOOL_DECISIONS
+    if decision not in allowed:
+        raise RoutineError(f"{kind} decisionが不正です: {decision}")
+    if decision != "none" and not target:
+        raise RoutineError("変更・提案decisionにはtargetが必要です")
+    missing = prior_incomplete(state, name)
+    if missing:
+        raise RoutineError(f"先に完了すべきstepがあります: {', '.join(missing)}")
+    require_active(state)
+    state["steps"][name] = {"status": "done", "evidence": evidence, "metadata": {"decision": decision, "target": target}, "updated_at": now()}
+    event(state, "reflection-recorded", kind=kind, decision=decision, target=target, evidence=evidence)
+    save(root, state)
+    return state
+
+
+def feedback(root: Path, state: dict[str, Any], decision: str, target: str | None, evidence: str) -> dict[str, Any]:
+    if decision not in FEEDBACK_DECISIONS:
+        raise RoutineError(f"feedback decisionが不正です: {decision}")
+    if decision != "none" and not target:
+        raise RoutineError("追跡decisionにはtargetが必要です")
+    name = "feedback_tracking"
+    missing = prior_incomplete(state, name)
+    if missing:
+        raise RoutineError(f"先に完了すべきstepがあります: {', '.join(missing)}")
+    require_active(state)
+    state["steps"][name] = {"status": "done", "evidence": evidence, "metadata": {"decision": decision, "target": target}, "updated_at": now()}
+    event(state, "feedback-recorded", decision=decision, target=target, evidence=evidence)
+    save(root, state)
+    return state
+
+
+def pause(root: Path, state: dict[str, Any], reason: str, abort: bool = False) -> dict[str, Any]:
+    if state["task"]["status"] in {"completed", "aborted"}:
+        raise RoutineError("完了済みtaskはpause/abortできません")
+    state["task"]["status"] = "aborted" if abort else "paused"
+    state["task"]["reason"] = reason
+    event(state, "task-aborted" if abort else "task-paused", reason=reason)
+    save(root, state)
+    return state
+
+
+def resume(root: Path, state: dict[str, Any]) -> dict[str, Any]:
+    if state["task"]["status"] != "paused":
+        raise RoutineError("paused taskだけresumeできます")
+    state["task"]["status"] = "active"
+    state["task"].pop("reason", None)
+    event(state, "task-resumed")
+    save(root, state)
+    return state
+
+
+def render(state: Mapping[str, Any] | None, root: Path) -> str:
+    if state is None:
+        return f"task routine: none\nrepo: {root}\nnext: task_routine.py start --id <id> --summary <summary>"
+    task, nxt = state["task"], next_step(state)
+    lines = [f"task: {task['id']} - {task['summary']}", f"status: {task['status']}", f"repo: {root}"]
+    for name in STEPS:
+        marker = "x" if complete(state, name) else " "
+        lines.append(f"[{marker}] {name}: {DESCRIPTIONS[name]}")
+    lines.append(f"next: {nxt or 'none'}")
+    return "\n".join(lines)
+
+

--- a/skills/development-orchestrator/tests/test_task_routine.py
+++ b/skills/development-orchestrator/tests/test_task_routine.py
@@ -147,8 +147,8 @@ class TaskRoutineTest(unittest.TestCase):
             {
                 "hook_event_name": "PreToolUse",
                 "cwd": str(self.root),
-                "tool_name": "GitHub.update_file",
-                "tool_input": {"path": "README.md"},
+                "tool_name": "apply_patch",
+                "tool_input": {"patch": "*** Begin Patch"},
             }
         )
         submit_result = hooks.handle_hook(
@@ -164,6 +164,52 @@ class TaskRoutineTest(unittest.TestCase):
         self.assertEqual(submit_result["hookSpecificOutput"]["permissionDecision"], "deny")
         self.assertIn("implementation", submit_result["hookSpecificOutput"]["permissionDecisionReason"])
 
+    def test_contents_api_writes_use_submission_gate(self) -> None:
+        routine = self.start()
+        for name in state.EARLY:
+            routine = state.mark(self.root, routine, name, "done", f"{name} evidence")
+
+        for tool_name in (
+            "GitHub.create_file",
+            "GitHub.update_file",
+            "GitHub.delete_file",
+        ):
+            with self.subTest(tool_name=tool_name):
+                result = hooks.handle_hook(
+                    {
+                        "hook_event_name": "PreToolUse",
+                        "cwd": str(self.root),
+                        "tool_name": tool_name,
+                        "tool_input": {"path": "README.md"},
+                    }
+                )
+                self.assertEqual(
+                    result["hookSpecificOutput"]["permissionDecision"],
+                    "deny",
+                )
+                self.assertIn(
+                    "implementation",
+                    result["hookSpecificOutput"]["permissionDecisionReason"],
+                )
+
+    def test_issue_tracking_tools_do_not_require_active_routine(self) -> None:
+        for tool_name in (
+            "GitHub.create_issue",
+            "GitHub.update_issue",
+            "GitHub.add_comment_to_issue",
+            "GitHub.add_review_to_pr",
+        ):
+            with self.subTest(tool_name=tool_name):
+                result = hooks.handle_hook(
+                    {
+                        "hook_event_name": "PreToolUse",
+                        "cwd": str(self.root),
+                        "tool_name": tool_name,
+                        "tool_input": {},
+                    }
+                )
+                self.assertIsNone(result)
+
     def test_shell_classification_distinguishes_read_edit_and_submission(self) -> None:
         self.assertEqual(hooks.classify_shell_command("git status --short"), "other")
         self.assertEqual(hooks.classify_shell_command("printf x > result.txt"), "edit")
@@ -177,7 +223,11 @@ class TaskRoutineTest(unittest.TestCase):
             {"hook_event_name": "SessionStart", "cwd": str(self.root)}
         )
         stop_result = hooks.handle_hook(
-            {"hook_event_name": "Stop", "cwd": str(self.root)}
+            {
+                "hook_event_name": "Stop",
+                "cwd": str(self.root),
+                "stop_hook_active": False,
+            }
         )
 
         self.assertIn(
@@ -186,6 +236,19 @@ class TaskRoutineTest(unittest.TestCase):
         )
         self.assertEqual(stop_result["decision"], "block")
         self.assertIn("intake", stop_result["reason"])
+
+    def test_stop_hook_reentry_does_not_loop(self) -> None:
+        self.start()
+
+        result = hooks.handle_hook(
+            {
+                "hook_event_name": "Stop",
+                "cwd": str(self.root),
+                "stop_hook_active": True,
+            }
+        )
+
+        self.assertIsNone(result)
 
     def test_paused_task_does_not_force_stop_continuation(self) -> None:
         routine = state.pause(self.root, self.start(), "利用者判断待ち")

--- a/skills/development-orchestrator/tests/test_task_routine.py
+++ b/skills/development-orchestrator/tests/test_task_routine.py
@@ -1,0 +1,239 @@
+"""development-orchestrator の task routine と hook gate の単体テスト。"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import task_routine_hooks as hooks
+import task_routine_state as state
+
+
+class TaskRoutineTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name).resolve()
+        result = subprocess.run(
+            ["git", "init", "-q", str(self.root)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def start(self) -> dict[str, object]:
+        return state.start(self.root, "issue-47", "task routine hookを検証する")
+
+    def finish_before_reflections(self, routine: dict[str, object]) -> dict[str, object]:
+        for name in state.STEPS[:7]:
+            routine = state.mark(self.root, routine, name, "done", f"{name} evidence")
+        return routine
+
+    def test_start_persists_state_inside_git_directory(self) -> None:
+        routine = self.start()
+
+        saved = state.load(self.root)
+
+        self.assertEqual(saved, routine)
+        self.assertEqual(state.next_step(saved), "intake")
+        self.assertTrue(state.state_path(self.root).is_file())
+        self.assertIn(".git", state.state_path(self.root).parts)
+
+    def test_step_order_is_enforced(self) -> None:
+        routine = self.start()
+
+        with self.assertRaisesRegex(state.RoutineError, "intake, skill_scan, task_definition"):
+            state.mark(self.root, routine, "plan", "done", "plan evidence")
+
+    def test_structured_steps_require_dedicated_commands(self) -> None:
+        routine = self.finish_before_reflections(self.start())
+
+        with self.assertRaisesRegex(state.RoutineError, "専用command"):
+            state.mark(self.root, routine, "skill_reflection", "done", "generic evidence")
+
+    def test_reflection_and_feedback_require_target_for_non_none_decision(self) -> None:
+        routine = self.finish_before_reflections(self.start())
+
+        with self.assertRaisesRegex(state.RoutineError, "target"):
+            state.reflection(
+                self.root,
+                routine,
+                "skill",
+                "update-existing",
+                None,
+                "skill evidence",
+            )
+
+        routine = state.reflection(
+            self.root,
+            routine,
+            "skill",
+            "none",
+            None,
+            "既存skillで十分",
+        )
+        routine = state.reflection(
+            self.root,
+            routine,
+            "tool",
+            "create-internal",
+            "task_routine.py",
+            "反復確認を内部CLI化",
+        )
+
+        with self.assertRaisesRegex(state.RoutineError, "target"):
+            state.feedback(self.root, routine, "issue", None, "duplicate evidence")
+
+    def test_full_lifecycle_completes_only_after_git_submission(self) -> None:
+        routine = self.finish_before_reflections(self.start())
+        routine = state.reflection(self.root, routine, "skill", "none", None, "変更不要")
+        routine = state.reflection(
+            self.root,
+            routine,
+            "tool",
+            "create-internal",
+            "task_routine.py",
+            "内部toolを追加",
+        )
+        routine = state.feedback(
+            self.root,
+            routine,
+            "issue",
+            "#47",
+            "既存issueへ統合",
+        )
+        routine = state.mark(self.root, routine, "progress_sync", "done", "進捗同期済み")
+        self.assertEqual(routine["task"]["status"], "active")
+
+        routine = state.mark(self.root, routine, "git_submission", "done", "commitとPR作成済み")
+
+        self.assertEqual(routine["task"]["status"], "completed")
+        self.assertIsNone(state.next_step(routine))
+
+    def test_pre_tool_use_blocks_edit_without_active_task(self) -> None:
+        result = hooks.handle_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "cwd": str(self.root),
+                "tool_name": "apply_patch",
+                "tool_input": {"patch": "*** Begin Patch"},
+            }
+        )
+
+        self.assertEqual(
+            result["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+        self.assertIn("active task routine", result["hookSpecificOutput"]["permissionDecisionReason"])
+
+    def test_pre_tool_use_allows_edit_after_early_steps_and_blocks_submission(self) -> None:
+        routine = self.start()
+        for name in state.EARLY:
+            routine = state.mark(self.root, routine, name, "done", f"{name} evidence")
+
+        edit_result = hooks.handle_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "cwd": str(self.root),
+                "tool_name": "GitHub.update_file",
+                "tool_input": {"path": "README.md"},
+            }
+        )
+        submit_result = hooks.handle_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "cwd": str(self.root),
+                "tool_name": "GitHub.create_pull_request",
+                "tool_input": {},
+            }
+        )
+
+        self.assertIsNone(edit_result)
+        self.assertEqual(submit_result["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("implementation", submit_result["hookSpecificOutput"]["permissionDecisionReason"])
+
+    def test_shell_classification_distinguishes_read_edit_and_submission(self) -> None:
+        self.assertEqual(hooks.classify_shell_command("git status --short"), "other")
+        self.assertEqual(hooks.classify_shell_command("printf x > result.txt"), "edit")
+        self.assertEqual(hooks.classify_shell_command("git commit -m test"), "submission")
+        self.assertEqual(hooks.classify_shell_command("echo ok >/dev/null"), "other")
+
+    def test_session_start_injects_current_step_and_stop_requests_continuation(self) -> None:
+        self.start()
+
+        start_result = hooks.handle_hook(
+            {"hook_event_name": "SessionStart", "cwd": str(self.root)}
+        )
+        stop_result = hooks.handle_hook(
+            {"hook_event_name": "Stop", "cwd": str(self.root)}
+        )
+
+        self.assertIn(
+            "next required step: intake",
+            start_result["hookSpecificOutput"]["additionalContext"],
+        )
+        self.assertEqual(stop_result["decision"], "block")
+        self.assertIn("intake", stop_result["reason"])
+
+    def test_paused_task_does_not_force_stop_continuation(self) -> None:
+        routine = state.pause(self.root, self.start(), "利用者判断待ち")
+
+        result = hooks.handle_hook(
+            {"hook_event_name": "Stop", "cwd": str(self.root)}
+        )
+
+        self.assertEqual(routine["task"]["status"], "paused")
+        self.assertIsNone(result)
+
+    def test_hook_installer_is_idempotent_and_preserves_existing_handler(self) -> None:
+        target = self.root / ".codex" / "hooks.json"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": [
+                            {
+                                "hooks": [
+                                    {"type": "command", "command": "python3 existing.py"}
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        script = self.root / "task_routine.py"
+
+        _, first_changed = hooks.install("project", self.root, target, script)
+        _, second_changed = hooks.install("project", self.root, target, script)
+        installed = json.loads(target.read_text(encoding="utf-8"))
+        _, removed = hooks.install("project", self.root, target, script, remove=True)
+        uninstalled = json.loads(target.read_text(encoding="utf-8"))
+
+        self.assertTrue(first_changed)
+        self.assertFalse(second_changed)
+        self.assertEqual(len(installed["hooks"]["SessionStart"]), 1)
+        self.assertEqual(
+            installed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+            "python3 existing.py",
+        )
+        self.assertTrue(removed)
+        self.assertEqual(uninstalled["hooks"], {"PostToolUse": installed["hooks"]["PostToolUse"]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/development-orchestrator/tests/test_task_routine_mcp_tool_names.py
+++ b/skills/development-orchestrator/tests/test_task_routine_mcp_tool_names.py
@@ -1,0 +1,140 @@
+"""MCP形式のtool名に対するtask routine gateを検証する。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import task_routine_hooks as hooks
+import task_routine_state as state
+
+
+class TaskRoutineMcpToolNameTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name).resolve()
+        result = subprocess.run(
+            ["git", "init", "-q", str(self.root)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def ready_for_pr(self) -> dict[str, object]:
+        routine = state.start(
+            self.root,
+            "issue-47-mcp-pr",
+            "MCP形式のPR tool名を検証する",
+        )
+        for name in state.STEPS[:7]:
+            routine = state.mark(
+                self.root,
+                routine,
+                name,
+                "done",
+                f"{name} evidence",
+            )
+        routine = state.reflection(
+            self.root,
+            routine,
+            "skill",
+            "none",
+            None,
+            "既存skillの責務内で対応済み",
+        )
+        routine = state.reflection(
+            self.root,
+            routine,
+            "tool",
+            "create-internal",
+            "task_routine_hooks.py",
+            "MCP形式のtool名を内部hookで正規化した",
+        )
+        routine = state.feedback(
+            self.root,
+            routine,
+            "issue",
+            "#47",
+            "Issue #47へ追跡を統合した",
+        )
+        return state.mark(
+            self.root,
+            routine,
+            "progress_sync",
+            "done",
+            "review reportとIssueを同期した",
+        )
+
+    def test_prefixed_mcp_pr_tool_name_is_normalized_and_body_is_gated(self) -> None:
+        self.ready_for_pr()
+        self.assertEqual(
+            hooks.tool_token("mcp__github__create_pull_request"),
+            "create_pull_request",
+        )
+
+        result = hooks.handle_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "cwd": str(self.root),
+                "tool_name": "mcp__github__create_pull_request",
+                "tool_input": {"body": "## Summary\n証跡なし"},
+            }
+        )
+
+        self.assertEqual(
+            result["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+        self.assertIn(
+            "PR本文",
+            result["hookSpecificOutput"]["permissionDecisionReason"],
+        )
+
+    def test_prefixed_mcp_contents_api_uses_submission_gate(self) -> None:
+        routine = state.start(
+            self.root,
+            "issue-47-mcp-update",
+            "MCP形式のContents API tool名を検証する",
+        )
+        for name in state.EARLY:
+            routine = state.mark(
+                self.root,
+                routine,
+                name,
+                "done",
+                f"{name} evidence",
+            )
+
+        result = hooks.handle_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "cwd": str(self.root),
+                "tool_name": "mcp__github__update_file",
+                "tool_input": {"path": "README.md"},
+            }
+        )
+
+        self.assertEqual(
+            result["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+        self.assertIn(
+            "implementation",
+            result["hookSpecificOutput"]["permissionDecisionReason"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/development-orchestrator/tests/test_task_routine_pr_body.py
+++ b/skills/development-orchestrator/tests/test_task_routine_pr_body.py
@@ -1,0 +1,142 @@
+"""PR本文のtask routine証跡ゲートを検証する。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import task_routine_hooks as hooks
+import task_routine_state as state
+
+
+class TaskRoutinePRBodyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name).resolve()
+        result = subprocess.run(
+            ["git", "init", "-q", str(self.root)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def ready_for_pr(self) -> dict[str, object]:
+        routine = state.start(self.root, "issue-47", "PR本文証跡ゲートを検証する")
+        for name in state.STEPS[:7]:
+            routine = state.mark(
+                self.root,
+                routine,
+                name,
+                "done",
+                f"{name} evidence",
+            )
+        routine = state.reflection(
+            self.root,
+            routine,
+            "skill",
+            "none",
+            None,
+            "既存skill更新は現在の差分に含まれる",
+        )
+        routine = state.reflection(
+            self.root,
+            routine,
+            "tool",
+            "create-internal",
+            "task_routine.py",
+            "task routineを内部toolとして実装した",
+        )
+        routine = state.feedback(
+            self.root,
+            routine,
+            "issue",
+            "#47",
+            "Issue #47へ追跡を統合した",
+        )
+        return state.mark(
+            self.root,
+            routine,
+            "progress_sync",
+            "done",
+            "review reportとIssueを同期した",
+        )
+
+    def pre_tool_use(self, body: str | None) -> dict[str, object] | None:
+        return hooks.handle_hook(
+            {
+                "hook_event_name": "PreToolUse",
+                "cwd": str(self.root),
+                "tool_name": "GitHub.create_pull_request",
+                "tool_input": {"body": body},
+            }
+        )
+
+    def test_missing_required_pr_sections_is_blocked(self) -> None:
+        self.ready_for_pr()
+
+        result = self.pre_tool_use("## Summary\n変更概要")
+
+        self.assertEqual(
+            result["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+        reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("task routine", reason)
+        self.assertIn("skill action", reason)
+        self.assertIn("tool action", reason)
+
+    def test_placeholder_only_pr_sections_are_blocked(self) -> None:
+        self.ready_for_pr()
+
+        result = self.pre_tool_use(
+            """## Task routine evidence
+TODO
+
+## Skill action
+none
+
+## Tool action
+未記入
+"""
+        )
+
+        self.assertEqual(
+            result["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+
+    def test_evidence_backed_pr_sections_are_allowed(self) -> None:
+        self.ready_for_pr()
+
+        result = self.pre_tool_use(
+            """## Summary
+task routine hookを追加した。
+
+## Task routine evidence
+- verification、review、feedback、progress syncを完了した。
+
+## Skill action
+- update-existing: development-orchestratorとfeedback-points-managerを更新した。
+
+## Tool action
+- create-internal: task_routine.pyとlifecycle hookを追加した。
+"""
+        )
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/feedback-points-manager/SKILL.md
+++ b/skills/feedback-points-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feedback-points-manager
-description: Maintain feedback-points.md as a cross-cutting record of reusable workflow lessons, repeated process failures, skill adoption status, and skillization candidates. Use from any skill whenever a new process-related instruction appears, a repeated point reoccurs, a workflow problem is discovered, or a decision must be made about whether a repeated point should become a skill.
+description: Maintain feedback-points.md as a cross-cutting record of reusable workflow lessons, repeated process failures, skill adoption status, skillization candidates, and reusable tool-automation findings. Use from any skill whenever a new process-related instruction appears, a repeated point reoccurs, a workflow problem is discovered, or a task-routine reflection needs durable duplicate and follow-up tracking.
 ---
 
 # Feedback Points Manager
@@ -9,22 +9,26 @@ Maintain `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md` as the sy
 
 ## Goal
 
-Capture process-level feedback, detect repetition, and route skill-improvement follow-up into issues so the active FP ledger does not remain the long-term execution queue and is empty again by commit timing.
+Capture process-level feedback, detect repetition, and route skill/tool improvement follow-up into issues so the active FP ledger does not remain the long-term execution queue and is empty again by commit timing.
+
+Use feedback points and issues as history, duplicate detection, and follow-up records. Do not use them as the only runtime trigger for mandatory task work; the active task routine owns the current executable step.
 
 ## Execution owner
 
 Run this skill as: `parent`
 
-- This skill governs feedback records and skillization decisions.
-- Parent agents may call it after issue completion, but issue-completion reflection itself is not owned here.
+- This skill governs feedback records, duplicate grouping, skillization tracking, and durable follow-up evidence.
+- `development-orchestrator` owns the task routine and the mandatory skill/tool reflection performed for each task.
+- Parent agents may call this skill after issue completion or from an in-flight task reflection, but issue-completion reflection itself is not owned here.
 
 ## Inputs
 
 Before running this skill, gather:
 
-- candidate process lesson or repeated workflow problem
+- candidate process lesson, repeated workflow problem, or reusable tool-automation finding
 - current active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
-- any existing duplicate group or related skill context
+- any existing duplicate group or related skill/tool context
+- current task-routine reflection decision and evidence when the call originated from `development-orchestrator`
 - whether the trigger came from explicit user instruction, parent judgment, or sub-agent proposal
 
 The canonical files live in the SKILL repository root, not inside the symlinked `skills/` tree of a consuming project:
@@ -59,9 +63,25 @@ Run this skill when:
 - a point seems reusable across repositories
 - you need to decide if a point should become a skill or a skill update
 - you need to decide whether to recommend a new skill or update an existing one
+- a deterministic repeated agent output may be better handled by an internal helper or tool
 - a reusable execution lesson is discovered during work even if the user did not explicitly label it as an `FP`
 - an in-flight adjustment to tools, patch sizing, sequencing, or delegation proved necessary to keep execution stable
-- a commit-ready skill/process improvement needs either a tracked follow-up issue or an explicit commit-backed skip rationale before the loop can be considered handed off
+- a commit-ready skill/process/tool improvement needs either a tracked follow-up issue or an explicit commit-backed skip rationale before the loop can be considered handed off
+
+## Task routine integration
+
+For normal development work, `development-orchestrator` records an explicit skill reflection and tool reflection before Git submission.
+
+Apply these rules:
+
+1. The local task routine is the runtime source of truth for the next required step.
+2. Feedback points and GitHub Issues are the source of truth for history, duplicate grouping, recurrence evidence, and follow-up work.
+3. Do not require the agent to remember to inspect GitHub before every step; task-routine hooks must re-inject or enforce the pending step.
+4. Recurrence count is prioritization evidence, not a hard gate that prevents a low-risk, reversible update within an existing skill's ownership.
+5. An internal helper may be created or updated automatically when it replaces deterministic repeated agent output, stays within the owning skill, and is reversible and low risk.
+6. New skill creation, standalone external tools, external contracts, destructive changes, credentials, or approval-bound work keep their existing user-confirmation boundary.
+7. When an existing-skill or internal-tool improvement was completed in the same task, record commit-backed evidence instead of opening a redundant follow-up issue.
+8. When work remains after the current commit, create or confirm the follow-up issue and move the active FP out of the active ledger.
 
 ## Scope filter
 
@@ -76,6 +96,7 @@ Good examples:
 - task sizing policy
 - Git workflow policy
 - restart or handover policy
+- repeated report generation or validation that should become an internal helper
 
 Do not keep one-off feature specifications here if they belong in design docs, reports, tasks, or phases.
 
@@ -98,7 +119,7 @@ Open only one reference unless the situation clearly spans multiple decisions:
 - Need category naming or duplicate-group naming:
   - [references/canonical-feedback-taxonomy.md](references/canonical-feedback-taxonomy.md)
 
-If the answer is obvious from the active row and current skill context, do not open any reference.
+If the answer is obvious from the active row, task-routine decision, and current skill/tool context, do not open any reference.
 
 If the active file is visibly noisy, mixed with issue-specific content, or hard to classify, call `feedback-points-sanitizer` first.
 
@@ -106,15 +127,15 @@ Before writing to `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`,
 
 Treat the classification as parent-direct only when the reusable-process nature is obvious. For non-obvious cases, request a classification pass from `feedback-points-sanitizer` first.
 
-Keep this skill as the parent governance point for skillization decisions. Use sub-agents for narrow classification, comparison, or review work when helpful, but keep the final proposal vs implementation decision in the main agent.
+Keep this skill as the parent governance point for durable skillization and tool-follow-up records. Use sub-agents for narrow classification, comparison, or review work when helpful, but keep the final proposal vs implementation decision in the main agent and the current task routine.
 
 When writing or updating a feedback-point row, always record `記録起点` so the user can distinguish explicitly requested entries from parent-originated entries.
 
 If the user says `〜べきです`, treat that statement as an explicit `指摘` by default, not as optional advice. Route it through this skill immediately unless it is clearly non-process content.
 
-When a skill-improvement loop has been committed or otherwise reached the point where follow-up should be tracked externally, create the corresponding issue, preserve the full FP content in that issue, and remove the active row from `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`.
-If the point has been fully reflected in the same skill commit and no external follow-up remains, an issue may be skipped, but the skip rationale and commit-backed system of record must be stated explicitly in `次アクション対応` and supporting evidence before the loop is treated as closed.
-If the current run has finished the skill edits but the commit-backed closure record does not exist yet, you may move the point out of the active ledger into backlog as `対応中`, provided `次アクション対応` explicitly says the closure is waiting on the upcoming commit and does not claim closure early.
+When a skill/tool-improvement loop has been committed or otherwise reached the point where follow-up should be tracked externally, create the corresponding issue, preserve the full FP content in that issue, and remove the active row from `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`.
+If the point has been fully reflected in the same skill or internal-tool commit and no external follow-up remains, an issue may be skipped, but the skip rationale and commit-backed system of record must be stated explicitly in `次アクション対応` and supporting evidence before the loop is treated as closed.
+If the current run has finished the edits but the commit-backed closure record does not exist yet, you may move the point out of the active ledger into backlog as `対応中`, provided `次アクション対応` explicitly says the closure is waiting on the upcoming commit and does not claim closure early.
 
 ## Required output after each run
 
@@ -124,7 +145,8 @@ After running this skill, leave clear evidence in chat or report:
 - recorded `記録起点`
 - duplicate group decision
 - skillization status decision and reason
-- related skill update/new-skill decision
+- related existing-skill update or new-skill decision
+- related internal-tool update/create or external-tool proposal decision when applicable
 - `次アクション対応`
 - issue creation result (issue URL/number, or draft file path)
 - explicit skip rationale when no issue was created
@@ -137,7 +159,7 @@ After this skill runs, there should be:
 
 - an added, merged, updated, or explicitly skipped feedback-point decision
 - an explicit `記録起点`
-- duplicate-group and skillization status rationale
+- duplicate-group and skillization/tool-automation rationale
 - clear evidence of `次アクション対応`
 - no stale active FP row for a point that has already been handed off to an issue
 - no ambiguous closure state when a point was closed without an issue; the commit-backed rationale must be explicit
@@ -146,18 +168,21 @@ After this skill runs, there should be:
 
 ## Completion condition
 
-This skill is complete only when the feedback-point decision and its rationale are recorded in chat, report, or the feedback ledger, and any commit-ready skill/process point has been removed from the active FP ledger.
+This skill is complete only when the feedback-point decision and its rationale are recorded in chat, report, or the feedback ledger, and any commit-ready skill/process/tool point has been removed from the active FP ledger.
 
 ## Strong rules
 
 - Always make an explicit skillization decision for repeated process points.
+- Preserve the task routine as the runtime trigger; do not replace it with an instruction to remember to inspect issues.
+- Treat recurrence thresholds as prioritization guidance, not as a veto against justified low-risk existing-skill or internal-tool improvements.
 - Keep process feedback and feature specifications separated.
 - Keep the active feedback records current when recurrence status changes.
 - Do not wait for an explicit `FP` request when a reusable process lesson is already clear from the work itself.
 - Do not register a new or updated feedback-point without making its origin visible to the user through `記録起点`.
 - When the user states `〜べきです`, do not defer classification or wait for an explicit `FP` request; treat it as a process finding immediately unless clearly out of scope.
-- When a feedback-point materially affects an existing skill, consider updating that skill even if the current thresholds or wording already exist.
-- When a follow-up issue has been created for a skill-improvement point, preserve the FP content in the issue body and remove that point from the active FP ledger.
-- When a feedback-point is fully resolved by the current skill commit and no external follow-up remains, you may skip issue creation only if the closure rationale is explicit and traceable.
+- When a feedback-point materially affects an existing skill, consider updating that skill in the active task even if the current recurrence threshold has not been reached.
+- When deterministic repeated agent output can be safely replaced by an internal helper, record and implement that tool decision through the task routine rather than leaving it as prose-only advice.
+- When a follow-up issue has been created for a skill/tool-improvement point, preserve the FP content in the issue body and remove that point from the active FP ledger.
+- When a feedback-point is fully resolved by the current commit and no external follow-up remains, you may skip issue creation only if the closure rationale is explicit and traceable.
 - Before that commit exists, a backlog row may remain `対応中`, but it must not claim final closure or a commit-backed system of record yet.
 - By the time related work is committed, active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md` should be empty again unless a truly not-yet-handoffable point was created in the same run and cannot yet be issue-tracked.

--- a/skills/feedback-points-manager/references/skillization-policy.md
+++ b/skills/feedback-points-manager/references/skillization-policy.md
@@ -1,6 +1,6 @@
 # Skillization Policy
 
-Open this only when deciding duplicate grouping, recurrence handling, or whether a point should become a skill.
+Open this only when deciding duplicate grouping, recurrence handling, whether a point should become a skill, or whether repeated agent output should become an internal tool.
 
 ## Duplicate grouping
 
@@ -13,25 +13,46 @@ When a new point appears:
 
 Group by intent, not literal wording.
 
-## Default skillization threshold
+## Recurrence and implementation priority
 
-- first occurrence: record only
-- second occurrence: set to `検討中` and prepare a skillization recommendation
-- third occurrence or more: prefer implementation, usually by updating an existing skill, unless clearly one-off
+Occurrence count is evidence for priority and recurrence risk. It is not a hard gate that forbids a justified low-risk improvement.
 
-Early skillization is allowed when all are true:
+Use this default interpretation:
+
+- first occurrence: record the point and classify ownership; implement immediately only when the gap is clear, omission risk is meaningful, and the change is an internal, reversible update within an existing skill or helper
+- second occurrence: raise priority, set to `検討中` when still unresolved, and prepare or execute the existing-skill/internal-tool change
+- third occurrence or more: prefer implementation unless the point is clearly one-off, externally constrained, or already covered by stronger evidence
+
+Early implementation is appropriate when any of the following makes delay costly:
 
 - cross-repository applicability is obvious
 - recurrence cost is high
-- omission risk is high if not automated by skill
+- omission risk is high if not enforced by the task routine, skill, or tool
+- the agent is repeatedly producing the same deterministic output manually
+- an existing skill already owns the behavior and a small reversible change closes the gap
 
-Do not skillize:
+Do not skillize or toolize:
 
 - issue-specific design content
 - one-time feature decisions
+- output that requires substantial case-by-case judgment and has no reusable deterministic core
 - externally constrained rules that are not reusable as workflow
 
-## Actions after skillization
+## Runtime trigger vs durable tracking
+
+The task routine is the runtime source of truth for the current step, including mandatory skill and tool reflection.
+
+Feedback points and GitHub Issues are the durable source of truth for:
+
+- history
+- duplicate grouping
+- recurrence evidence
+- follow-up work
+- commit or PR references
+
+Do not make issue lookup the only mechanism that reminds the agent what to do. Hooks and local task-routine state must surface or block missing steps even when GitHub has not been opened in the current turn.
+
+## Actions after skillization or toolization
 
 When a point is skillized:
 
@@ -41,7 +62,15 @@ When a point is skillized:
 4. rewrite wording from incident-specific to reusable rule
 5. if ongoing execution should be tracked as work, move the loop to an issue and stop using the active FP ledger as the execution queue
 
-If an existing skill is close, prefer extending it over creating a near-duplicate skill.
+When a point becomes an internal tool or helper:
+
+1. identify the owning existing skill
+2. keep the helper under that skill's `scripts/`, `hooks/`, or equivalent internal directory
+3. record the task-routine tool decision and evidence
+4. add tests for deterministic behavior when practical
+5. use a follow-up issue only when work remains after the current commit
+
+If an existing skill is close, prefer extending it over creating a near-duplicate skill. If an internal helper can remove deterministic repeated output without creating a new public contract, prefer that over a standalone tool.
 
 ## New skill vs existing skill update
 
@@ -54,7 +83,7 @@ Use these classes:
 Prefer `existing skill update` when:
 
 - an existing skill already owns most of the workflow
-- the gap can be closed by adding rules, routing, references, or a small helper script
+- the gap can be closed by adding rules, routing, references, hooks, or a small helper script
 - creating another skill would fragment ownership or triggering
 
 Choose `new skill candidate` only when:
@@ -63,26 +92,50 @@ Choose `new skill candidate` only when:
 - the workflow is reusable across repositories
 - forcing it into an existing skill would make ownership unclear
 
+## Tool decision classes
+
+Use these classes in the task routine:
+
+1. `none`
+2. `update-existing`
+3. `create-internal`
+4. `propose-external`
+
+Prefer `update-existing` or `create-internal` when:
+
+- the repeated output has a deterministic reusable core
+- the helper remains within an existing skill's ownership
+- the action is internal, reversible, and low risk
+- no new external contract, credential, or organizational approval is introduced
+
+Choose `propose-external` when:
+
+- the tool would expose a new standalone interface
+- it changes an external/public contract
+- it performs destructive or irreversible operations
+- it requires credentials, legal review, or organizational approval
+
 ## Approval boundary
 
-New skill creation is high risk.
+New skill creation and standalone external tools are high risk.
 
 - do not implement a brand-new skill without first recommending it to the user
-- the recommendation should explain the recurring gap, why existing skills are insufficient, and the proposed owner scope
+- do not introduce a standalone external tool without first recommending it to the user
+- the recommendation should explain the recurring gap, why existing skills/internal helpers are insufficient, and the proposed owner scope
 
-Existing skill updates may proceed without extra approval when they stay within the current skill family and ownership.
+Existing skill updates and internal helper creation may proceed without extra approval when they stay within current ownership and are internal, reversible, and low risk.
 
-If a skill/process improvement remains as follow-up work after commit timing, prefer issue creation over leaving it in the active FP ledger.
+If a skill/process/tool improvement remains as follow-up work after commit timing, prefer issue creation over leaving it in the active FP ledger.
 
 ## Ownership and maintenance
 
-The agent that discovers the recurring gap owns the next lifecycle action until one of these is true:
+The agent that discovers the gap owns the next lifecycle action until one of these is true:
 
-- the user received a new-skill recommendation
-- an existing-skill update PR was created
-- the point was explicitly recorded as non-skill work
+- the user received a new-skill or external-tool recommendation
+- an existing-skill/internal-tool update PR was created
+- the point was explicitly recorded as no-change work
 
-Do not leave stale skill gaps unowned.
+Do not leave stale skill or tool gaps unowned.
 
 ## Sub-agent rule
 
@@ -90,7 +143,7 @@ Use sub-agents for narrow, context-heavy work when available:
 
 - duplicate clustering
 - reusable-vs-noise classification
-- comparison against existing skills
-- focused review of a skill update diff
+- comparison against existing skills and helpers
+- focused review of a skill or internal-tool update diff
 
-Keep the final skillization decision in the main agent.
+Keep the final skillization/toolization decision in the main agent and record it in the active task routine.

--- a/skills/git-pr-submitter/SKILL.md
+++ b/skills/git-pr-submitter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-pr-submitter
-description: Create a pull request that packages the current task with sufficient context, validation evidence, and report references. Use when a task has passed implementation, verification, review, and commit stages and is ready to be submitted for integration.
+description: Create a pull request that packages the current task with sufficient context, validation evidence, routine evidence, skill/tool decisions, and report references. Use when a task has passed implementation, verification, review, reflection, feedback disposition, progress synchronization, and commit stages and is ready to be submitted for integration.
 ---
 
 # Git PR Submitter
@@ -9,7 +9,7 @@ Turn task work into a reviewable PR.
 
 ## Goal
 
-Submit each completed task as a PR with enough context for efficient review.
+Submit each completed task as a PR with enough context and evidence for efficient review.
 
 ## Execution owner
 
@@ -26,11 +26,30 @@ Before running this skill, gather:
 - relevant commits and branch
 - linked issue identifier(s) for the task or an explicit reason why no issue exists
 - review evidence and validation evidence
+- active task-routine evidence for completed or skipped steps
+- skill reflection decision, target, and evidence
+- tool reflection decision, target, and evidence
 - report references needed in the PR body
 
 ## Required PR contents
 
-Include as relevant:
+Every PR body must contain the following exact headings with non-placeholder evidence:
+
+```markdown
+## Task routine evidence
+
+## Skill action
+
+## Tool action
+```
+
+Record the following under those headings:
+
+- `Task routine evidence`: verification, review, feedback disposition, progress synchronization, and Git submission readiness
+- `Skill action`: `none`, `update-existing`, or `propose-new`, including the reason and target when applicable
+- `Tool action`: `none`, `update-existing`, `create-internal`, or `propose-external`, including the reason and target when applicable
+
+Also include as relevant:
 
 - task or issue scope
 - explicit linked issue reference in the PR body
@@ -43,21 +62,24 @@ Include as relevant:
 
 - Keep PR scope aligned with the task.
 - Always link the relevant issue in the PR body. Prefer closing keywords such as `Closes #123` when the PR resolves that issue; otherwise add an explicit non-closing reference.
+- Do not use empty headings, `TODO`, `TBD`, `none` without rationale, `N/A`, `未記入`, or equivalent placeholders as evidence.
 - Do not hide unresolved findings.
 - Do not create a PR with missing review evidence when the workflow requires review first.
-- If no issue exists yet for a process/skill loop that must be handed off, create or confirm that issue before opening the PR.
+- Do not create a PR until the task routine has evidence for both reflections, feedback disposition, and progress synchronization.
+- If no issue exists yet for a process/skill/tool loop that must be handed off, create or confirm that issue before opening the PR.
+- When the task-routine `PreToolUse` hook is active, treat a missing required PR-body section as a blocking gate rather than adding it after PR creation.
 
 ## Outputs
 
-After this skill runs, the current task has a PR that another reviewer can understand and evaluate.
+After this skill runs, the current task has a PR that another reviewer can understand and evaluate, including explicit task-routine, skill-action, and tool-action evidence.
 
 ## Completion condition
 
-This skill is complete only when a reviewable PR exists with the necessary context and evidence.
+This skill is complete only when a reviewable PR exists with the necessary context, validation and review evidence, exact required routine headings, and linked tracking records.
 
 ## Large-scope delegation
 
-If PR context is large enough that assembling summary, validation evidence, and report references would be noisy, the parent may:
+If PR context is large enough that assembling summary, validation evidence, routine evidence, and report references would be noisy, the parent may:
 
 1. use `sub-agent-task-manager`
 2. ask a `sub-agent` for a bounded PR-draft preparation pass


### PR DESCRIPTION
Closes #47

## Summary

agentの記憶やIssue確認だけに依存せず、1 taskごとの永続状態とCodex lifecycle hookで開発routineを維持します。

- repositoryごとのtask routine stateとCLIを追加
- `SessionStart` / `UserPromptSubmit`でactive taskと次工程を再注入
- `PreToolUse`で前提工程未完了の編集・commit・push・PRを拒否
- `Stop`で未完了taskに継続promptを返し、再入loopを防止
- skill改善判断とtool自動化判断をtaskごとに必須化
- Issue/FPを履歴・重複・follow-upの正本、local routineをruntimeの正本として分離
- plugin hook設定とproject/user installerを追加
- PR本文にroutine・skill action・tool actionの証跡を必須化
- `mcp__<server>__<tool>`形式のconnector tool名を実tool名へ正規化し、提出gateの迂回を防止

## Validation

- 初期task routine unittest 11件: pass
- 最新hook/stateに対するtargeted unittest 8件: pass
  - Contents API提出gate
  - tracking tool除外
  - Stop再入防止
  - PR本文section不足
  - PR本文placeholder
  - PR本文証跡あり
  - MCP形式PR tool名の正規化と本文gate
  - MCP形式Contents API tool名のsubmission gate
- `.codex-plugin/plugin.json` / `hooks/hooks.json` JSON parse: pass
- 最終hook変更と追加testのPython AST parse: pass
- GitHub Actions run: 現時点ではなし

最新差分を含む19件の単一command一括実行は、clone可能なrunnerがこの作業環境にないため未実行です。merge前にCIまたはlocal runnerで実行してください。

Review reports:

- `reports/issue-47-task-routine-review-20260711115502.md`
- `reports/issue-47-task-routine-review-r2-20260711121600.md`

## Risks and follow-ups

- shellや任意script内部の副作用を完全には分類できないため、hookはsecurity sandboxではなくworkflow omission gateです。
- 未知のnamespace表現が将来追加された場合はtool名の正規化規則を更新する必要があります。
- Stop hookは無限再入回避のため、1回のcontinuation後は再blockしません。継続不能時は`pause`または`abort`の明示記録が必要です。
- branchは`main`に対して10 commits aheadです。GitHub connectorで段階的に作成した履歴を保持しています。

## Task routine evidence

- intake: Issue #47と利用者の追加指示を確認済み
- skill scan: development-orchestrator、feedback-points-manager、git-pr-submitter、関連設計、Codex公式hook実装を確認済み
- task definition: task routine、hook gate、skill/tool reflection、connector tool名正規化、tests、review、PRを対象化
- implementation: state/CLI/hook/plugin/installer/skill/policy/design/testsをbranchへ反映
- verification: 初期11 tests、最新差分targeted 8 tests、JSON parse、AST parseを実施
- review: r1/r2 reportにfindingと残存riskを記録
- feedback disposition: Issue #47をdurable tracking recordとして使用
- progress sync: review reports、branch、Draft PR、Issue commentへ同期

## Skill action

`update-existing`

- `development-orchestrator`: task routine ownerとskill/tool reflectionを追加
- `feedback-points-manager`: runtime triggerとdurable trackingの責務を分離
- `git-pr-submitter`: PR本文のroutine/skill/tool証跡を必須化

新規skillは作成せず、既存skillの責務内で更新しました。

## Tool action

`create-internal`

- `task_routine.py`
- `task_routine_state.py`
- `task_routine_hooks.py`
- plugin hook設定
- project/user hook installer
- unit tests
- MCP canonical tool名の正規化

agentが反復していた工程確認と提出前判定を、`development-orchestrator`所有の内部toolへ移しました。