### PR TITLE
SSC方式でPre-releaseタグをPATCHインクリメント

### DIFF
--- a/.github/workflows/release-chatgpt-worker-skills.yml
+++ b/.github/workflows/release-chatgpt-worker-skills.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - closed
     paths:
       - "AGENTS.md"
       - "README.md"
@@ -46,18 +45,8 @@ concurrency:
 
 jobs:
   build:
-    if: >-
-      !(
-        github.event_name == 'pull_request' &&
-        github.event.action == 'closed' &&
-        github.event.pull_request.merged != true
-      ) &&
-      !(
-        github.event_name == 'release' &&
-        startsWith(github.event.release.tag_name, 'chatgpt-worker-skills-pr-')
-      )
     env:
-      TARGET_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merge_commit_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      TARGET_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target HEAD without write credentials
@@ -144,23 +133,58 @@ jobs:
             release-dist/chatgpt-worker-skills.zip \
             --clobber
 
-  publish-merge-prerelease:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.action == 'closed' &&
-      github.event.pull_request.merged == true
+  publish-versioned-prerelease:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     permissions:
       contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
-      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      PR_URL: ${{ github.event.pull_request.html_url }}
-      TAG: chatgpt-worker-skills-pr-${{ github.event.pull_request.number }}
     steps:
+      - name: Checkout merged main HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Resolve incremented prerelease tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_stable_tag=$(git tag --sort=-v:refname | grep -E '^(v)?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+          if [[ -n "${latest_stable_tag}" ]]; then
+            base_version="${latest_stable_tag#v}"
+            commits_since_base=$(git rev-list --count "${latest_stable_tag}..HEAD")
+          else
+            base_version="0.1.0"
+            commits_since_base=$(git rev-list --count HEAD)
+          fi
+
+          if [[ ! "${base_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid base version format: ${base_version}"
+            exit 1
+          fi
+
+          IFS='.' read -r major minor patch <<< "${base_version}"
+          if [[ "${commits_since_base}" -lt 1 ]]; then
+            commits_since_base=1
+          fi
+
+          next_patch=$((patch + commits_since_base))
+          prerelease_tag="${major}.${minor}.${next_patch}-pre"
+
+          if git rev-parse -q --verify "refs/tags/${prerelease_tag}" >/dev/null; then
+            echo "Pre-release tag already exists: ${prerelease_tag}"
+            exit 1
+          fi
+
+          echo "tag=${prerelease_tag}" >> "${GITHUB_OUTPUT}"
+
       - name: Download validated ChatGPT Skill ZIP
         uses: actions/download-artifact@v4
         with:
@@ -174,38 +198,39 @@ jobs:
           test -f release-dist/chatgpt-worker-skills.zip
           python3 -m zipfile -l release-dist/chatgpt-worker-skills.zip
 
-      - name: Publish PR merge prerelease
+      - name: Publish incremented GitHub Pre-release
         shell: bash
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          notes="Automatic ChatGPT Worker Skills prerelease for merged PR #${PR_NUMBER}. Source PR: ${PR_URL}. Source commit: ${MERGE_SHA}. Repository validation and package structure verification passed."
-          title="ChatGPT Worker Skills PR #${PR_NUMBER}"
 
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release edit "${TAG}" \
-              --target "${MERGE_SHA}" \
-              --title "${title}" \
-              --notes "${notes}" \
-              --prerelease
-            gh release upload \
-              "${TAG}" \
-              release-dist/chatgpt-worker-skills.zip \
-              --clobber
-          else
-            gh release create \
-              "${TAG}" \
-              release-dist/chatgpt-worker-skills.zip \
-              --target "${MERGE_SHA}" \
-              --title "${title}" \
-              --notes "${notes}" \
-              --prerelease \
-              --latest=false
-          fi
+          notes_file=$(mktemp)
+          {
+            echo "Automated ChatGPT Worker Skills pre-release from main push."
+            echo
+            echo "Source commit: ${GITHUB_SHA}"
+            pr_numbers=$(gh api -H "Accept: application/vnd.github+json" "/repos/${GH_REPO}/commits/${GITHUB_SHA}/pulls" --jq '.[].number' 2>/dev/null || true)
+            if [[ -n "${pr_numbers}" ]]; then
+              echo
+              echo "Related pull requests:"
+              while IFS= read -r pr; do
+                [[ -z "${pr}" ]] && continue
+                echo "- #${pr}"
+              done <<< "${pr_numbers}"
+            fi
+          } > "${notes_file}"
+
+          gh release create "${TAG}" \
+            release-dist/chatgpt-worker-skills.zip \
+            --target "${GITHUB_SHA}" \
+            --title "${TAG}" \
+            --notes-file "${notes_file}" \
+            --prerelease \
+            --latest=false
 
   attach-published-release-asset:
-    if: >-
-      github.event_name == 'release' &&
-      !startsWith(github.event.release.tag_name, 'chatgpt-worker-skills-pr-')
+    if: github.event_name == 'release'
     needs: build
     permissions:
       contents: write


### PR DESCRIPTION
## 概要

SSCの`.github/workflows/publish-nuget.yml`を参考に、`main`へのスカッシュマージごとに新しいSemVer Pre-releaseを作成します。

## 採番

- 最新の安定版tagのみを基準にする（例: `1.1.0`）
- 最新安定版tagから最新`main` HEADまでのcommit数をPATCHへ加算する
- `1.1.0`後の1回目のスカッシュマージ: `1.1.1-pre`
- 2回目: `1.1.2-pre`
- 既存Pre-release tagやReleaseは上書きしない

## 添付するZIP

Pre-releaseへ添付するのは、前回安定版のZIPではありません。

そのスカッシュマージ後の最新`main` HEADから、同じWorkflow runで新しく生成した`chatgpt-worker-skills.zip`を添付します。

## 維持する動作

- 固定通常Release `chatgpt-worker-skills-latest`の更新
- 利用者が公開した手動Release／Pre-releaseへのZIP自動添付
- PR作業中のread-only validationとworkflow artifact生成

mergeは利用者が行います。