### PR TITLE
fix(delegation): spawn agentの実行profileを正しく適用する

### DIFF
--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -139,7 +139,7 @@ handover-memo-writer [親が実行]
 
 1. workflow 冒頭で `/home/ibis/AI/CodexSkill` が最新か確認し、安全に更新できるなら最新取得してから先へ進む。
 2. 再開セッションなら `restart-handover-manager` を呼び、再開文脈を復元してから同じ workflow に戻る。
-3. 新規着手で今回の作業対象がまだ曖昧なら、`development-orchestrator` がユーザーに何の作業をするか確認してから task 選定へ進む。
+3. 新規着手の最初のユーザー確認で、`development-orchestrator` が実装sub-agent用modelを確認する。今回の作業対象も曖昧なら、何の作業をするかも確認してから task 選定へ進む。未確認のmodelを推測して実装sub-agentをdispatchしない。
 4. `development-orchestrator` が現在状態を確認し、次の task を 1 つ選ぶ。
 5. `task-consistency-manager` で task と phase の追跡状態を整える。
 6. 設計影響がある場合は `design-doc-maintainer` を呼ぶ。
@@ -173,10 +173,10 @@ handover-memo-writer [親が実行]
 sub-agent を使う作業は、親が必ず次の順番で準備してから実行する。
 
 1. `codex-delegation-executor` または呼び出し元 skill が、sub-agent を使うべき作業だと判断する。
-2. `sub-agent-task-manager` が task purpose、scope、non-goals、読むべき skill を定義する。
+2. `sub-agent-task-manager` が task purpose、scope、non-goals、読むべき skill、model/reasoning/fork方針を定義する。
 3. `report-output-manager` を呼び、`reports/` 配下の report path を決める。
 4. 親が標準テンプレートで report file を先に作る。
-5. 親が sub-agent に、読むべき `SKILL.md`、report path、既存 report を先に読んで空欄または placeholder だけ埋めること、format を変えないことを明示して dispatch する。
+5. 親が sub-agent に、読むべき `SKILL.md`、report path、既存 report を先に読んで空欄または placeholder だけ埋めること、format を変えないことを明示し、選択した実行profileを実spawn引数で渡して dispatch する。
 6. review や investigation では、sub-agent は parent が切った diff だけに閉じず、必要な周辺コードを workspace から直接読む。
 7. sub-agent が作業し、既存 report の見出し順、空行、既存記述を保持したまま結果を書く。
 8. 親が report を確認し、完了条件を満たしているか判定する。
@@ -216,9 +216,9 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `development-orchestrator` | 全体フローの入口として、task 選定から設計、TDD、委譲、レビュー、進捗同期、Git、issue 完了時の振り返りまでを統括する。 | `親が実行` |
-| `codex-delegation-executor` | 実装・検証・調査を誰が実行するかを決め、sub-agent 必須カテゴリを正しく委譲する。 | `親が実行` |
-| `sub-agent-task-manager` | sub-agent へ渡す task の範囲、読むべき skill、report path、report template 保持ルール、完了条件を固定する。 | `親が実行` |
+| `development-orchestrator` | 全体フローの入口として、task 選定から設計、TDD、委譲、レビュー、進捗同期、Git、issue 完了時の振り返りまでを統括し、実装sub-agent用modelのユーザー確認を開始時に所有する。 | `親が実行` |
+| `codex-delegation-executor` | 実装・検証・調査を誰が実行するかを決め、sub-agent 必須カテゴリと実行profileを `sub-agent-task-manager` へ正しく委譲する。 | `親が実行` |
+| `sub-agent-task-manager` | sub-agent へ渡す task の範囲、読むべき skill、model/reasoning/fork実行profile、report path、report template 保持ルール、完了条件を固定する。 | `親が実行` |
 | `execution-cost-stabilizer` | 無駄な再実行や過剰並列を抑え、委譲実行のコストと不安定さを下げる。 | `親が実行` |
 | `feedback-autonomy-boundary-manager` | 自律実行してよい範囲と、ユーザー確認で止まるべき境界を決める。 | `親が実行` |
 | `skill-authoring-wrapper` | built-in `skill-creator` をラップし、この repo 標準の粒度で local skill を作成・更新する。 | `親が実行` |
@@ -251,7 +251,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `review-enforcer` | task 完了前に必ずレビューを通し、セッション内で原則同じ reviewer sub-agent を使い、review report が残るまで完了扱いにしない。Markdown 関連変更では `markdown-word-checker` の結果を review report に含め、許可一覧、`prh`、target 除外変更では利用者が実 entry を明示確認したことも完了条件に含める。 | `親が実行` |
+| `review-enforcer` | task 完了前に必ずレビューを通し、親agentと同じmodelと`high` reasoningを既定reviewer profileとして所有し、セッション内で原則同じ reviewer sub-agent を使い、選択したprofileを実spawn引数へ適用してreview report が残るまで完了扱いにしない。reasoning effortは利用者がoverrideできる。Markdown 関連変更では `markdown-word-checker` の結果を review report に含め、許可一覧、`prh`、target 除外変更では利用者が実 entry を明示確認したことも完了条件に含める。 | `親が実行` |
 | `markdown-word-checker` | 対象repoの `tools/lint/` 設定を読み、Markdown用語、表記揺れ、backtick回避、`skip` / `unsupported` / `failed gate` を分類して呼び出し元へ返す。 | `親が実行` |
 | `feedback-coding-standards-enforcer` | API ドキュメント、命名、解析ルールなどのコーディング規約を review/commit 前に強制する。 | `親が実行` |
 | `feedback-issue-intake-fallback-manager` | issue 要件の取得が失敗したときに、代替経路で authoritative な要件を確保する。 | `親が実行` |
@@ -287,9 +287,9 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `development-orchestrator` | tasks/phases、recent reports、feedback-points、repo state | 現在 task と次の実行経路 | 1 task 分の標準サイクル完了または明確な blocking 状態 |
-| `codex-delegation-executor` | 実行対象の work item、scope、evidence 要件 | executor 決定、委譲結果、report evidence | executor 決定と結果記録が完了 |
-| `sub-agent-task-manager` | task purpose、scope、読むべき skill、report path 要件、workspace context 方針 | dispatch 済み sub-agent task、pre-created report、review 済み evidence | report 作成と review 済み evidence の確認完了 |
+| `development-orchestrator` | tasks/phases、recent reports、feedback-points、repo state、実装sub-agent用modelのユーザー確認 | 現在 task と次の実行経路、確認済みimplementation model | 1 task 分の標準サイクル完了または明確な blocking 状態 |
+| `codex-delegation-executor` | 実行対象の work item、scope、evidence 要件、確認済みimplementation modelまたはreview-enforcer選択profile | executor 決定、委譲結果、report evidence | executor 決定と結果記録が完了 |
+| `sub-agent-task-manager` | task purpose、scope、読むべき skill、caller選択のmodel/reasoning/fork方針、report path 要件、workspace context 方針 | 実spawn引数でprofileを適用したdispatch済み sub-agent task、pre-created report、review 済み evidence | report 作成と review 済み evidence の確認完了 |
 | `execution-cost-stabilizer` | delegated task plan、retry pressure、parallelism 候補 | 安定化された実行計画 | 次アクションが無駄なく scoped されている |
 | `feedback-autonomy-boundary-manager` | 次の planned action、assumption、approval risk | continue または stop の明示判断 | continue/stop 判断が理由付きで明確 |
 | `skill-authoring-wrapper` | skill purpose、target location、new/update distinction、repo standards | repo-standard local skill、updated hierarchy design documents、必要なら実在 inventory の更新 | built-in `skill-creator` 出力が repo 標準に補正されている |
@@ -322,7 +322,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `review-enforcer` | task-scoped diff、review scope、workspace context、validation context、session reviewer、適用するレビュー指針、`markdown-word-checker` 結果、Markdown 許可一覧、`prh`、target 除外の利用者レビュー状態 | review report、findings または no findings、disposition、reviewer reuse decision、`markdown-word-checker` 証跡、exact entry変更時の利用者明示レビュー記録 | review evidence が report に残り disposition 済み。Markdown lint gate failure は完了扱いにせず、exact entry変更は利用者が実 entries を明示確認済み |
+| `review-enforcer` | task-scoped diff、review scope、workspace context、validation context、session reviewer、親agentのcurrent model、利用者override済みならreasoning effort、適用するレビュー指針、`markdown-word-checker` 結果、Markdown 許可一覧、`prh`、target 除外の利用者レビュー状態 | review report、親modelと`high`を既定値ownerとして選択し実spawn引数で適用したreviewer profile、findings または no findings、disposition、reviewer reuse decision、`markdown-word-checker` 証跡、exact entry変更時の利用者明示レビュー記録 | review evidence が report に残り disposition 済み。Markdown lint gate failure は完了扱いにせず、exact entry変更は利用者が実 entries を明示確認済み |
 | `markdown-word-checker` | target repo root、Markdown file list、caller gate context、repo-local `tools/lint/` 設定、package lint wiring | command evidence、対象files、`skip` / `unsupported` / `failed gate` 分類、lint指摘分類、backtick回避確認、exact entry review要否、sub-agent report path | Markdown check結果がcallerへ返り、repo固有 whitelist / `prh` / target 除外のexact entry変更が利用者reviewなしに適用されていない |
 | `feedback-coding-standards-enforcer` | changed files、API diff、repo standards | standards evidence、violation fixes または rationale | standards-sensitive change の確認と記録が完了 |
 | `feedback-issue-intake-fallback-manager` | issue id/URL、available retrieval paths、partial context | authoritative requirements report、confidence、gaps | requirements と confidence が report に明示済み |

--- a/reports/topic-spawn-agent-model-overrides-implementation-20260711194140.md
+++ b/reports/topic-spawn-agent-model-overrides-implementation-20260711194140.md
@@ -1,0 +1,45 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: multi-agent v2のhidden model overrideを正しく使うSkill契約を追加する
+- タスク種別: Skill・設計実装
+
+## sub-agentを使う理由
+
+- 理由: 変更対象が複数Skill、reference、重複hierarchy designにまたがり、`codex-delegation-executor` のsub-agent基準を満たすため
+
+## 対象範囲
+
+- 対象: `sub-agent-task-manager`、`codex-delegation-executor`、`review-enforcer`、中央reference、2つのhierarchy design
+
+## 対象外
+
+- 対象外: Codex本体、ユーザーconfig、stashed feedback-points、他Skill、Git操作
+
+## 実行コマンド
+
+- 実行コマンド: `python3 /home/ibis/.codex/skills/.system/skill-creator/scripts/quick_validate.py` を3対象Skillに実行、`cmp -s skills/design/skill-hierarchy-design.md design/skill-hierarchy-design.md`、`rg --files -g 'package.json' -g 'tools/lint/**' -g '.markdownlint*' -g '.textlintrc*'`
+- blocking再検証: 同quick validationを`development-orchestrator`を含む4 Skillに実行、`cmp -s skills/design/skill-hierarchy-design.md design/skill-hierarchy-design.md`、`git diff --check`、対象Skillの旧reviewer model hardcode検索。
+
+## 対象ファイル
+
+- 変更または確認したファイル: `skills/sub-agent-task-manager/SKILL.md`、`skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`、`skills/codex-delegation-executor/SKILL.md`、`skills/review-enforcer/SKILL.md`、`skills/design/skill-hierarchy-design.md`、`design/skill-hierarchy-design.md`
+- 追加対象: `skills/development-orchestrator/SKILL.md`。実装sub-agent modelの開始時ユーザー確認を所有する。
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: hidden runtime overrideをprompt本文だけで指定すると実行profileにならないため、親が実際のspawn引数にmodelとreasoning effortを渡す中央契約を追加した。
+- blocking対応: reviewer profileの既定値が複数Skillに重複していたため、既定値ownerを`review-enforcer`へ一本化した。
+- 追加契約: reviewerは親agentと同じmodelを実spawn引数で使い、reasoning effortは`high`を既定として利用者がoverrideできる。実装sub-agentのmodelは`development-orchestrator`が開始時に利用者確認する。
+
+## 結果
+
+- 結果: `sub-agent-task-manager` がmodel/reasoning/fork方針とruntime rejection時の親側fallbackを所有し、delegation/review側がその契約へ選択値を渡す構成にした。3対象Skillのquick validationはpassし、2つのhierarchy designはbyte-identicalだった。repo内に`package.json`、`tools/lint/`、Markdown lint設定は見つからなかった。
+- blocking対応結果: `sub-agent-task-manager` と `codex-delegation-executor` はcallerが選択したreviewer profileをactual spawn argsへ渡すだけとし、`review-enforcer`の既存priorityを唯一の既定値として維持した。
+- 追加契約の結果: 上記の旧priority記述を親model＋`high`の契約へ置換した。未確認のimplementation modelは`codex-delegation-executor`が推測dispatchせず、確認済み選択だけを`sub-agent-task-manager`へ渡す。
+- 再検証結果: 4 Skillのquick validation、hierarchy designのbyte-identical確認、`git diff --check`、対象Skillの旧reviewer model hardcode不在確認はすべてpassした。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: visible schemaとbackend受理状態が異なる可能性がある。override rejection時は親が`codex exec` fallbackを使い、sub-agent内からの照会・nested Codexは行わない。repo固有Markdown lint配線がないため、今回のMarkdown変更にはfocused/full lintを実行できなかった。

--- a/reports/topic-spawn-agent-model-overrides-review-20260711194140.md
+++ b/reports/topic-spawn-agent-model-overrides-review-20260711194140.md
@@ -1,0 +1,43 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: `spawn_agent` model override Skill修正を独立レビューする
+- タスク種別: レビュー
+
+## sub-agentを使う理由
+
+- 理由: review-enforcerが独立sub-agent reviewとreport保存を必須としているため
+
+## 対象範囲
+
+- 対象: T-001のSkill、reference、hierarchy design、tracking、report差分
+
+## 対象外
+
+- 対象外: ファイル修正、commit、push、PR操作
+
+## 実行コマンド
+
+- 実行コマンド: `git status --short`、`git diff --stat origin/main`、`git diff --name-status origin/main`、`git diff --find-renames origin/main -- <対象6ファイル>`、`git diff --check origin/main`、`python3 /home/ibis/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>`（4 Skill）、`cmp -s skills/design/skill-hierarchy-design.md design/skill-hierarchy-design.md`、新規referenceの`test -f`、Markdown lint配線の`find`、required sectionと契約行の`rg`/`nl`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `skills/development-orchestrator/SKILL.md`、`skills/codex-delegation-executor/SKILL.md`、`skills/review-enforcer/SKILL.md`、`skills/sub-agent-task-manager/SKILL.md`、`skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`、`skills/skill-authoring-wrapper/SKILL.md`、`skills/skill-authoring-wrapper/references/responsibility-placement-policy.md`、`skills/design/skill-hierarchy-design.md`、`design/skill-hierarchy-design.md`、`tasks/tasks-status.md`、`tasks/phases-status.md`、関連implementation/verification/review report
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: **Medium / ユーザー確認必須** — `tasks/tasks-status.md:21` はT-001の終了条件としてMarkdown lintの成功を要求するが、repoには`package.json`、`tools/lint/`、Markdown lint設定がなく、focused/fullとも`unsupported`でpassではない。`review-enforcer`と`markdown-word-checker`の契約上、unsupportedだけでは必須gateを完了できないため、lint配線を追加して成功させるか、今回のunsupportedを受容するよう終了条件を変更するかをユーザーに確認する必要がある。
+- blocking normal-path finding: なし。hidden model/reasoningのactual spawn引数、`fork_turns: "none"`/明示的な正数partialのみ、`all`/省略禁止、親所有`codex exec` fallback、reviewer profile owner、implementation model確認ownerのSkill契約には指摘なし。
+- non-blocking finding: なし。
+- 再review disposition: **Resolved**。`tasks/tasks-status.md:21-22`はMarkdown lintを実行し、配線が無い場合は`unsupported`の理由と残リスクを記録する条件へ補正され、Skill validation・独立review成功とは別条件になった。`tasks/phases-status.md:25`も実行または`unsupported`分類へ同期しており、finding解消後の新規指摘なし。
+
+## 結果
+
+- 結果: **ユーザー確認待ち**。上記1件を除き、origin/mainからworktreeまでのT-001差分に新規指摘なし。4 Skillのrequired sectionsは揃い、追加記述は既存Skillの責務内に収まり、4 Skillのquick validationはpass、2 hierarchy designはbyte-identical、新規referenceリンクは実在、`git diff --check origin/main`はpassした。親は本reviewerを`model: gpt-5.6-sol`、`reasoning_effort: high`、`fork_turns: "none"`のhidden actual spawn argsで起動し、runtime errorなくtask受領まで到達したためtool-call acceptanceの証拠になる。
+- 再review結果: **Pass（finding解消、新規指摘なし）**。trackingの終了条件とPhase 3、implementation/verification reportの`unsupported`分類が整合し、`git diff --check origin/main`も引き続きpassした。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: Markdown lintはrepo配線不在の`unsupported`であり、pass扱いできない。reviewer自身はdispatch後のlive spawn callまたは実適用profileを自己照会できないため、確認できるのはhidden引数を含むspawn callが受理されtask deliveryに成功したことまでで、backendが要求profileを実際に適用したことの自己証明はできない。
+- 再review後リスク: Markdown lint未配線とlive profile自己照会不可の既知制約は、理由と残リスクを保持したnon-blockingな制約として残る。追加対応を要するreview findingはない。

--- a/reports/topic-spawn-agent-model-overrides-verification-20260711194628.md
+++ b/reports/topic-spawn-agent-model-overrides-verification-20260711194628.md
@@ -1,0 +1,43 @@
+# Sub-agent実行レポート
+
+## タスク
+
+- 目的: `spawn_agent` model override Skill修正を独立検証する
+- タスク種別: 検証
+
+## sub-agentを使う理由
+
+- 理由: codex-delegation-executorがverification evidenceを独立sub-agentの固定担当としているため
+
+## 対象範囲
+
+- 対象: 3 Skill、中央reference、2 hierarchy design、tracking/reportの構文・契約・整合性
+
+## 対象外
+
+- 対象外: ファイル修正、commit、push、PR操作
+
+## 実行コマンド
+
+- 実行コマンド: `python3 /home/ibis/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>`（3 Skill）、`cmp -s skills/design/skill-hierarchy-design.md design/skill-hierarchy-design.md`、`test -f skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`、`rg --files -g 'package.json' -g 'tools/lint/**' -g '.markdownlint*' -g '.textlintrc*' -g 'cspell*.json' -g 'cspell*.yaml' -g 'cspell*.yml'`、Issue #32031本文確認、`git diff --check`
+- 再検証コマンド: `quick_validate.py`を`development-orchestrator`を含む4 Skillへ実行、関連4 Skillの`gpt-5.x` hardcode検索、workflow開始時確認・reviewer owner・actual spawn引数・中央override/fork/fallback契約の`rg`/行番号確認、lint配線の`find`、designの`cmp -s`、referenceの`test -f`、`git diff --check`
+
+## 対象ファイル
+
+- 変更または確認したファイル: `skills/sub-agent-task-manager/SKILL.md`、`skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`、`skills/codex-delegation-executor/SKILL.md`、`skills/review-enforcer/SKILL.md`、`skills/skill-authoring-wrapper/SKILL.md`、`skills/design/skill-hierarchy-design.md`、`design/skill-hierarchy-design.md`、`skills/markdown-word-checker/SKILL.md`、`tasks/tasks-status.md`、`tasks/phases-status.md`、関連implementation/review/verification report
+- 再検証対象: `skills/development-orchestrator/SKILL.md`、`skills/sub-agent-task-manager/SKILL.md`、`skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`、`skills/codex-delegation-executor/SKILL.md`、`skills/review-enforcer/SKILL.md`、2 hierarchy design、Markdown lint配線
+
+## 指摘事項
+
+- 指摘要約または「指摘なし」: **Blocking**: reviewer既定profileが関連Skill間で矛盾する。`skills/sub-agent-task-manager/SKILL.md:79` と `skills/codex-delegation-executor/SKILL.md:59` は `gpt-5.4 high` を既定とする一方、`skills/review-enforcer/SKILL.md:47,74` は `gpt-5.5 high` を第一選択、利用不可時のみ `gpt-5.4 high` とする。callerと中央dispatch契約のどちらを優先するか一意に決まらず、「全関連Skill/designが矛盾なく表す」検証条件を満たさない。
+- 再検証disposition: **Resolved / 新規指摘なし**。関連4 Skillから`gpt-5.4`/`gpt-5.5` hardcodeが除去され、`review-enforcer`だけが親agentのcurrent modelと既定`high` reasoning effort（effortは利用者override可）の選択ownerになった。`codex-delegation-executor`と`sub-agent-task-manager`はownerが選択・確認したprofileを受け取り、実spawn引数へ適用する責務に限定されている。
+
+## 結果
+
+- 結果: **Fail（1 blocking finding）**。3 Skillのbuilt-in `quick_validate.py` はすべてpass、2 hierarchy designはbyte-identical、新規referenceへの相対リンクは実在、`git diff --check` はpass。model/reasoningをprompt-onlyではなく実spawn引数で渡し、override時は`fork_turns: "none"`または明示的な正数partial forkだけを許し、`all`/省略を禁止し、拒否時の`codex exec` fallbackを親所有とする中央契約は関連Skill/designに矛盾なく反映されている。Issue #32031本文はhidden schemaでもruntime parserがoverrideを受理すること、ただし省略forkはfull-historyとなりoverrideを拒否し、`none`/partialが必要であることを説明しており、今回の実spawn acceptanceと整合する。repo内に`package.json`、`lint:md`、`tools/lint/`、Markdown lint設定がないためfocused/full Markdown lintはともに`unsupported`（passではない）と分類する。
+- 再検証結果: **Pass（前回blocking解消、新規findingなし）**。`development-orchestrator`はworkflow開始時の最初のユーザー確認でimplementation sub-agent modelを確認し、未確認modelの推測・dispatchを禁止する。review profileは`review-enforcer`が所有し、delegation/task-managerは確認済み選択の受け渡しとactual spawn引数適用のみを担う。hidden override、`none`/正数partial fork、`all`/省略禁止、親側`codex exec` fallbackの中央契約も維持されている。4 Skillのquick validation、2 designのbyte一致、新規reference実在、`git diff --check`はすべてpass。Markdown lintはfocused/fullとも配線不在の`unsupported`。
+
+## リスク
+
+- 未解決のリスクまたは後続対応: reviewer既定profileを中央契約と`review-enforcer`で統一後、再verificationが必要。親のhidden override dispatchは本verification agentを`model: gpt-5.6-sol`、`reasoning_effort: high`、`fork_turns: "none"`でエラーなく起動し、task受領まで到達したためtool acceptance evidenceとなる。ただしagent自身はdispatch後のlive spawn callや適用済みprofileを照会できず、backendが要求profileを実際に適用したことまでは自己証明できない。Markdown lintはrepo配線不足の`unsupported`であり、callerがblocking/hold/accepted riskを明示的にdispositionする必要がある。
+- 再検証後リスク: 前回blockingの後続対応は完了。残るのは、agent自身が適用済みlive profileを自己照会できない既知の証明限界と、repo固有Markdown lint配線がないためlint結果をpass/failとして得られない`unsupported`状態。後者はcaller dispositionが必要であり、passとは扱わない。

--- a/skills/codex-delegation-executor/SKILL.md
+++ b/skills/codex-delegation-executor/SKILL.md
@@ -26,6 +26,8 @@ Before running this skill, identify:
 - whether the work is implementation, review, verification, or investigation
 - scope boundaries, target files, and non-goals when known
 - validation or evidence expectations
+- when a `sub-agent` is selected, the intended model, reasoning effort, and fork policy
+- for implementation `sub-agent` work, the model confirmed by `development-orchestrator` with the user
 
 ## Delegate these work types
 
@@ -55,7 +57,7 @@ The following work must be executed by a `sub-agent` now, not merely preferred:
 - standards detection or standards validation
 
 Use `sub-agent-task-manager` for these categories and require a report in `reports/`.
-Use `gpt-5.4` with `high` reasoning effort as the default reviewer configuration for review tasks unless the user explicitly overrides it for the current run.
+For review tasks, receive the parent-model plus reasoning-effort profile selected by `review-enforcer` and pass it to `sub-agent-task-manager`; do not define a reviewer default here.
 
 ## Executor selection
 
@@ -84,12 +86,13 @@ For each delegated task:
 1. classify the work as fixed-sub-agent vs implementation-side delegation
 2. if fixed-sub-agent, call `sub-agent-task-manager`
 3. otherwise choose executor and record why that executor was chosen
-4. define the exact scope
-5. identify any skill files the executor must read
-6. define expected outputs
-7. define validation commands or evidence
-8. run the delegated work
-9. capture results in `reports/`
+4. when choosing a `sub-agent`, pass the selected model, reasoning effort, and fork policy to `sub-agent-task-manager`; for implementation, accept only the user-confirmed model from `development-orchestrator`; that skill owns the spawn-call contract
+5. define the exact scope
+6. identify any skill files the executor must read
+7. define expected outputs
+8. define validation commands or evidence
+9. run the delegated work
+10. capture results in `reports/`
 
 ## Rules
 
@@ -113,6 +116,8 @@ For each delegated task:
 - For review and investigation tasks, prefer workspace-direct inspection over parent-written excerpts when repository access is available.
 - For review tasks, do not accept chat-only review output; require the findings to be written into the report file.
 - When a delegated task depends on an existing skill, instruct the executor to read that skill file explicitly.
+- Do not encode model or reasoning selection only in a task prompt. Let `sub-agent-task-manager` apply the selected profile as actual spawn arguments and its central fallback rule when the runtime rejects an override.
+- Do not infer an implementation sub-agent model or dispatch implementation work without the user confirmation that `development-orchestrator` owns.
 
 ## Strong rule
 

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -139,7 +139,7 @@ handover-memo-writer [親が実行]
 
 1. workflow 冒頭で `/home/ibis/AI/CodexSkill` が最新か確認し、安全に更新できるなら最新取得してから先へ進む。
 2. 再開セッションなら `restart-handover-manager` を呼び、再開文脈を復元してから同じ workflow に戻る。
-3. 新規着手で今回の作業対象がまだ曖昧なら、`development-orchestrator` がユーザーに何の作業をするか確認してから task 選定へ進む。
+3. 新規着手の最初のユーザー確認で、`development-orchestrator` が実装sub-agent用modelを確認する。今回の作業対象も曖昧なら、何の作業をするかも確認してから task 選定へ進む。未確認のmodelを推測して実装sub-agentをdispatchしない。
 4. `development-orchestrator` が現在状態を確認し、次の task を 1 つ選ぶ。
 5. `task-consistency-manager` で task と phase の追跡状態を整える。
 6. 設計影響がある場合は `design-doc-maintainer` を呼ぶ。
@@ -173,10 +173,10 @@ handover-memo-writer [親が実行]
 sub-agent を使う作業は、親が必ず次の順番で準備してから実行する。
 
 1. `codex-delegation-executor` または呼び出し元 skill が、sub-agent を使うべき作業だと判断する。
-2. `sub-agent-task-manager` が task purpose、scope、non-goals、読むべき skill を定義する。
+2. `sub-agent-task-manager` が task purpose、scope、non-goals、読むべき skill、model/reasoning/fork方針を定義する。
 3. `report-output-manager` を呼び、`reports/` 配下の report path を決める。
 4. 親が標準テンプレートで report file を先に作る。
-5. 親が sub-agent に、読むべき `SKILL.md`、report path、既存 report を先に読んで空欄または placeholder だけ埋めること、format を変えないことを明示して dispatch する。
+5. 親が sub-agent に、読むべき `SKILL.md`、report path、既存 report を先に読んで空欄または placeholder だけ埋めること、format を変えないことを明示し、選択した実行profileを実spawn引数で渡して dispatch する。
 6. review や investigation では、sub-agent は parent が切った diff だけに閉じず、必要な周辺コードを workspace から直接読む。
 7. sub-agent が作業し、既存 report の見出し順、空行、既存記述を保持したまま結果を書く。
 8. 親が report を確認し、完了条件を満たしているか判定する。
@@ -216,9 +216,9 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `development-orchestrator` | 全体フローの入口として、task 選定から設計、TDD、委譲、レビュー、進捗同期、Git、issue 完了時の振り返りまでを統括する。 | `親が実行` |
-| `codex-delegation-executor` | 実装・検証・調査を誰が実行するかを決め、sub-agent 必須カテゴリを正しく委譲する。 | `親が実行` |
-| `sub-agent-task-manager` | sub-agent へ渡す task の範囲、読むべき skill、report path、report template 保持ルール、完了条件を固定する。 | `親が実行` |
+| `development-orchestrator` | 全体フローの入口として、task 選定から設計、TDD、委譲、レビュー、進捗同期、Git、issue 完了時の振り返りまでを統括し、実装sub-agent用modelのユーザー確認を開始時に所有する。 | `親が実行` |
+| `codex-delegation-executor` | 実装・検証・調査を誰が実行するかを決め、sub-agent 必須カテゴリと実行profileを `sub-agent-task-manager` へ正しく委譲する。 | `親が実行` |
+| `sub-agent-task-manager` | sub-agent へ渡す task の範囲、読むべき skill、model/reasoning/fork実行profile、report path、report template 保持ルール、完了条件を固定する。 | `親が実行` |
 | `execution-cost-stabilizer` | 無駄な再実行や過剰並列を抑え、委譲実行のコストと不安定さを下げる。 | `親が実行` |
 | `feedback-autonomy-boundary-manager` | 自律実行してよい範囲と、ユーザー確認で止まるべき境界を決める。 | `親が実行` |
 | `skill-authoring-wrapper` | built-in `skill-creator` をラップし、この repo 標準の粒度で local skill を作成・更新する。 | `親が実行` |
@@ -251,7 +251,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 役割 | 実行方式 |
 | --- | --- | --- |
-| `review-enforcer` | task 完了前に必ずレビューを通し、セッション内で原則同じ reviewer sub-agent を使い、review report が残るまで完了扱いにしない。Markdown 関連変更では `markdown-word-checker` の結果を review report に含め、許可一覧、`prh`、target 除外変更では利用者が実 entry を明示確認したことも完了条件に含める。 | `親が実行` |
+| `review-enforcer` | task 完了前に必ずレビューを通し、親agentと同じmodelと`high` reasoningを既定reviewer profileとして所有し、セッション内で原則同じ reviewer sub-agent を使い、選択したprofileを実spawn引数へ適用してreview report が残るまで完了扱いにしない。reasoning effortは利用者がoverrideできる。Markdown 関連変更では `markdown-word-checker` の結果を review report に含め、許可一覧、`prh`、target 除外変更では利用者が実 entry を明示確認したことも完了条件に含める。 | `親が実行` |
 | `markdown-word-checker` | 対象repoの `tools/lint/` 設定を読み、Markdown用語、表記揺れ、backtick回避、`skip` / `unsupported` / `failed gate` を分類して呼び出し元へ返す。 | `親が実行` |
 | `feedback-coding-standards-enforcer` | API ドキュメント、命名、解析ルールなどのコーディング規約を review/commit 前に強制する。 | `親が実行` |
 | `feedback-issue-intake-fallback-manager` | issue 要件の取得が失敗したときに、代替経路で authoritative な要件を確保する。 | `親が実行` |
@@ -287,9 +287,9 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `development-orchestrator` | tasks/phases、recent reports、feedback-points、repo state | 現在 task と次の実行経路 | 1 task 分の標準サイクル完了または明確な blocking 状態 |
-| `codex-delegation-executor` | 実行対象の work item、scope、evidence 要件 | executor 決定、委譲結果、report evidence | executor 決定と結果記録が完了 |
-| `sub-agent-task-manager` | task purpose、scope、読むべき skill、report path 要件、workspace context 方針 | dispatch 済み sub-agent task、pre-created report、review 済み evidence | report 作成と review 済み evidence の確認完了 |
+| `development-orchestrator` | tasks/phases、recent reports、feedback-points、repo state、実装sub-agent用modelのユーザー確認 | 現在 task と次の実行経路、確認済みimplementation model | 1 task 分の標準サイクル完了または明確な blocking 状態 |
+| `codex-delegation-executor` | 実行対象の work item、scope、evidence 要件、確認済みimplementation modelまたはreview-enforcer選択profile | executor 決定、委譲結果、report evidence | executor 決定と結果記録が完了 |
+| `sub-agent-task-manager` | task purpose、scope、読むべき skill、caller選択のmodel/reasoning/fork方針、report path 要件、workspace context 方針 | 実spawn引数でprofileを適用したdispatch済み sub-agent task、pre-created report、review 済み evidence | report 作成と review 済み evidence の確認完了 |
 | `execution-cost-stabilizer` | delegated task plan、retry pressure、parallelism 候補 | 安定化された実行計画 | 次アクションが無駄なく scoped されている |
 | `feedback-autonomy-boundary-manager` | 次の planned action、assumption、approval risk | continue または stop の明示判断 | continue/stop 判断が理由付きで明確 |
 | `skill-authoring-wrapper` | skill purpose、target location、new/update distinction、repo standards | repo-standard local skill、updated hierarchy design documents、必要なら実在 inventory の更新 | built-in `skill-creator` 出力が repo 標準に補正されている |
@@ -322,7 +322,7 @@ local skill を新規作成または実質更新するときは、親が次の�
 
 | Skill名 | 入力 | 出力 | 完了条件 |
 | --- | --- | --- | --- |
-| `review-enforcer` | task-scoped diff、review scope、workspace context、validation context、session reviewer、適用するレビュー指針、`markdown-word-checker` 結果、Markdown 許可一覧、`prh`、target 除外の利用者レビュー状態 | review report、findings または no findings、disposition、reviewer reuse decision、`markdown-word-checker` 証跡、exact entry変更時の利用者明示レビュー記録 | review evidence が report に残り disposition 済み。Markdown lint gate failure は完了扱いにせず、exact entry変更は利用者が実 entries を明示確認済み |
+| `review-enforcer` | task-scoped diff、review scope、workspace context、validation context、session reviewer、親agentのcurrent model、利用者override済みならreasoning effort、適用するレビュー指針、`markdown-word-checker` 結果、Markdown 許可一覧、`prh`、target 除外の利用者レビュー状態 | review report、親modelと`high`を既定値ownerとして選択し実spawn引数で適用したreviewer profile、findings または no findings、disposition、reviewer reuse decision、`markdown-word-checker` 証跡、exact entry変更時の利用者明示レビュー記録 | review evidence が report に残り disposition 済み。Markdown lint gate failure は完了扱いにせず、exact entry変更は利用者が実 entries を明示確認済み |
 | `markdown-word-checker` | target repo root、Markdown file list、caller gate context、repo-local `tools/lint/` 設定、package lint wiring | command evidence、対象files、`skip` / `unsupported` / `failed gate` 分類、lint指摘分類、backtick回避確認、exact entry review要否、sub-agent report path | Markdown check結果がcallerへ返り、repo固有 whitelist / `prh` / target 除外のexact entry変更が利用者reviewなしに適用されていない |
 | `feedback-coding-standards-enforcer` | changed files、API diff、repo standards | standards evidence、violation fixes または rationale | standards-sensitive change の確認と記録が完了 |
 | `feedback-issue-intake-fallback-manager` | issue id/URL、available retrieval paths、partial context | authoritative requirements report、confidence、gaps | requirements と confidence が report に明示済み |

--- a/skills/development-orchestrator/SKILL.md
+++ b/skills/development-orchestrator/SKILL.md
@@ -33,6 +33,7 @@ Before running this skill, confirm:
   - always confirm whether a relevant skill already exists while working
   - when unsure, suspect skill insufficiency before improvising
 - the user's intended work for this run when it is not already explicit from the request or restart context
+- the user-confirmed model for implementation `sub-agent` work, when implementation may be delegated
 - current `tasks-status.md` and `phases-status.md`
 - recent `reports/` relevant to the active issue or task
 - active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`
@@ -47,7 +48,7 @@ Follow this sequence:
 3. If the local skill repo is clean and behind its intended source, update it before continuing the workflow.
 4. If the local skill repo is dirty, diverged, or otherwise unsafe to auto-update, stop and resolve that explicitly before trusting the workflow.
 5. When entering from a resumed or restarted session, call `restart-handover-manager` to reconstruct the current position before selecting the next task.
-6. When the intended work for this run is not already explicit, read [references/start-intake-policy.md](references/start-intake-policy.md) and confirm with the user what work should be done before selecting a task.
+6. At the first user confirmation for this run, confirm the model to use for implementation `sub-agent` work. When the intended work is not already explicit, also read [references/start-intake-policy.md](references/start-intake-policy.md) and confirm what work should be done before selecting a task.
 7. Confirm current state from `tasks-status.md`, `phases-status.md`, recent `reports/`, and `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`.
 8. Select exactly one next task.
 9. Call `task-consistency-manager`.
@@ -74,6 +75,7 @@ Follow this sequence:
 - Do not skip parent-owned end-of-issue skill-gap reflection when an issue reaches done.
 - Do not leave local skill creation or substantial local skill updates floating without an explicit caller; use `development-orchestrator` as the default caller when the need is discovered through normal task completion.
 - Do not decide `main agent` vs `sub-agent` for implementation outside `codex-delegation-executor`.
+- Own implementation `sub-agent` model confirmation at workflow start. Do not let `codex-delegation-executor` infer an unconfirmed model or dispatch implementation sub-agent work until the user has confirmed it.
 - Treat design-document editing as switchable implementation work under `codex-delegation-executor` with `design-executor`.
 - Treat test authoring and code authoring as switchable implementation work under `codex-delegation-executor` with `implementation-executor`.
 - Do not downgrade skills that require mandatory `sub-agent` execution.

--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -27,6 +27,7 @@ Before running this skill, gather:
 - relevant validation context and reports
 - current task identifier and review scope
 - active session reviewer assignment, if one already exists
+- the parent agent's current model and any user override of reviewer reasoning effort
 - task-specific review criteria that were established earlier in the same session, such as audit decisions, design rules, naming rules, or comment standards
 - when Markdown-related work is in scope, the `markdown-word-checker` result and any proposed exact whitelist, `prh`, or target-exclusion entries with the user's explicit review state
 
@@ -44,7 +45,7 @@ Before running this skill, gather:
 10. Include task-specific review criteria from earlier audit/design decisions in the review request, and require the reviewer to evaluate the diff against those criteria.
 11. Run review for that task only as a `sub-agent` task through `sub-agent-task-manager`.
 12. Instruct the review `sub-agent` to use the built-in review behavior: findings first, severity-ordered, with file/line references when available.
-13. Use `gpt-5.5` with `high` reasoning effort as the first-choice review `sub-agent` unless the user explicitly overrides the reviewer model for the current run. If `gpt-5.5` is unavailable, use `gpt-5.4` with `high` reasoning effort as the next choice.
+13. Select the parent agent's current model for the reviewer and use `high` reasoning effort unless the user overrides it. Pass that profile through `sub-agent-task-manager` into the actual spawn arguments; for a fresh reviewer spawn, use `fork_turns: "none"`, or an explicit positive partial fork only when bounded context is required.
 14. Materialize the built-in review result into the pre-created report file under `reports/` while preserving the existing template format and filling only the intended blank sections.
 15. Prefer having the review `sub-agent` write the report file directly; treat parent-side report materialization as fallback only.
 16. If the review `sub-agent` does not write the report file directly, have the parent write it immediately from the returned review findings.
@@ -71,7 +72,8 @@ When creating a new review report file, call `report-output-manager`.
 - A single session should normally use one reviewer `sub-agent` for initial review and re-review so review standards remain consistent.
 - If the reviewer must change because the original reviewer is unavailable, conflicted, or explicitly replaced by the user, record the reason in the review report.
 - When a session has established concrete review criteria, such as naming, placement, XML comment, test-comment, or design-consistency rules, later reviews in that session must apply those criteria unless the user supersedes them.
-- Default reviewer model priority is `gpt-5.5 high` first, then `gpt-5.4 high` if `gpt-5.5` is unavailable, unless the user explicitly chooses another reviewer configuration.
+- The reviewer model is the parent agent's current model. Default reviewer reasoning effort is `high`; the user may override that effort for the current run.
+- Apply the selected reviewer model and reasoning effort through the central `sub-agent-task-manager` spawn contract, not as prompt text. Do not use a full-history fork with that override.
 - If mandatory `sub-agent` review is blocked by permission or execution-mode constraints, ask the user explicitly instead of improvising a parent-side substitute.
 - Review requests should explicitly ask for a code review, not a generic diff summary.
 - Review requests should tell the `sub-agent` to read the pre-created report first and preserve its headings, order, spacing, and any prefilled text.

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -26,6 +26,8 @@ Before running this skill, identify:
 - relevant skill files the `sub-agent` must read
 - whether the `sub-agent` should inspect the repository directly beyond the parent-prepared diff or summary
 - write boundaries and validation expectations
+- dispatch model, reasoning effort, and fork policy
+- confirmation source for an implementation `sub-agent` model when implementation work is delegated
 
 ## Run this skill
 
@@ -40,14 +42,16 @@ Run this skill whenever:
 
 1. define the exact task type and why a `sub-agent` is being used
 2. define the scope, non-goals, and expected outputs
-3. identify which skill files the `sub-agent` must read
-4. define write ownership and file boundaries when edits are allowed
-5. call `report-output-manager` and decide the report path before dispatch
-6. create the report file before dispatch using the standard template
-7. tell the `sub-agent` to read the specified skill files before executing
-8. tell the `sub-agent` to read that exact report file first and fill only the intended blank sections or placeholder values
-9. require commands run, changed files, outcome, and unresolved risks in the report
-10. do not treat the delegated task as complete until the report exists and has been reviewed
+3. receive the caller-selected dispatch model, reasoning effort, and fork policy before drafting the request; for implementation work, require the `development-orchestrator` user-confirmed model
+4. when selecting or applying a model or reasoning override, read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md)
+5. identify which skill files the `sub-agent` must read
+6. define write ownership and file boundaries when edits are allowed
+7. call `report-output-manager` and decide the report path before dispatch
+8. create the report file before dispatch using the standard template
+9. tell the `sub-agent` to read the specified skill files before executing
+10. tell the `sub-agent` to read that exact report file first and fill only the intended blank sections or placeholder values
+11. require commands run, changed files, outcome, and unresolved risks in the report
+12. do not treat the delegated task as complete until the report exists and has been reviewed
 
 Read the template from `report-output-manager` when creating the file:
 
@@ -62,6 +66,8 @@ Every sub-agent request must include:
 - explicit non-goals
 - explicit instruction not to run `codex exec`, nested Codex, or equivalent agent-spawning inside the sub-agent task
 - explicit instruction not to re-enter `development-orchestrator` or any other parent-owned workflow unless the parent explicitly named that workflow as part of the delegated task
+- the selected model and reasoning effort only as tool-call parameters, never as a prompt-only request
+- an explicit fork policy; a fresh override spawn must set `fork_turns: "none"`
 - skill names and file paths that must be read first
 - validation commands or evidence expectations
 - report path
@@ -71,7 +77,7 @@ Every sub-agent request must include:
 
 For review tasks also include:
 
-- instruction to use `gpt-5.4` with `high` reasoning effort by default unless the user explicitly overrides the reviewer model
+- the reviewer profile selected by `review-enforcer`: the parent agent's current model and `high` reasoning effort unless the user overrides the effort; apply it through actual spawn arguments rather than prompt text
 - explicit instruction to perform a code review using the built-in review behavior
 - instruction to return findings first, ordered by severity
 - instruction to include file/line references when available
@@ -145,6 +151,7 @@ After this skill runs, there should be:
 
 - a dispatched sub-agent task with explicit scope
 - a pre-created report path under `reports/`
+- a dispatch configuration applied through the actual spawn call
 - report-backed evidence for the delegated work
 
 ## Completion condition
@@ -167,6 +174,10 @@ This skill is complete only when:
 - For investigation and review tasks, prefer letting the `sub-agent` read the relevant workspace directly instead of over-constraining it to parent-curated excerpts.
 - For review tasks, prefer the model's native review behavior over inventing a custom review rubric in the prompt.
 - When a task depends on an existing skill, prefer making the `sub-agent` read that skill over duplicating its workflow in the prompt.
+- Do not treat a model or reasoning mention in `message` as an override. Pass the selected values in the `spawn_agent` call itself.
+- Do not infer an implementation sub-agent model. Apply only the user-confirmed model supplied by `development-orchestrator` through `codex-delegation-executor`.
+- Do not combine a model or reasoning override with omitted `fork_turns` or `fork_turns: "all"`; those full-history forks inherit the parent execution profile. Use `fork_turns: "none"` for a fresh specialist, or an explicit positive partial fork only when the needed context is bounded.
+- If the runtime rejects a hidden override argument, keep fallback execution parent-owned: use `codex exec --model <model> -c model_reasoning_effort="<effort>"`. Do not ask the delegated sub-agent to run it.
 
 ## Cross-cutting rule
 

--- a/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
+++ b/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
@@ -1,0 +1,31 @@
+# Spawn-agent model overrides
+
+Use this reference when a parent selects a model or reasoning effort for a `sub-agent`.
+
+## Core contract
+
+- `collaboration.spawn_agent` accepts the runtime arguments `model` and `reasoning_effort` even when they are absent from the visible tool schema.
+- Decide model, reasoning effort, and fork policy before dispatch. Put model and reasoning in the actual spawn call, not only in the task message.
+- For review, `review-enforcer` selects the parent agent's current model and `high` reasoning effort by default; the user may override the reasoning effort. For implementation, use only the model that `development-orchestrator` confirmed with the user at workflow start.
+- For a fresh specialist with an override, explicitly use `fork_turns: "none"`.
+- An explicit positive partial fork may use an override when its context need is bounded. Do not use an override with `fork_turns: "all"` or omitted `fork_turns`: full-history forks inherit the parent model and reasoning profile.
+
+## Call shape
+
+```js
+await collaboration.spawn_agent({
+  task_name: "bounded_task",
+  message: "Task-local instructions only.",
+  fork_turns: "none",
+  model: "<caller-selected-model>",
+  reasoning_effort: "<caller-selected-effort>",
+});
+```
+
+Keep the task request focused on work, scope, and report rules. A model name written only in `message` does not configure the spawned agent.
+
+## Failure handling and limit
+
+The visible schema and backend acceptance can differ. If the runtime rejects either override argument, the parent may run the work through `codex exec --model <model> -c model_reasoning_effort="<effort>"`; a sub-agent must never run that fallback or nested Codex.
+
+An agent cannot inspect its own live spawn call after dispatch. Record the intended profile and call outcome in the parent-owned report, and treat backend rejection as a capability gap rather than claiming the override was applied. Background: [Codex issue #32031](https://github.com/openai/codex/issues/32031).

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -1,0 +1,26 @@
+# Phases Status
+
+このファイルは `task-breakdown-planner`、`task-consistency-manager`、`progress-sync-manager` のみが更新する。
+
+- Updated: 2026-07-11
+
+## Phase 1: 契約・設計
+
+- Status: Done
+- Notes:
+  - Issue #32031 と実環境で、hidden `model` / `reasoning_effort` override、`fork_turns` 制約、`codex exec` fallbackを確認した
+  - dispatch詳細は `sub-agent-task-manager` が所有し、caller Skillはその契約へ従う方針とした
+  - reviewer modelは原則parentと同じmodel、implementation modelは作業開始時にユーザー確認する契約とした
+
+## Phase 2: Skill実装
+
+- Status: Done
+- Notes:
+  - orchestration/delegation/review Skill、reference、2つのhierarchy designを同期した
+
+## Phase 3: 検証・提出
+
+- Status: Done
+- Notes:
+  - Markdown lintを`unsupported`分類し、4 Skill validation、独立reviewを完了した
+  - commit、push、PR作成を実行する

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -1,0 +1,48 @@
+# Tasks Status
+
+このファイルは `task-breakdown-planner`、`task-consistency-manager`、`progress-sync-manager` のみが更新する。
+
+- Updated: 2026-07-11
+
+## In Progress
+
+なし
+
+## Backlog
+
+なし
+
+## Done
+
+- T-001: `spawn_agent` model override 呼び出し契約を Skill 化する
+  - Status: 完了
+  - Phase: Phase 2
+  - Estimate: S
+  - Depends on: なし
+  - Exit Criteria:
+    - `model` と `reasoning_effort` を prompt ではなく `spawn_agent` の実引数で渡す契約が明記されている
+    - override 時は `fork_turns: "none"` または部分 fork を使い、full-history forkを避ける規則が明記されている
+    - hidden schemaでもruntimeが受理する現在のmulti-agent v2挙動と、失敗時の `codex exec` fallbackが明記されている
+    - reviewerは原則parentと同じmodelを使用し、review reasoningの既定をhighとする
+    - implementation modelはdevelopment-orchestratorが作業開始時にユーザーへ確認する
+    - orchestration/delegation/review Skillと2つのhierarchy designが同期している
+    - Markdown lintを実行し、配線が無い場合は`unsupported`として理由と残リスクを記録する
+    - Skill validationと独立reviewが成功する
+    - commit、push、PR作成が完了する
+  - Output:
+    - `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+    - `skills/sub-agent-task-manager/SKILL.md`
+    - `skills/codex-delegation-executor/SKILL.md`
+    - `skills/development-orchestrator/SKILL.md`
+    - `skills/review-enforcer/SKILL.md`
+    - `skills/design/skill-hierarchy-design.md`
+    - `design/skill-hierarchy-design.md`
+    - `reports/topic-spawn-agent-model-overrides-implementation-20260711194140.md`
+    - `reports/topic-spawn-agent-model-overrides-verification-20260711194628.md`
+    - `reports/topic-spawn-agent-model-overrides-review-20260711194140.md`
+  - Verification:
+    - built-in `skill-creator` の `quick_validate.py` が4 Skillで成功
+    - 2つのhierarchy designがbyte-identical
+    - `git diff --check` 成功
+    - Markdown lintはrepo配線不在のため`unsupported`として記録
+    - parentと同じ`gpt-5.6-sol / high` reviewerの再レビューで指摘なし


### PR DESCRIPTION
## 概要

multi-agent v2でvisible schemaから隠れている`spawn_agent`の`model` / `reasoning_effort` overrideを、prompt本文ではなく実際のtool引数として適用するSkill契約を追加します。

## 変更内容

- `sub-agent-task-manager`にhidden override、`fork_turns`制約、親側`codex exec` fallbackの中央referenceを追加
- reviewerは原則parentと同じmodel、reasoningは`high`とする契約へ統一
- implementation sub-agent modelは`development-orchestrator`がworkflow開始時にユーザー確認し、未確認dispatchを禁止
- delegation/review/orchestration Skillと2つのhierarchy designを同期
- task/phase trackingと実装・検証・review reportを追加

## 検証

- built-in `skill-creator`の`quick_validate.py`: 4 Skill成功
- `skills/design/skill-hierarchy-design.md`と`design/skill-hierarchy-design.md`: byte-identical
- `git diff --check`: 成功
- `gpt-5.6-sol / high`独立review: 指摘なし
- Markdown lint: repository配線不在のため`unsupported`として記録

## レポート

- `reports/topic-spawn-agent-model-overrides-implementation-20260711194140.md`
- `reports/topic-spawn-agent-model-overrides-verification-20260711194628.md`
- `reports/topic-spawn-agent-model-overrides-review-20260711194140.md`

## 関連

- Non-closing reference: https://github.com/openai/codex/issues/32031

## 補足

- 対象外だった`feedback-points/feedback-points.md`の既存変更はstash済みで、このPRには含めていません。
