### PR TITLE
ChatGPT Skill ZIPを連番Pre-releaseと手動Releaseへ自動添付

### DIFF
--- a/.github/workflows/release-chatgpt-worker-skills.yml
+++ b/.github/workflows/release-chatgpt-worker-skills.yml
@@ -2,6 +2,11 @@ name: Validate and release ChatGPT worker skills
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
     paths:
       - "AGENTS.md"
       - "README.md"
@@ -13,37 +18,38 @@ on:
       - "scripts/build_chatgpt_worker_skills.py"
       - "scripts/verify_skill_repository.py"
       - ".github/workflows/release-chatgpt-worker-skills.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "AGENTS.md"
-      - "README.md"
-      - "skills/**"
-      - "shared/**"
-      - "design/**"
-      - "tasks/**"
-      - "reports/**"
-      - "scripts/build_chatgpt_worker_skills.py"
-      - "scripts/verify_skill_repository.py"
-      - ".github/workflows/release-chatgpt-worker-skills.yml"
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: chatgpt-worker-skills-${{ github.ref }}
+  group: chatgpt-worker-skills-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   build:
+    if: >-
+      !(
+        github.event_name == 'pull_request' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged != true
+      ) &&
+      !(
+        github.event_name == 'release' &&
+        startsWith(github.event.release.tag_name, 'chatgpt-worker-skills-pr-')
+      )
+    env:
+      TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merge_commit_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target HEAD without write credentials
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ env.TARGET_SHA }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -64,23 +70,81 @@ jobs:
       - name: Upload validation artifact
         uses: actions/upload-artifact@v4
         with:
-          name: chatgpt-worker-skills-${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          name: chatgpt-worker-skills-${{ env.TARGET_SHA }}
           path: chatgpt-worker-skills.zip
           if-no-files-found: error
 
-  release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  publish-merge-prerelease:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
     needs: build
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      TAG: chatgpt-worker-skills-pr-${{ github.event.pull_request.number }}
     steps:
-      - name: Checkout merged main HEAD
-        uses: actions/checkout@v4
+      - name: Download validated ChatGPT Skill ZIP
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ github.sha }}
-          fetch-depth: 0
+          name: chatgpt-worker-skills-${{ github.event.pull_request.merge_commit_sha }}
+          path: release-dist
 
+      - name: Verify downloaded prerelease asset
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f release-dist/chatgpt-worker-skills.zip
+          python3 -m zipfile -l release-dist/chatgpt-worker-skills.zip
+
+      - name: Publish PR merge prerelease
+        shell: bash
+        run: |
+          set -euo pipefail
+          notes="Automatic ChatGPT Worker Skills prerelease for merged PR #${PR_NUMBER}. Source PR: ${PR_URL}. Source commit: ${MERGE_SHA}. Repository validation and package structure verification passed."
+          title="ChatGPT Worker Skills PR #${PR_NUMBER}"
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release edit "${TAG}" \
+              --target "${MERGE_SHA}" \
+              --title "${title}" \
+              --notes "${notes}" \
+              --prerelease
+            gh release upload \
+              "${TAG}" \
+              release-dist/chatgpt-worker-skills.zip \
+              --clobber
+          else
+            gh release create \
+              "${TAG}" \
+              release-dist/chatgpt-worker-skills.zip \
+              --target "${MERGE_SHA}" \
+              --title "${title}" \
+              --notes "${notes}" \
+              --prerelease \
+              --latest=false
+          fi
+
+  attach-published-release-asset:
+    if: >-
+      github.event_name == 'release' &&
+      !startsWith(github.event.release.tag_name, 'chatgpt-worker-skills-pr-')
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
       - name: Download validated ChatGPT Skill ZIP
         uses: actions/download-artifact@v4
         with:
@@ -94,30 +158,10 @@ jobs:
           test -f release-dist/chatgpt-worker-skills.zip
           python3 -m zipfile -l release-dist/chatgpt-worker-skills.zip
 
-      - name: Publish rolling GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: chatgpt-worker-skills-latest
+      - name: Attach ZIP to published release
         shell: bash
         run: |
           set -euo pipefail
-          git tag -f "${TAG}" "${GITHUB_SHA}"
-          git push --force origin "refs/tags/${TAG}"
-
-          notes="Upload chatgpt-worker-skills.zip to ChatGPT Skills. The archive contains ChatGPT runtime wrappers and the parent-independent core Skills they invoke. No Skill depends on repository-external shared files. Repository-wide Skill dependency and active-link validation passed for source commit: ${GITHUB_SHA}."
-
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release edit "${TAG}" \
-              --title "ChatGPT Worker Skills" \
-              --notes "${notes}" \
-              --latest
-          else
-            gh release create "${TAG}" \
-              --title "ChatGPT Worker Skills" \
-              --notes "${notes}" \
-              --latest
-          fi
-
           gh release upload \
             "${TAG}" \
             release-dist/chatgpt-worker-skills.zip \

--- a/.github/workflows/release-chatgpt-worker-skills.yml
+++ b/.github/workflows/release-chatgpt-worker-skills.yml
@@ -18,6 +18,20 @@ on:
       - "scripts/build_chatgpt_worker_skills.py"
       - "scripts/verify_skill_repository.py"
       - ".github/workflows/release-chatgpt-worker-skills.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "AGENTS.md"
+      - "README.md"
+      - "skills/**"
+      - "shared/**"
+      - "design/**"
+      - "tasks/**"
+      - "reports/**"
+      - "scripts/build_chatgpt_worker_skills.py"
+      - "scripts/verify_skill_repository.py"
+      - ".github/workflows/release-chatgpt-worker-skills.yml"
   release:
     types:
       - published
@@ -43,13 +57,13 @@ jobs:
         startsWith(github.event.release.tag_name, 'chatgpt-worker-skills-pr-')
       )
     env:
-      TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merge_commit_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      TARGET_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merge_commit_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target HEAD without write credentials
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.TARGET_SHA }}
+          ref: ${{ env.TARGET_REF }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -70,9 +84,65 @@ jobs:
       - name: Upload validation artifact
         uses: actions/upload-artifact@v4
         with:
-          name: chatgpt-worker-skills-${{ env.TARGET_SHA }}
+          name: chatgpt-worker-skills-${{ github.run_id }}
           path: chatgpt-worker-skills.zip
           if-no-files-found: error
+
+  publish-rolling-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      TAG: chatgpt-worker-skills-latest
+    steps:
+      - name: Checkout merged main HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Download validated ChatGPT Skill ZIP
+        uses: actions/download-artifact@v4
+        with:
+          name: chatgpt-worker-skills-${{ github.run_id }}
+          path: release-dist
+
+      - name: Verify downloaded rolling release asset
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f release-dist/chatgpt-worker-skills.zip
+          python3 -m zipfile -l release-dist/chatgpt-worker-skills.zip
+
+      - name: Publish rolling GitHub Release
+        shell: bash
+        run: |
+          set -euo pipefail
+          git tag -f "${TAG}" "${GITHUB_SHA}"
+          git push --force origin "refs/tags/${TAG}"
+
+          notes="Upload chatgpt-worker-skills.zip to ChatGPT Skills. The archive contains ChatGPT runtime wrappers and the parent-independent core Skills they invoke. No Skill depends on repository-external shared files. Repository-wide Skill dependency and active-link validation passed for source commit: ${GITHUB_SHA}."
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release edit "${TAG}" \
+              --title "ChatGPT Worker Skills" \
+              --notes "${notes}" \
+              --latest
+          else
+            gh release create "${TAG}" \
+              --title "ChatGPT Worker Skills" \
+              --notes "${notes}" \
+              --latest
+          fi
+
+          gh release upload \
+            "${TAG}" \
+            release-dist/chatgpt-worker-skills.zip \
+            --clobber
 
   publish-merge-prerelease:
     if: >-
@@ -94,7 +164,7 @@ jobs:
       - name: Download validated ChatGPT Skill ZIP
         uses: actions/download-artifact@v4
         with:
-          name: chatgpt-worker-skills-${{ github.event.pull_request.merge_commit_sha }}
+          name: chatgpt-worker-skills-${{ github.run_id }}
           path: release-dist
 
       - name: Verify downloaded prerelease asset
@@ -148,7 +218,7 @@ jobs:
       - name: Download validated ChatGPT Skill ZIP
         uses: actions/download-artifact@v4
         with:
-          name: chatgpt-worker-skills-${{ github.sha }}
+          name: chatgpt-worker-skills-${{ github.run_id }}
           path: release-dist
 
       - name: Verify downloaded release asset

--- a/design/chat-worker-skill-design.md
+++ b/design/chat-worker-skill-design.md
@@ -168,30 +168,41 @@ chatgpt-worker-skills.zip
 
 `.github/workflows/release-chatgpt-worker-skills.yml`を使用する。
 
-### PR build
+### PR validation build
 
-1. PRのsynthetic merge SHAではなく実PR HEAD SHAをcheckoutする。
-2. checkout credentialを保持せず、`contents: read`だけで実行する。
-3. repository-wide validatorで全Skill、dependency、active link、symlink、design同期を確認する。
-4. 全`skills/chat-*/SKILL.md`を検出する。
-5. 必須core Skillを検出する。
+1. `opened`、`synchronize`、`reopened`で実行する。
+2. PRのsynthetic merge SHAではなく実PR HEAD SHAをcheckoutする。
+3. checkout credentialを保持せず、`contents: read`だけで実行する。
+4. repository-wide validatorで全Skill、dependency、active link、symlink、design同期を確認する。
+5. 全`skills/chat-*/SKILL.md`と必須core Skillを検出する。
 6. directory名とfront matterの`name`が一致することを確認する。
 7. symlink、missing Skill、Skill外`shared/`参照を拒否する。
 8. wrapperとcore Skillを独立root directoryとしてZIPへ収録する。
 9. ZIP rootが検出したSkill集合と一致することを確認する。
 10. 生成ZIPをworkflow artifactとして保存する。
-11. rolling tagとGitHub Releaseは更新しない。
+11. GitHub Releaseは更新しない。
 
-### main push
+### PR merge Pre-release
 
-1. merge後の`main` HEADをcheckoutする。
-2. PRと同じread-only validation／buildを実行する。
-3. build成功後だけ別release jobへ`contents: write`を付与する。
-4. build jobの検証済みartifactをrelease jobへ渡す。
-5. rolling tag `chatgpt-worker-skills-latest`をmerge後HEADへ更新する。
-6. Release `ChatGPT Worker Skills`へ`chatgpt-worker-skills.zip`を添付または置換する。
+1. `pull_request.closed`かつ`merged == true`の場合だけ実行する。未merge closeでは実行しない。
+2. `merge_commit_sha`をcheckoutし、PR validationと同じread-only validation／buildを再実行する。
+3. build成功後だけpublish jobへ`contents: write`を付与する。
+4. build jobの検証済みartifactをpublish jobへ渡す。
+5. tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する。
+6. `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成し、`chatgpt-worker-skills.zip`をAssetへ添付する。
+7. job再実行時は同じPR tag／Pre-releaseを更新し、同名Assetを置換する。
+8. この自動Pre-releaseの`release.published`イベントでは再build／再uploadしない。
 
-PR branchと`workflow_dispatch`ではReleaseを更新しない。
+### 手動Release／Pre-release
+
+1. GitHub UIまたはAPIでRelease／Pre-releaseを公開した`release.published`イベントで実行する。
+2. Release tagが指すcommitをcheckoutし、repository validationとZIP buildを実行する。
+3. build成功後だけupload jobへ`contents: write`を付与する。
+4. 検証済み`chatgpt-worker-skills.zip`を、公開された同じReleaseのAssetへ添付する。
+5. 同名Assetが存在する場合は置換する。
+6. 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は二重処理防止のため対象外とする。
+
+`workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
 
 Release時の共通file複製とrepository相対linkの書換は行わない。
 
@@ -412,7 +423,8 @@ core Skillとwrapperはいずれもmergeを行わず、利用者がmerge判断�
 - ChatGPT wrapperがruntime固有責務だけを持つ
 - wrapperとcore SkillがSkill外`shared/`fileへ依存していない
 - wrapperと必須core Skillを単一ZIPで登録できる構造になっている
-- merge後にRelease assetが生成される
+- PRマージ時にPR単位のPre-releaseへZIP Assetが生成される
+- 手動Release／Pre-release公開時に同じReleaseへZIP Assetが追加される
 - ChatGPTとCodexの双方で同じreview lifecycleを使用する
 - initial reviewとfix verificationがnormal reviewer continuityを維持する
 - pre-freeze gateがSkill decision、feedback ledger、normal handoff、report、trackingを含む

--- a/design/chat-worker-skill-design.md
+++ b/design/chat-worker-skill-design.md
@@ -182,6 +182,15 @@ chatgpt-worker-skills.zip
 10. 生成ZIPをworkflow artifactとして保存する。
 11. GitHub Releaseは更新しない。
 
+### Rolling normal Release
+
+1. 対象変更が`main`へpushされた場合に実行する。
+2. push後の`main` HEADをcheckoutし、PR validationと同じread-only validation／buildを実行する。
+3. build成功後だけpublish jobへ`contents: write`を付与する。
+4. build jobの検証済みartifactをpublish jobへ渡す。
+5. rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する。
+6. 固定通常Release `ChatGPT Worker Skills`を作成または更新し、`chatgpt-worker-skills.zip`をAssetへ添付または置換する。
+
 ### PR merge Pre-release
 
 1. `pull_request.closed`かつ`merged == true`の場合だけ実行する。未merge closeでは実行しない。
@@ -195,12 +204,13 @@ chatgpt-worker-skills.zip
 
 ### 手動Release／Pre-release
 
-1. GitHub UIまたはAPIでRelease／Pre-releaseを公開した`release.published`イベントで実行する。
+1. 利用者がGitHub UIまたはAPIでRelease／Pre-releaseを公開した`release.published`イベントで実行する。
 2. Release tagが指すcommitをcheckoutし、repository validationとZIP buildを実行する。
 3. build成功後だけupload jobへ`contents: write`を付与する。
 4. 検証済み`chatgpt-worker-skills.zip`を、公開された同じReleaseのAssetへ添付する。
 5. 同名Assetが存在する場合は置換する。
 6. 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は二重処理防止のため対象外とする。
+7. Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない。
 
 `workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
 
@@ -423,6 +433,7 @@ core Skillとwrapperはいずれもmergeを行わず、利用者がmerge判断�
 - ChatGPT wrapperがruntime固有責務だけを持つ
 - wrapperとcore SkillがSkill外`shared/`fileへ依存していない
 - wrapperと必須core Skillを単一ZIPで登録できる構造になっている
+- mainへの対象変更反映時に固定通常Release `chatgpt-worker-skills-latest`へZIP Assetが生成または更新される
 - PRマージ時にPR単位のPre-releaseへZIP Assetが生成される
 - 手動Release／Pre-release公開時に同じReleaseへZIP Assetが追加される
 - ChatGPTとCodexの双方で同じreview lifecycleを使用する

--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -335,27 +335,40 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 
 `.github/workflows/release-chatgpt-worker-skills.yml`を使用する。
 
-### pull request
+### pull request validation
 
 - `AGENTS.md`、`README.md`、全Skill、`shared/**`、design、tasks、reports、builder、repository validator、workflowの変更で実行する
-- forbidden shared runtime pathだけを追加する変更でも、PRとmain pushの両方でvalidation workflowを起動する
+- forbidden shared runtime pathだけを追加する変更でもvalidation workflowを起動する
+- `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
 - build jobは`contents: read`だけを持ち、checkout credentialを保持しない
-- PRのsynthetic merge SHAではなく実PR HEAD SHAをcheckoutする
 - `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
 - 全`chat-*` wrapperと必須core Skillを検出する
 - missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
 - 単一`chatgpt-worker-skills.zip`を作成する
 - ZIP rootが検出Skill集合と一致することを確認する
 - ZIPをworkflow artifactとして保存する
-- rolling tagとGitHub Releaseは更新しない
+- GitHub Releaseは更新しない
 
-### main push
+### PR merge Pre-release
 
-- merge後のmain HEADでread-only validation／build jobを実行する
-- build成功後だけ別release jobへ`contents: write`を付与する
-- build jobの検証済みartifactをrelease jobへ渡す
-- rolling tag `chatgpt-worker-skills-latest`をmerge後HEADへ更新する
-- GitHub Release `ChatGPT Worker Skills`へZIPを添付または置換する
+- `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
+- `merge_commit_sha`でread-only validation／build jobを再実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する
+- `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成する
+- Pre-releaseへ`chatgpt-worker-skills.zip`を添付する
+- job再実行時は同じPR tag／Pre-releaseとAssetを更新する
+- 自動Pre-releaseの`release.published`イベントはtag prefixで除外し、二重build／uploadしない
+
+### 手動Release／Pre-release
+
+- GitHub UIまたはAPIで公開した`release.published`イベントで実行する
+- Release tagが指すcommitでread-only validation／build jobを実行する
+- build成功後だけ別upload jobへ`contents: write`を付与する
+- build jobの検証済みZIPを、公開された同じReleaseへ添付する
+- 同名Assetがある場合は置換する
+- 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
 
 `workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
 

--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -349,6 +349,15 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 - ZIPをworkflow artifactとして保存する
 - GitHub Releaseは更新しない
 
+### Rolling normal Release
+
+- 対象変更が`main`へpushされた場合に実行する
+- push後の`main` HEADでread-only validation／build jobを実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する
+- 固定通常Release `ChatGPT Worker Skills`へZIPを添付または置換する
+
 ### PR merge Pre-release
 
 - `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
@@ -363,12 +372,13 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 
 ### 手動Release／Pre-release
 
-- GitHub UIまたはAPIで公開した`release.published`イベントで実行する
+- 利用者がGitHub UIまたはAPIで公開した`release.published`イベントで実行する
 - Release tagが指すcommitでread-only validation／build jobを実行する
 - build成功後だけ別upload jobへ`contents: write`を付与する
 - build jobの検証済みZIPを、公開された同じReleaseへ添付する
 - 同名Assetがある場合は置換する
 - 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
+- Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない
 
 `workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
 

--- a/reports/pr-55-release-asset-automation-20260730095800.md
+++ b/reports/pr-55-release-asset-automation-20260730095800.md
@@ -1,0 +1,102 @@
+# PR #55 ChatGPT Skill ZIP Release Automation Report
+
+## Summary
+
+PR #55で、ChatGPT worker Skill ZIPの配布契機を次の3経路へ分離した。
+
+1. PR作業中はread-only validation／buildとworkflow artifact生成だけを行う。
+2. PRがmergeされた場合、PR番号単位のGitHub Pre-releaseを自動作成し、`chatgpt-worker-skills.zip`をAssetへ添付する。
+3. 利用者がGitHub ReleaseまたはPre-releaseを手動公開した場合、そのtagが指すcommitからZIPを生成し、同じReleaseへAssetとして添付する。
+
+既存のrolling tag `chatgpt-worker-skills-latest`と固定通常Releaseの自動更新は廃止した。
+
+## Scope
+
+### Changed files
+
+- `.github/workflows/release-chatgpt-worker-skills.yml`
+- `design/chat-worker-skill-design.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+
+### Workflow behavior
+
+#### PR validation
+
+- `pull_request`の`opened`、`synchronize`、`reopened`で実PR HEADをcheckoutする。
+- repository validatorとChatGPT Skill ZIP buildを実行する。
+- ZIPをworkflow artifactとして保存する。
+- Releaseは変更しない。
+
+#### PR merge Pre-release
+
+- `pull_request.closed`かつ`merged == true`の場合だけ実行する。
+- `merge_commit_sha`でvalidatorとZIP buildを再実行する。
+- tag `chatgpt-worker-skills-pr-<PR番号>`を使用する。
+- `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成する。
+- `chatgpt-worker-skills.zip`をPre-release Assetとして添付する。
+- 再実行時は同じReleaseと同名Assetを更新する。
+
+#### Manual Release asset
+
+- `release.published`で対象tagのcommitをcheckoutする。
+- validatorとZIP buildを実行する。
+- 公開された同じRelease／Pre-releaseへZIPを添付する。
+- 同名Assetは置換する。
+- 自動PR merge Pre-releaseのtag prefixは二重処理を防ぐため除外する。
+
+## Design synchronization
+
+- `design/chat-worker-skill-design.md`のRelease生成節と完了条件を更新した。
+- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`は同一blob SHA `65a8fd7f33cb0ce2f067e9c93eca0fd323c5d8bf`へ同期した。
+- Release時に共通fileを複製せず、repository相対linkを書き換えない既存方針は維持した。
+- Project Instruction例、review lifecycle、handoff、Merge境界などRelease変更と無関係な既存節は維持した。
+
+## Validation
+
+### Current verified implementation HEAD
+
+```text
+77016ce8164cd804d72ed0b8e5a0d656b234be64
+```
+
+### GitHub Actions
+
+- Workflow: `Validate and release ChatGPT worker skills`
+- Run ID: `30504279374`
+- Run number: `131`
+- Head SHA: `77016ce8164cd804d72ed0b8e5a0d656b234be64`
+- Conclusion: `success`
+
+Successful build steps:
+
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
+
+PR作業中のため、次のpublish jobは設計どおり`skipped`だった。
+
+- `publish-merge-prerelease`
+- `attach-published-release-asset`
+
+### Artifact
+
+- Artifact ID: `8744689225`
+- Name: `chatgpt-worker-skills-77016ce8164cd804d72ed0b8e5a0d656b234be64`
+- Size: `15586` bytes
+- Digest: `sha256:c0bf732d960050ded0feb7cbf361d22f9ca6ecbf0062a4a9e49fc1322b213ee4`
+
+## Event-specific verification boundary
+
+PR merge Pre-release jobは実際のmerge後にだけ実行される。手動Release asset jobは実際の`release.published`イベント後にだけ実行される。そのため、PR #55をmergeしていない現在時点では、GitHub Releaseの作成およびRelease Asset uploadの実行結果は未確認である。
+
+ただし、Workflow YAMLの構文、PR eventでの条件評価、repository validator、ZIP build、artifact uploadはcurrent HEAD固有runで成功している。
+
+## Testing policy
+
+CodexSkill repositoryの`AGENTS.md`に従い、TDDとこの変更専用のRed／Green testは実施していない。既存repository validator、package build、ZIP構造確認、設計同期、Workflow event条件の差分reviewを検証に使用した。
+
+## Merge boundary
+
+mergeは実施していない。利用者がPR #55のmerge判断と実行を所有する。

--- a/reports/pr-55-release-asset-automation-20260730095800.md
+++ b/reports/pr-55-release-asset-automation-20260730095800.md
@@ -67,36 +67,18 @@ PR #55で、ChatGPT worker Skill ZIPの配布を次の4経路へ整理した。
 ### Current verified implementation HEAD
 
 ```text
-9b89b487e077a91707f3b07859447d90292c905a
+55475a40be92e380a376e7d6f0fba9d5d8817e7d
 ```
 
 ### GitHub Actions
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `30577431643`
-- Run number: `135`
-- Head SHA: `9b89b487e077a91707f3b07859447d90292c905a`
+- Run ID: `30577567713`
+- Run number: `136`
+- Head SHA: `55475a40be92e380a376e7d6f0fba9d5d8817e7d`
 - Conclusion: `success`
 
-Successful build steps:
-
-- Checkout target HEAD without write credentials
-- Validate repository Skill architecture and active links
-- Build and verify ChatGPT wrapper and core Skill ZIP
-- Upload validation artifact
-
-PR作業中のため、次のpublish jobは設計どおり`skipped`だった。
-
-- `publish-rolling-release`
-- `publish-merge-prerelease`
-- `attach-published-release-asset`
-
-### Artifact
-
-- Artifact ID: `8773247546`
-- Name: `chatgpt-worker-skills-30577431643`
-- Size: `15586` bytes
-- Digest: `sha256:3b465c5b7a04a0a96e52b7a1607edf5da9d2ee8102b451d7403423625841c6b5`
+PR作業中のため、publish jobは設計どおり`skipped`となる。build jobではrepository validator、ZIP build、workflow artifact uploadが成功した。
 
 ## Event-specific verification boundary
 

--- a/reports/pr-55-release-asset-automation-20260730095800.md
+++ b/reports/pr-55-release-asset-automation-20260730095800.md
@@ -67,15 +67,15 @@ PR #55で、ChatGPT worker Skill ZIPの配布を次の4経路へ整理した。
 ### Current verified implementation HEAD
 
 ```text
-3e26d9ba742cce20611e64ba1cda62224ef00536
+9b89b487e077a91707f3b07859447d90292c905a
 ```
 
 ### GitHub Actions
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `30577297119`
-- Run number: `134`
-- Head SHA: `3e26d9ba742cce20611e64ba1cda62224ef00536`
+- Run ID: `30577431643`
+- Run number: `135`
+- Head SHA: `9b89b487e077a91707f3b07859447d90292c905a`
 - Conclusion: `success`
 
 Successful build steps:
@@ -93,16 +93,18 @@ PR作業中のため、次のpublish jobは設計どおり`skipped`だった。
 
 ### Artifact
 
-- Artifact ID: `8773195277`
-- Name: `chatgpt-worker-skills-30577297119`
+- Artifact ID: `8773247546`
+- Name: `chatgpt-worker-skills-30577431643`
 - Size: `15586` bytes
-- Digest: `sha256:68cd0cab12de33e4dcbac15ae390ce88260d12d7dc20d86800e1667fa3952f9a`
+- Digest: `sha256:3b465c5b7a04a0a96e52b7a1607edf5da9d2ee8102b451d7403423625841c6b5`
 
 ## Event-specific verification boundary
 
 PR merge Pre-release jobは実際のmerge後にだけ実行される。rolling通常Release jobは`main` push後にだけ実行される。手動Release asset jobは利用者による実際の`release.published`イベント後にだけ実行される。
 
 PR #55をmergeしていない現在時点では、rolling通常Release更新、PR単位Pre-release作成、手動ReleaseへのAsset uploadの実行結果は未確認である。
+
+PR #55のWorkflowがmainへ反映される前に公開済みだったReleaseには遡ってAssetを添付しない。main反映後に新しく公開されるRelease／Pre-releaseが自動添付の対象になる。
 
 ただし、Workflow YAML、PR eventでの条件評価、repository validator、ZIP build、run ID基準のartifact受け渡しはcurrent HEAD固有runで成功している。
 

--- a/reports/pr-55-release-asset-automation-20260730095800.md
+++ b/reports/pr-55-release-asset-automation-20260730095800.md
@@ -2,13 +2,14 @@
 
 ## Summary
 
-PR #55で、ChatGPT worker Skill ZIPの配布契機を次の3経路へ分離した。
+PR #55で、ChatGPT worker Skill ZIPの配布を次の4経路へ整理した。
 
 1. PR作業中はread-only validation／buildとworkflow artifact生成だけを行う。
-2. PRがmergeされた場合、PR番号単位のGitHub Pre-releaseを自動作成し、`chatgpt-worker-skills.zip`をAssetへ添付する。
-3. 利用者がGitHub ReleaseまたはPre-releaseを手動公開した場合、そのtagが指すcommitからZIPを生成し、同じReleaseへAssetとして添付する。
+2. 対象変更が`main`へpushされた場合、既存のrolling tag `chatgpt-worker-skills-latest`と固定通常Releaseを更新し、ZIP Assetを添付または置換する。
+3. PRがmergeされた場合、PR番号単位のGitHub Pre-releaseを自動作成し、`chatgpt-worker-skills.zip`をAssetへ添付する。
+4. 利用者がGitHub ReleaseまたはPre-releaseを手動公開した場合、そのtagが指すcommitからZIPを生成し、同じReleaseへAssetとして添付する。
 
-既存のrolling tag `chatgpt-worker-skills-latest`と固定通常Releaseの自動更新は廃止した。
+固定通常Release、PR単位Pre-release、手動ReleaseへのAsset添付は併存する。
 
 ## Scope
 
@@ -28,6 +29,14 @@ PR #55で、ChatGPT worker Skill ZIPの配布契機を次の3経路へ分離し�
 - ZIPをworkflow artifactとして保存する。
 - Releaseは変更しない。
 
+#### Rolling normal Release
+
+- 対象変更の`main` pushで実行する。
+- merge後の`main` HEADでvalidatorとZIP buildを実行する。
+- rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する。
+- 固定通常Release `ChatGPT Worker Skills`を作成または更新する。
+- `chatgpt-worker-skills.zip`をAssetとして添付または置換する。
+
 #### PR merge Pre-release
 
 - `pull_request.closed`かつ`merged == true`の場合だけ実行する。
@@ -39,59 +48,53 @@ PR #55で、ChatGPT worker Skill ZIPの配布契機を次の3経路へ分離し�
 
 #### Manual Release asset
 
-- `release.published`で対象tagのcommitをcheckoutする。
+- 利用者による`release.published`で対象tagのcommitをcheckoutする。
 - validatorとZIP buildを実行する。
 - 公開された同じRelease／Pre-releaseへZIPを添付する。
 - 同名Assetは置換する。
 - 自動PR merge Pre-releaseのtag prefixは二重処理を防ぐため除外する。
+- Workflowが`GITHUB_TOKEN`で作成・更新したReleaseイベントはGitHub Actionsを再帰起動しないため、rolling通常Releaseと自動Pre-releaseの作成から手動Release添付jobが重複実行されない。
 
 ## Design synchronization
 
-- `design/chat-worker-skill-design.md`のRelease生成節と完了条件を更新した。
-- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`は同一blob SHA `65a8fd7f33cb0ce2f067e9c93eca0fd323c5d8bf`へ同期した。
-- Release時に共通fileを複製せず、repository相対linkを書き換えない既存方針は維持した。
-- Project Instruction例、review lifecycle、handoff、Merge境界などRelease変更と無関係な既存節は維持した。
+- `design/chat-worker-skill-design.md`のRelease生成節と完了条件を更新対象とする。
+- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`は同一内容を維持する。
+- Release時に共通fileを複製せず、repository相対linkを書き換えない既存方針は維持する。
+- Project Instruction例、review lifecycle、handoff、Merge境界などRelease変更と無関係な既存節は維持する。
 
 ## Validation
 
-### Current verified implementation HEAD
+### Previous verified implementation HEAD
 
 ```text
-77016ce8164cd804d72ed0b8e5a0d656b234be64
+5a10890c9b99e458855be9def245604c154209aa
 ```
 
-### GitHub Actions
+### Previous GitHub Actions evidence
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `30504279374`
-- Run number: `131`
-- Head SHA: `77016ce8164cd804d72ed0b8e5a0d656b234be64`
+- Run ID: `30504399327`
+- Run number: `132`
+- Head SHA: `5a10890c9b99e458855be9def245604c154209aa`
 - Conclusion: `success`
+- Repository validator: `success`
+- ZIP build: `success`
+- Artifact upload: `success`
 
-Successful build steps:
+PR作業中のため、publish jobは設計どおり`skipped`だった。
 
-- Checkout target HEAD without write credentials
-- Validate repository Skill architecture and active links
-- Build and verify ChatGPT wrapper and core Skill ZIP
-- Upload validation artifact
+### Current correction
 
-PR作業中のため、次のpublish jobは設計どおり`skipped`だった。
-
-- `publish-merge-prerelease`
-- `attach-published-release-asset`
-
-### Artifact
-
-- Artifact ID: `8744689225`
-- Name: `chatgpt-worker-skills-77016ce8164cd804d72ed0b8e5a0d656b234be64`
-- Size: `15586` bytes
-- Digest: `sha256:c0bf732d960050ded0feb7cbf361d22f9ca6ecbf0062a4a9e49fc1322b213ee4`
+- fixed rolling normal Releaseの自動更新を廃止せず、`publish-rolling-release` jobとして復元した。
+- Artifact名をrun ID基準へ変更し、同一run内のbuild jobと各publish jobが確実に同じ検証済みZIPを受け渡すようにした。
+- `release.published`ではRelease tagを明示的なcheckout refとして使用する。
+- current correction HEAD固有のCI evidenceは、Workflow run完了後にPR body／commentへ記録する。
 
 ## Event-specific verification boundary
 
-PR merge Pre-release jobは実際のmerge後にだけ実行される。手動Release asset jobは実際の`release.published`イベント後にだけ実行される。そのため、PR #55をmergeしていない現在時点では、GitHub Releaseの作成およびRelease Asset uploadの実行結果は未確認である。
+PR merge Pre-release jobは実際のmerge後にだけ実行される。rolling通常Release jobは`main` push後にだけ実行される。手動Release asset jobは利用者による実際の`release.published`イベント後にだけ実行される。
 
-ただし、Workflow YAMLの構文、PR eventでの条件評価、repository validator、ZIP build、artifact uploadはcurrent HEAD固有runで成功している。
+PR #55をmergeしていない現在時点では、rolling通常Release更新、PR単位Pre-release作成、手動ReleaseへのAsset uploadの実行結果は未確認である。
 
 ## Testing policy
 

--- a/reports/pr-55-release-asset-automation-20260730095800.md
+++ b/reports/pr-55-release-asset-automation-20260730095800.md
@@ -64,37 +64,47 @@ PR #55で、ChatGPT worker Skill ZIPの配布を次の4経路へ整理した。
 
 ## Validation
 
-### Previous verified implementation HEAD
+### Current verified implementation HEAD
 
 ```text
-5a10890c9b99e458855be9def245604c154209aa
+3e26d9ba742cce20611e64ba1cda62224ef00536
 ```
 
-### Previous GitHub Actions evidence
+### GitHub Actions
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `30504399327`
-- Run number: `132`
-- Head SHA: `5a10890c9b99e458855be9def245604c154209aa`
+- Run ID: `30577297119`
+- Run number: `134`
+- Head SHA: `3e26d9ba742cce20611e64ba1cda62224ef00536`
 - Conclusion: `success`
-- Repository validator: `success`
-- ZIP build: `success`
-- Artifact upload: `success`
 
-PR作業中のため、publish jobは設計どおり`skipped`だった。
+Successful build steps:
 
-### Current correction
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
 
-- fixed rolling normal Releaseの自動更新を廃止せず、`publish-rolling-release` jobとして復元した。
-- Artifact名をrun ID基準へ変更し、同一run内のbuild jobと各publish jobが確実に同じ検証済みZIPを受け渡すようにした。
-- `release.published`ではRelease tagを明示的なcheckout refとして使用する。
-- current correction HEAD固有のCI evidenceは、Workflow run完了後にPR body／commentへ記録する。
+PR作業中のため、次のpublish jobは設計どおり`skipped`だった。
+
+- `publish-rolling-release`
+- `publish-merge-prerelease`
+- `attach-published-release-asset`
+
+### Artifact
+
+- Artifact ID: `8773195277`
+- Name: `chatgpt-worker-skills-30577297119`
+- Size: `15586` bytes
+- Digest: `sha256:68cd0cab12de33e4dcbac15ae390ce88260d12d7dc20d86800e1667fa3952f9a`
 
 ## Event-specific verification boundary
 
 PR merge Pre-release jobは実際のmerge後にだけ実行される。rolling通常Release jobは`main` push後にだけ実行される。手動Release asset jobは利用者による実際の`release.published`イベント後にだけ実行される。
 
 PR #55をmergeしていない現在時点では、rolling通常Release更新、PR単位Pre-release作成、手動ReleaseへのAsset uploadの実行結果は未確認である。
+
+ただし、Workflow YAML、PR eventでの条件評価、repository validator、ZIP build、run ID基準のartifact受け渡しはcurrent HEAD固有runで成功している。
 
 ## Testing policy
 

--- a/reports/pr-55-release-asset-automation-20260730095800.md
+++ b/reports/pr-55-release-asset-automation-20260730095800.md
@@ -57,28 +57,42 @@ PR #55で、ChatGPT worker Skill ZIPの配布を次の4経路へ整理した。
 
 ## Design synchronization
 
-- `design/chat-worker-skill-design.md`のRelease生成節と完了条件を更新対象とする。
-- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`は同一内容を維持する。
-- Release時に共通fileを複製せず、repository相対linkを書き換えない既存方針は維持する。
-- Project Instruction例、review lifecycle、handoff、Merge境界などRelease変更と無関係な既存節は維持する。
+- `design/chat-worker-skill-design.md`のRelease生成節と完了条件へ4経路の併存を反映した。
+- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同一blob SHA `58062a701366b49cfd0870032fa5608be5bd1ec8`へ同期した。
+- Release時に共通fileを複製せず、repository相対linkを書き換えない既存方針は維持した。
+- Project Instruction例、review lifecycle、handoff、Merge境界などRelease変更と無関係な既存節は維持した。
 
 ## Validation
 
-### Current verified implementation HEAD
+### Verified implementation HEAD
 
 ```text
-55475a40be92e380a376e7d6f0fba9d5d8817e7d
+c8e89817fa6216ea773cb8493f0dfc9d9033f00e
 ```
 
 ### GitHub Actions
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `30577567713`
-- Run number: `136`
-- Head SHA: `55475a40be92e380a376e7d6f0fba9d5d8817e7d`
+- Run ID: `30577982738`
+- Run number: `140`
+- Head SHA: `c8e89817fa6216ea773cb8493f0dfc9d9033f00e`
 - Conclusion: `success`
+- Repository validator: `success`
+- ZIP build: `success`
+- Artifact upload: `success`
 
-PR作業中のため、publish jobは設計どおり`skipped`となる。build jobではrepository validator、ZIP build、workflow artifact uploadが成功した。
+PR作業中のため、次のpublish jobは設計どおり`skipped`だった。
+
+- `publish-rolling-release`
+- `publish-merge-prerelease`
+- `attach-published-release-asset`
+
+### Artifact
+
+- Artifact ID: `8773453993`
+- Name: `chatgpt-worker-skills-30577982738`
+- Size: `15586` bytes
+- Digest: `sha256:b448df10a3eccdb9deb4d6753a5da8474eef5e09d6530a72954081e3ce003be8`
 
 ## Event-specific verification boundary
 
@@ -88,7 +102,7 @@ PR #55をmergeしていない現在時点では、rolling通常Release更新、P
 
 PR #55のWorkflowがmainへ反映される前に公開済みだったReleaseには遡ってAssetを添付しない。main反映後に新しく公開されるRelease／Pre-releaseが自動添付の対象になる。
 
-ただし、Workflow YAML、PR eventでの条件評価、repository validator、ZIP build、run ID基準のartifact受け渡しはcurrent HEAD固有runで成功している。
+ただし、Workflow YAML、PR eventでの条件評価、repository validator、ZIP build、run ID基準のartifact受け渡し、設計書同期はimplementation HEAD固有runで成功している。
 
 ## Testing policy
 

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -335,27 +335,40 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 
 `.github/workflows/release-chatgpt-worker-skills.yml`を使用する。
 
-### pull request
+### pull request validation
 
 - `AGENTS.md`、`README.md`、全Skill、`shared/**`、design、tasks、reports、builder、repository validator、workflowの変更で実行する
-- forbidden shared runtime pathだけを追加する変更でも、PRとmain pushの両方でvalidation workflowを起動する
+- forbidden shared runtime pathだけを追加する変更でもvalidation workflowを起動する
+- `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
 - build jobは`contents: read`だけを持ち、checkout credentialを保持しない
-- PRのsynthetic merge SHAではなく実PR HEAD SHAをcheckoutする
 - `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
 - 全`chat-*` wrapperと必須core Skillを検出する
 - missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
 - 単一`chatgpt-worker-skills.zip`を作成する
 - ZIP rootが検出Skill集合と一致することを確認する
 - ZIPをworkflow artifactとして保存する
-- rolling tagとGitHub Releaseは更新しない
+- GitHub Releaseは更新しない
 
-### main push
+### PR merge Pre-release
 
-- merge後のmain HEADでread-only validation／build jobを実行する
-- build成功後だけ別release jobへ`contents: write`を付与する
-- build jobの検証済みartifactをrelease jobへ渡す
-- rolling tag `chatgpt-worker-skills-latest`をmerge後HEADへ更新する
-- GitHub Release `ChatGPT Worker Skills`へZIPを添付または置換する
+- `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
+- `merge_commit_sha`でread-only validation／build jobを再実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する
+- `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成する
+- Pre-releaseへ`chatgpt-worker-skills.zip`を添付する
+- job再実行時は同じPR tag／Pre-releaseとAssetを更新する
+- 自動Pre-releaseの`release.published`イベントはtag prefixで除外し、二重build／uploadしない
+
+### 手動Release／Pre-release
+
+- GitHub UIまたはAPIで公開した`release.published`イベントで実行する
+- Release tagが指すcommitでread-only validation／build jobを実行する
+- build成功後だけ別upload jobへ`contents: write`を付与する
+- build jobの検証済みZIPを、公開された同じReleaseへ添付する
+- 同名Assetがある場合は置換する
+- 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
 
 `workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
 

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -349,6 +349,15 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 - ZIPをworkflow artifactとして保存する
 - GitHub Releaseは更新しない
 
+### Rolling normal Release
+
+- 対象変更が`main`へpushされた場合に実行する
+- push後の`main` HEADでread-only validation／build jobを実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する
+- 固定通常Release `ChatGPT Worker Skills`へZIPを添付または置換する
+
 ### PR merge Pre-release
 
 - `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
@@ -363,12 +372,13 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 
 ### 手動Release／Pre-release
 
-- GitHub UIまたはAPIで公開した`release.published`イベントで実行する
+- 利用者がGitHub UIまたはAPIで公開した`release.published`イベントで実行する
 - Release tagが指すcommitでread-only validation／build jobを実行する
 - build成功後だけ別upload jobへ`contents: write`を付与する
 - build jobの検証済みZIPを、公開された同じReleaseへ添付する
 - 同名Assetがある場合は置換する
 - 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
+- Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない
 
 `workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
 


### PR DESCRIPTION
## 概要

ChatGPT worker Skill ZIPの配布を次の4経路で併存させます。

- PR作業中: validationとworkflow artifact生成のみ
- `main`への対象変更反映時: 既存の固定通常Release `chatgpt-worker-skills-latest`を更新
- 同じ`main` push時: 最新安定版SemVer tagを基準にPATCHを進めた新しい`x.y.z-pre` Pre-releaseを作成
- 利用者による手動Release／Pre-release公開時: 対象tagが指すcommitからZIPを生成し、そのReleaseへ自動添付

## Pre-release採番

SSCの`.github/workflows/publish-nuget.yml`を参考にしています。

- 最新の安定版tagだけを基準にする（`v1.1.0`または`1.1.0`）
- 最新安定版tagから`HEAD`までのcommit数をPATCHへ加算する
- スカッシュマージ運用では、`1.1.0`後の1回目が`1.1.1-pre`、2回目が`1.1.2-pre`
- 毎回新しいtag／Pre-releaseを作成し、既存Pre-releaseを上書きしない
- Pre-releaseへ添付するZIPは、そのマージ後の最新`main` HEADから同じWorkflow runで生成したもの
- 前回安定版のZIPやAssetは流用しない

## Rolling normal Release

- rolling tag `chatgpt-worker-skills-latest`を最新`main` HEADへ更新
- 固定通常Release `ChatGPT Worker Skills`を作成または更新
- 最新`main` HEADから生成した`chatgpt-worker-skills.zip`をAssetとして添付または置換

## 手動Release／Pre-release

- 利用者による`release.published`で対象tagのcommitをvalidation／build
- 公開された同じReleaseへ、そのtagのcommitから生成したZIPを自動添付
- 同名Assetは置換

## Report

`reports/pr-55-release-asset-automation-20260730095800.md`

CodexSkill repository自身にはTDDを適用していません。mergeは利用者が行います。