### PR TITLE
Issue #59: ChatGPT配布ZIPへtask更新Skillを追加

### DIFF
--- a/design/chat-worker-skill-design.md
+++ b/design/chat-worker-skill-design.md
@@ -4,11 +4,13 @@
 
 利用者が親として複数のChatGPT chatを起動し、実装、レビュー、レポート作成を独立したworker Skillへ割り当てる構成を定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillへ置き、ChatGPT側はruntime固有wrapperからそれらを呼び出す。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillへ置き、ChatGPT側はruntime固有wrapperからそれらを呼び出す。canonical task trackingの更新はruntime-neutralなtask tracking Skillへ委譲し、ChatGPT wrapperが更新規則を複製しない。
 
-ChatGPT chat同士は自動的に会話履歴を共有しない。repository、Issue、PR、report、handoffを永続的な引継ぎ情報として使用する。
+ChatGPT chat同士は自動的に会話履歴を共有しない。repository、Issue、PR、task tracking、report、handoffを永続的な引継ぎ情報として使用する。
 
 Skill外の`shared/`file参照や、複数Skillから同一fileを直接参照する構成には依存しない。
+
+Issue #59で追加するtask tracking contractの詳細は`design/issue-59-chatgpt-task-tracking-extension.md`にも記録する。本設計書のIssue #59影響箇所と同extensionを一致させる。
 
 ## アーキテクチャ
 
@@ -19,6 +21,11 @@ Skill外の`shared/`file参照や、複数Skillから同一fileを直接参照�
 ├─ review-worker
 └─ report-writer
 
+runtime-neutral task tracking Skill
+├─ task-breakdown-planner
+├─ task-consistency-manager
+└─ progress-sync-manager
+
 ChatGPT runtime wrapper
 ├─ chat-implementation-worker
 ├─ chat-review-worker
@@ -26,9 +33,9 @@ ChatGPT runtime wrapper
 └─ chat-handoff-manager
 ```
 
-core Skillが作業の意味論を保持する。wrapperはChatGPT固有の権限、connector利用、repository／PRへの永続化、chat continuity、handoff transportだけを保持する。
+core Skillが作業の意味論を保持する。task tracking Skillはcanonical trackingの分割、整合確認、進捗同期を保持する。wrapperはChatGPT固有の権限、connector利用、repository／PRへの永続化、chat continuity、handoff transportだけを保持する。
 
-wrapperとcore Skillの依存は、同一fileへのpath参照ではなく、install済みSkill名による呼び出しとして表現する。
+Skill間の依存は、同一fileへのpath参照ではなく、install済みSkill名による呼び出しとして表現する。
 
 ## 対象Skill
 
@@ -39,7 +46,7 @@ wrapperとcore Skillの依存は、同一fileへのpath参照ではなく、inst
 - `chat-report-writer`
 - `chat-handoff-manager`
 
-各wrapperは別workerまたはsub-agentを起動しない。利用者が親としてchatを開始し、そのchat内で必要なcore Skillを呼び出す。
+各wrapperは別workerまたはsub-agentを起動しない。利用者が親としてchatを開始し、そのchat内で必要なSkillを呼び出す。
 
 ### 親非依存core Skill
 
@@ -50,12 +57,22 @@ wrapperとcore Skillの依存は、同一fileへのpath参照ではなく、inst
 
 core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存しない。
 
+### runtime-neutral task tracking Skill
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+3 Skillはcanonical tracking writeを所有するauthorized callerが実行する。Codex標準flowでは通常parent、ChatGPT implementation wrapperではcurrent chatが直接実行する。Skill自身はsub-agent起動を要求しない。
+
 ## Core Skill責務
 
 ### `work-context-manager`
 
 - user instruction、repository instruction、Issue、task、design、PR、report、handoffのauthorityを解決する
 - accepted scope、non-goal、target identity、development policy、validation target、current-HEAD CI evidenceを解決する
+- canonical task tracking pathと、存在する場合はcanonical phase tracking pathをauthorityから解決する
+- configured tracking pathをbasenameへ置換せず、解決不能時はunknownとして返す
 - planned validationとrequired failure diagnosticsを明示する
 - blocked、unknown、held、unexploredを区別する
 - allowed writeとforbidden writeを明示する
@@ -92,6 +109,26 @@ core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存�
 - 保存先と永続化はcallerへ委ねる
 - mergeしない
 
+## Task tracking Skill責務
+
+### `task-breakdown-planner`
+
+- 未登録、大きすぎる、または曖昧なwork itemを完了判定可能なtask／phaseへ分割する
+- `work-context-manager`が解決したcanonical tracking pathを完全一致で使用する
+- dependencies、exit criteria、estimateを明示する
+- pathを解決できない場合は推測せずblockedとする
+
+### `task-consistency-manager`
+
+- 実装開始前とscope変更時にcanonical trackingと実作業を照合する
+- significant workがtrackingへ存在しない場合は実装前にtrackingを整合させる
+- 分割が必要な場合は同じcanonical pathで`task-breakdown-planner`を使用する
+
+### `progress-sync-manager`
+
+- implementation、validation、review follow-up、commit／PR、blocked、完了状態をcanonical trackingへ同期する
+- task state、phase、dependencies、exit criteria、blockers、pending actionを次workerへ渡せる形で返す
+
 ## ChatGPT wrapper責務
 
 ### `chat-implementation-worker`
@@ -99,11 +136,15 @@ core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存�
 次のSkillを呼び出す。
 
 1. `work-context-manager`
-2. `implementation-worker`
-3. `report-writer`
-4. `chat-handoff-manager`
+2. `task-consistency-manager`
+3. trackingが未登録、大きすぎる、曖昧、またはdependencies／exit criteria不足の場合だけ`task-breakdown-planner`
+4. 3を実行した場合は`task-consistency-manager`を再実行する
+5. `implementation-worker`
+6. `progress-sync-manager`
+7. `report-writer`
+8. `chat-handoff-manager`
 
-wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、report保存、PR簡易コメント投稿を管理する。
+wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、report保存、PR簡易コメント投稿を管理する。`work-context-manager`が解決したcanonical tracking pathを変更せずtask tracking Skillへ渡し、tracking更新ロジックをwrapperへ複製しない。
 
 ### `chat-review-worker`
 
@@ -131,6 +172,8 @@ wrapperはsource discovery、保存先、PR comment投稿、権限境界だけ�
 - 独立chat間のhandoff packet schemaを所有する
 - reportとhandoffを別成果物として扱う
 - typed projectionとversioned raw source payloadを両方保持する
+- canonical task／phase tracking path、task state、phase、dependencies、exit criteria、blockers、pending actionをtyped projectionとして保持する
+- task tracking Skillを実行した場合は、そのcomplete outputも`source_payloads`へ保持する
 - repository write可能時は通常handoffを`reports/handoffs/`へ保存する
 - write不可時は完全なpacket本文を返す
 - 前chatの権限を次chatへ引き継がない
@@ -156,11 +199,17 @@ chatgpt-worker-skills.zip
 │  └─ SKILL.md
 ├─ review-worker/
 │  └─ SKILL.md
-└─ report-writer/
+├─ report-writer/
+│  └─ SKILL.md
+├─ task-breakdown-planner/
+│  └─ SKILL.md
+├─ task-consistency-manager/
+│  └─ SKILL.md
+└─ progress-sync-manager/
    └─ SKILL.md
 ```
 
-このZIPをChatGPTのSkill uploadへ指定し、wrapperと依存core Skillを一括登録する。
+このZIPをChatGPTのSkill uploadへ指定し、wrapper、依存core Skill、task tracking Skillを一括登録する。
 
 各directoryは独立Skillであり、別Skill directory内のfileやrepository外の`shared/`fileを参照しない。
 
@@ -174,10 +223,10 @@ chatgpt-worker-skills.zip
 2. PRのsynthetic merge SHAではなく実PR HEAD SHAをcheckoutする。
 3. checkout credentialを保持せず、`contents: read`だけで実行する。
 4. repository-wide validatorで全Skill、dependency、active link、symlink、design同期を確認する。
-5. 全`skills/chat-*/SKILL.md`と必須core Skillを検出する。
+5. 全`skills/chat-*/SKILL.md`、必須core Skill、必須task tracking Skillを検出する。
 6. directory名とfront matterの`name`が一致することを確認する。
 7. symlink、missing Skill、Skill外`shared/`参照を拒否する。
-8. wrapperとcore Skillを独立root directoryとしてZIPへ収録する。
+8. wrapper、core Skill、task tracking Skillを独立root directoryとしてZIPへ収録する。
 9. ZIP rootが検出したSkill集合と一致することを確認する。
 10. 生成ZIPをworkflow artifactとして保存する。
 11. GitHub Releaseは更新しない。
@@ -271,7 +320,7 @@ initial reviewとfix verificationは、利用可能であれば同じnormal revi
 Issue #<number>を開始してください。
 ```
 
-`chat-implementation-worker`は`work-context-manager`でIssue、task list、design、branch、PR、validation、current HEADを自己解決し、`implementation-worker`へ渡す。
+`chat-implementation-worker`は`work-context-manager`でIssue、canonical task／phase tracking path、task、design、branch、PR、validation、current HEADを自己解決する。`task-consistency-manager`で実装前のtracking整合を確認し、必要時だけ`task-breakdown-planner`で分割・補完して再確認した後、`implementation-worker`へcontextを渡す。実装結果は`progress-sync-manager`でcanonical trackingへ同期する。
 
 ### 初回レビュー
 
@@ -287,7 +336,7 @@ normal review chatは`work-context-manager`で対象を解決し、`review-worke
 レビュー結果に対応してください。
 ```
 
-初回実装chatを継続し、該当finding、直接原因、影響境界、同一欠陥classのsibling caseだけを対象に`implementation-worker`の`review follow-up`を実行する。
+初回実装chatを継続し、該当finding、直接原因、影響境界、同一欠陥classのsibling caseだけを対象に`implementation-worker`の`review follow-up`を実行する。新しい作業またはtracking state変更が生じた場合はcanonical pathを使ってtask tracking Skillを実行する。
 
 ### 修正確認
 
@@ -378,7 +427,8 @@ normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身の
 - `chat-handoff-manager`がhandoff packetのschemaと生成を所有する
 - schema version 3を使用する
 - typed projectionとversioned `source_payloads`を両方保持する
-- source core Skillのcomplete outputをraw payloadとして保持する
+- source core Skillと、実行されたtask tracking Skillのcomplete outputをraw payloadとして保持する
+- canonical task／phase tracking path、task state、phase、dependencies、exit criteria、blockers、pending actionを保持する
 - development policy、planned validation、required failure diagnostics、blocked stateを保持する
 - implementation failure diagnosticsとblocked itemsを保持する
 - reviewer identity、reviewer continuity、independence evidenceを保持する
@@ -397,12 +447,12 @@ normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身の
 
 ## Skill dependencyの扱い
 
-- wrapperは必要なcore SkillをSkill名で呼び出す
-- core Skillとwrapperの間で同一fileを共有しない
+- wrapperは必要なcore Skillとtask tracking SkillをSkill名で呼び出す
+- core Skill、task tracking Skill、wrapperの間で同一fileを共有しない
 - 各Skillは自directory内で完結する
-- dependency Skillが利用できない場合、wrapperはcore処理を複製しない
+- dependency Skillが利用できない場合、wrapperは処理を複製しない
 - missing dependencyとして停止し、不足しているSkill名を明示する
-- ChatGPT登録用ZIPにはwrapperと必須core Skillを同時に含める
+- ChatGPT登録用ZIPにはwrapper、必須core Skill、必須task tracking Skillを同時に含める
 
 ## CodexSkill repositoryの検証方針
 
@@ -419,7 +469,7 @@ Release packaging workflowは製品コードのTDDではなく、配布物生成
 
 ## Merge境界
 
-core Skillとwrapperはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
+core Skill、task tracking Skill、wrapperはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
 
 ## 設計書保守方針
 
@@ -430,9 +480,12 @@ core Skillとwrapperはいずれもmergeを行わず、利用者がmerge判断�
 ## 完了条件
 
 - 実装、レビュー、レポートの意味論が親非依存core Skillとして定義されている
+- canonical tracking更新がruntime-neutral task tracking Skillとして定義され、ChatGPT current chatからsub-agentなしで実行できる
 - ChatGPT wrapperがruntime固有責務だけを持つ
-- wrapperとcore SkillがSkill外`shared/`fileへ依存していない
-- wrapperと必須core Skillを単一ZIPで登録できる構造になっている
+- wrapper、core Skill、task tracking SkillがSkill外`shared/`fileへ依存していない
+- 4 wrapper、4 core Skill、3 task tracking Skillを単一ZIPで登録できる11 Skill構造になっている
+- canonical tracking pathがauthorityから解決され、configured pathをbasenameへ置換または推測しない
+- handoffがtask tracking path/state/phase/dependencies/exit criteria/blockers/pending actionとtask tracking Skill raw outputを保持する
 - mainへの対象変更反映時に固定通常Release `chatgpt-worker-skills-latest`へZIP Assetが生成または更新される
 - PRマージ時にPR単位のPre-releaseへZIP Assetが生成される
 - 手動Release／Pre-release公開時に同じReleaseへZIP Assetが追加される
@@ -445,4 +498,4 @@ core Skillとwrapperはいずれもmergeを行わず、利用者がmerge判断�
 - current HEAD固有CI規則が反映されている
 - reportとhandoffが別成果物として維持されている
 - attestation後にrepository-writing Skillを呼ばない
-- core Skill、wrapper、sub-agent、親agentはmergeしない
+- core Skill、task tracking Skill、wrapper、sub-agent、親agentはmergeしない

--- a/design/chat-worker-skill-design.md
+++ b/design/chat-worker-skill-design.md
@@ -4,9 +4,9 @@
 
 利用者が親として複数のChatGPT chatを起動し、実装、レビュー、レポート作成を独立したworker Skillへ割り当てる構成を定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillへ置き、ChatGPT側はruntime固有wrapperからそれらを呼び出す。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillへ置き、ChatGPT側はruntime固有wrapperからそれらを呼び出す。task trackingの正本更新は専用Skillへ委譲し、ChatGPT workerがtask更新規則を独自実装しない。
 
-ChatGPT chat同士は自動的に会話履歴を共有しない。repository、Issue、PR、report、handoffを永続的な引継ぎ情報として使用する。
+ChatGPT chat同士は会話履歴を自動共有しない。repository、Issue、PR、task tracking、report、handoffを永続的な引継ぎ情報として使用する。
 
 Skill外の`shared/`file参照や、複数Skillから同一fileを直接参照する構成には依存しない。
 
@@ -19,6 +19,11 @@ Skill外の`shared/`file参照や、複数Skillから同一fileを直接参照�
 ├─ review-worker
 └─ report-writer
 
+task tracking Skill
+├─ task-breakdown-planner
+├─ task-consistency-manager
+└─ progress-sync-manager
+
 ChatGPT runtime wrapper
 ├─ chat-implementation-worker
 ├─ chat-review-worker
@@ -26,9 +31,9 @@ ChatGPT runtime wrapper
 └─ chat-handoff-manager
 ```
 
-core Skillが作業の意味論を保持する。wrapperはChatGPT固有の権限、connector利用、repository／PRへの永続化、chat continuity、handoff transportだけを保持する。
+core Skillが作業の意味論を保持する。task tracking Skillはtask分割、開始前整合、進捗・完了同期を所有する。wrapperはChatGPT固有の権限、connector利用、repository／PRへの永続化、chat continuity、handoff transportだけを保持する。
 
-wrapperとcore Skillの依存は、同一fileへのpath参照ではなく、install済みSkill名による呼び出しとして表現する。
+依存は同一fileへのpath参照ではなく、install済みSkill名による呼び出しとして表現する。
 
 ## 対象Skill
 
@@ -39,7 +44,7 @@ wrapperとcore Skillの依存は、同一fileへのpath参照ではなく、inst
 - `chat-report-writer`
 - `chat-handoff-manager`
 
-各wrapperは別workerまたはsub-agentを起動しない。利用者が親としてchatを開始し、そのchat内で必要なcore Skillを呼び出す。
+各wrapperは別workerまたはsub-agentを起動しない。利用者が親としてchatを開始し、そのchat内で必要なSkillを呼び出す。
 
 ### 親非依存core Skill
 
@@ -48,7 +53,13 @@ wrapperとcore Skillの依存は、同一fileへのpath参照ではなく、inst
 - `review-worker`
 - `report-writer`
 
-core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存しない。
+### task tracking Skill
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+`task-consistency-manager`は実装開始前に対象作業がcanonical task trackingへ表現されていることを確認する。taskが大きい、曖昧、または未登録の場合は`task-breakdown-planner`で分割・明確化した後に実装へ進む。進捗、blocked、完了、PR、検証結果は`progress-sync-manager`でtask／phaseへ同期する。
 
 ## Core Skill責務
 
@@ -92,18 +103,43 @@ core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存�
 - 保存先と永続化はcallerへ委ねる
 - mergeしない
 
+## task tracking Skill責務
+
+### `task-breakdown-planner`
+
+- 未登録または大きすぎる作業を、完了判定可能なtaskへ分割する
+- dependencies、exit criteria、estimate、phaseを明示する
+- canonical tracking fileの更新規則を維持する
+
+### `task-consistency-manager`
+
+- 実装開始前とscope変更時にtask／phaseと実作業を照合する
+- significant workがtrackingへ存在しない場合は実装を開始しない
+- reviewで追加作業が発生した場合は先にtrackingへ反映する
+
+### `progress-sync-manager`
+
+- active、blocked、verification、PR、完了状態をcanonical trackingへ同期する
+- workerの実装結果とtrackingの記述を一致させる
+- task完了時にexit criteriaと検証証拠を記録する
+
 ## ChatGPT wrapper責務
 
 ### `chat-implementation-worker`
 
-次のSkillを呼び出す。
+次のSkillを順に呼び出す。
 
 1. `work-context-manager`
-2. `implementation-worker`
-3. `report-writer`
-4. `chat-handoff-manager`
+2. `task-consistency-manager`
+3. 必要時のみ`task-breakdown-planner`
+4. `implementation-worker`
+5. `progress-sync-manager`
+6. `report-writer`
+7. `chat-handoff-manager`
 
-wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、report保存、PR簡易コメント投稿を管理する。
+全7 Skillを配布ZIPへ含める。`task-breakdown-planner`はtaskが未登録、大きい、曖昧、依存またはexit criteria不足の場合だけ実行する。
+
+wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、report保存、PR簡易コメント投稿を管理する。task tracking fileは専用task tracking Skill経由でのみ更新する。
 
 ### `chat-review-worker`
 
@@ -114,7 +150,7 @@ wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、
 3. `report-writer`
 4. `chat-handoff-manager`
 
-wrapperはreview mode、reviewer continuity、independent reviewer条件、pre-freeze gate、report保存、PR comment投稿を管理する。
+review findingが新しい作業を要求する場合は、実装workerへhandoffし、実装workerが`task-consistency-manager`または`task-breakdown-planner`でtrackingへ反映する。
 
 ### `chat-report-writer`
 
@@ -124,17 +160,15 @@ wrapperはreview mode、reviewer continuity、independent reviewer条件、pre-f
 2. `report-writer`
 3. `chat-handoff-manager`
 
-wrapperはsource discovery、保存先、PR comment投稿、権限境界だけを管理し、新しいtechnical judgmentを追加しない。
-
 ### `chat-handoff-manager`
 
 - 独立chat間のhandoff packet schemaを所有する
 - reportとhandoffを別成果物として扱う
 - typed projectionとversioned raw source payloadを両方保持する
+- task identity、task tracking path、tracking state、pending tracking actionを保持する
 - repository write可能時は通常handoffを`reports/handoffs/`へ保存する
 - write不可時は完全なpacket本文を返す
 - 前chatの権限を次chatへ引き継がない
-- target Skill名、mode、必要な権限、参照先を明示する
 
 ## ChatGPT登録用ZIP
 
@@ -143,26 +177,21 @@ GitHub Releaseへ、次の構造を持つ単一ファイル`chatgpt-worker-skill
 ```text
 chatgpt-worker-skills.zip
 ├─ chat-implementation-worker/
-│  └─ SKILL.md
 ├─ chat-review-worker/
-│  └─ SKILL.md
 ├─ chat-report-writer/
-│  └─ SKILL.md
 ├─ chat-handoff-manager/
-│  └─ SKILL.md
 ├─ work-context-manager/
-│  └─ SKILL.md
 ├─ implementation-worker/
-│  └─ SKILL.md
 ├─ review-worker/
-│  └─ SKILL.md
-└─ report-writer/
-   └─ SKILL.md
+├─ report-writer/
+├─ task-breakdown-planner/
+├─ task-consistency-manager/
+└─ progress-sync-manager/
 ```
 
-このZIPをChatGPTのSkill uploadへ指定し、wrapperと依存core Skillを一括登録する。
+各directoryは`SKILL.md`を持つ独立Skillである。このZIPをChatGPTのSkill uploadへ指定し、wrapper、core Skill、task tracking Skillを一括登録する。
 
-各directoryは独立Skillであり、別Skill directory内のfileやrepository外の`shared/`fileを参照しない。
+build scriptは全`chat-*`wrapper、必須core Skill、必須task tracking Skillを検出し、ZIP rootが期待集合と一致することを検証する。missing Skill、directory名とfront matter nameの不一致、symlink、Skill外`shared/`参照を拒否する。
 
 ## Release生成
 
@@ -170,92 +199,31 @@ chatgpt-worker-skills.zip
 
 ### PR validation build
 
-1. `opened`、`synchronize`、`reopened`で実行する。
-2. PRのsynthetic merge SHAではなく実PR HEAD SHAをcheckoutする。
-3. checkout credentialを保持せず、`contents: read`だけで実行する。
-4. repository-wide validatorで全Skill、dependency、active link、symlink、design同期を確認する。
-5. 全`skills/chat-*/SKILL.md`と必須core Skillを検出する。
-6. directory名とfront matterの`name`が一致することを確認する。
-7. symlink、missing Skill、Skill外`shared/`参照を拒否する。
-8. wrapperとcore Skillを独立root directoryとしてZIPへ収録する。
-9. ZIP rootが検出したSkill集合と一致することを確認する。
-10. 生成ZIPをworkflow artifactとして保存する。
-11. GitHub Releaseは更新しない。
+1. PRの実HEAD SHAをcheckoutする。
+2. repository-wide validatorを実行する。
+3. wrapper、core Skill、task tracking Skillを単一ZIPへ収録する。
+4. ZIP rootと必須Skill集合を照合する。
+5. 生成ZIPをworkflow artifactとして保存する。
+6. PR validationではReleaseを更新しない。
 
-### Rolling normal Release
+### main反映後
 
-1. 対象変更が`main`へpushされた場合に実行する。
-2. push後の`main` HEADをcheckoutし、PR validationと同じread-only validation／buildを実行する。
-3. build成功後だけpublish jobへ`contents: write`を付与する。
-4. build jobの検証済みartifactをpublish jobへ渡す。
-5. rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する。
-6. 固定通常Release `ChatGPT Worker Skills`を作成または更新し、`chatgpt-worker-skills.zip`をAssetへ添付または置換する。
-
-### PR merge Pre-release
-
-1. `pull_request.closed`かつ`merged == true`の場合だけ実行する。未merge closeでは実行しない。
-2. `merge_commit_sha`をcheckoutし、PR validationと同じread-only validation／buildを再実行する。
-3. build成功後だけpublish jobへ`contents: write`を付与する。
-4. build jobの検証済みartifactをpublish jobへ渡す。
-5. tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する。
-6. `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成し、`chatgpt-worker-skills.zip`をAssetへ添付する。
-7. job再実行時は同じPR tag／Pre-releaseを更新し、同名Assetを置換する。
-8. この自動Pre-releaseの`release.published`イベントでは再build／再uploadしない。
-
-### 手動Release／Pre-release
-
-1. 利用者がGitHub UIまたはAPIでRelease／Pre-releaseを公開した`release.published`イベントで実行する。
-2. Release tagが指すcommitをcheckoutし、repository validationとZIP buildを実行する。
-3. build成功後だけupload jobへ`contents: write`を付与する。
-4. 検証済み`chatgpt-worker-skills.zip`を、公開された同じReleaseのAssetへ添付する。
-5. 同名Assetが存在する場合は置換する。
-6. 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は二重処理防止のため対象外とする。
-7. Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない。
+main push時に同じvalidationとbuildを実行し、成功したartifactだけをrolling Releaseとversioned pre-releaseへ公開する。
 
 `workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
-
-Release時の共通file複製とrepository相対linkの書換は行わない。
-
-## Project Instruction
-
-Skill ZIPとは別に、対象ChatGPT ProjectへProject Instructionを設定する。
-
-維持する設定例は`design/chatgpt-project-instruction-example.md`に置く。対象Projectのinstructionが正本であり、設定例をすべてのrepositoryへ強制しない。
-
-### RevMem向け例
-
-```text
-対象リポジトリ:
-https://github.com/ssaattww/RevMem
-
-タスク一覧:
-tasks/tasks-status.md
-
-Skillの参照リポジトリ:
-https://github.com/ssaattww/CodexSkill
-
-必要な作業手順やSkillの構成は、この参照リポジトリを確認してください。
-
-リポジトリの参照・更新、IssueとPRの作成・更新、PRコメントの投稿にはGitHub connectorを使用してください。
-
-作業開始時に、テスト失敗時の原因調査に必要な情報をartifactとして保存するworkflowが存在するか確認してください。存在しない場合は、対象workflowへ追加してください。artifactには、少なくともテスト結果、標準出力、標準エラー、および失敗原因の調査に必要なログを含めてください。
-
-RevMemの実装はTDDを基本とし、先にテストを追加して失敗を確認してから実装してください。このTDD方針と診断artifact workflowの追加方針はRevMemの実装作業に適用し、参照先のCodexSkillリポジトリには適用しません。
-
-変更は、レビュー可能な小さな論理単位でcommit/pushしてください。
-
-作業完了時は、詳細reportをrepositoryへ保存してください。それとは別に、変更内容と検証結果を要約した簡易reportをPRコメントへ投稿してください。
-
-PRの作成または既存PRの更新まで行ってください。mergeは利用者が行うため、workerはmergeしないでください。
-
-「最新のworkflow run」ではなく、対象PRのcurrent HEAD SHAとrunのhead SHAが一致するworkflow runだけをCI確認の対象としてください。HEAD更新後は新しいHEADに紐づくrunを確認してください。一致するrunがない場合はCI未実施として報告し、別SHAのrunを代用しないでください。
-```
 
 ## ChatGPT worker flow
 
 ```text
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
+│  ├─ work-context-manager
+│  ├─ task-consistency-manager
+│  ├─ task-breakdown-planner [必要時]
+│  ├─ implementation-worker
+│  ├─ progress-sync-manager
+│  ├─ report-writer
+│  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
 ├─ Chat A: chat-implementation-worker [review follow-up]
 ├─ Chat B: chat-review-worker [fix verification]
@@ -263,146 +231,37 @@ PRの作成または既存PRの更新まで行ってください。mergeは利�
 └─ Report chat: chat-report-writer [必要な場合のみ]
 ```
 
-initial reviewとfix verificationは、利用可能であれば同じnormal review chatを継続する。independent final reviewだけを、implementation、review fix、normal reviewに参加していない新規chatで実施する。
-
 ### 初回実装
 
-```text
-Issue #<number>を開始してください。
-```
-
-`chat-implementation-worker`は`work-context-manager`でIssue、task list、design、branch、PR、validation、current HEADを自己解決し、`implementation-worker`へ渡す。
-
-### 初回レビュー
-
-```text
-PR #<number>を初回レビューしてください。
-```
-
-normal review chatは`work-context-manager`で対象を解決し、`review-worker`の`initial review`を実行する。全変更file、直接依存、要件、設計、current HEAD固有の検証証拠を確認する。
+`chat-implementation-worker`はIssue、task list、design、branch、PR、validation、current HEADを自己解決する。実装前にtask整合を確認し、必要ならtaskを分割・登録してから`implementation-worker`へ渡す。
 
 ### レビュー対応
 
-```text
-レビュー結果に対応してください。
-```
-
-初回実装chatを継続し、該当finding、直接原因、影響境界、同一欠陥classのsibling caseだけを対象に`implementation-worker`の`review follow-up`を実行する。
-
-### 修正確認
-
-```text
-PR #<number>の修正確認をしてください。
-```
-
-初回レビューと同じnormal review chatを継続し、previous reviewed HEAD以降のfix、finding解消、regression evidence、影響範囲、新規変更領域を`review-worker`の`fix verification`で確認する。
-
-元のnormal review chatを利用できない場合、implementationへ参加していない別chatがfinding identity、review criteria、reviewed HEAD、fix context、held、unexploredを復元し、continuity変更をreportへ記録する。
+review findingがtask scopeを追加または変更する場合、実装前にtrackingを同期する。単なる既存taskのfinding解消は同一taskのreview follow-upとして扱い、進捗と検証結果を`progress-sync-manager`で更新する。
 
 ### Pre-freeze gate
 
-独立最終レビュー開始前に、次を完了してrepositoryへ保存する。
-
-- implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report
-- end-of-Issue Skill-gap decision
-- current scopeで必要なSkill update
-- feedback classificationとfeedback ledger
-- repository-backed normal handoff
-- current-HEAD validationとCI evidence
+独立最終レビュー開始前に、implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report、Skill-gap decision、feedback classification、normal handoff、current-HEAD CI evidenceを保存する。
 
 これらの処理でrepositoryが変わった場合はnormal review／fix verificationへ戻る。全pre-freeze変更を含むnormal cycleが収束するまでHEADをfreezeしない。
 
 ### 独立最終レビュー
 
-```text
-PR #<number>を独立レビューしてください。
-```
-
-pre-freeze gate通過後、independent-final-review report pathを予約し、その時点のcurrent HEADを`reviewed implementation HEAD`としてfreezeする。
-
-実装、review fix、normal reviewを行っていない新規chatで、frozen HEADを`review-worker`の`independent final review`として独立確認する。過去reviewの結論は独立pass後に照合する。
-
-独立最終レビューでfindingまたはrepository write obligationが出た場合、freezeを無効化してnormal implementation／fix-verification flowへ戻る。
-
-passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成する。attestation後はPR body／PR commentなどGit HEADを変えない操作だけを行い、final handoffをinlineまたはbranch外で返す。repository commitを追加しない。
-
-## 最終review reportの終端規則
-
-technical verdictは`reviewed implementation HEAD`へ結び付ける。
-
-report-attestation commitは次を全て満たす。
-
-- first parentがreviewed implementation HEADである
-- reviewed implementation HEAD以後のcommitがこの1件だけである
-- 事前予約したindependent-final-review report pathだけを変更する
-- reportにreviewed implementation HEADとadministrative attestationであることを記録する
-- Skill、design、workflow、configuration、tracking、feedback、handoff、implementation、product fileを変更しない
-- attestation後にrepository commitを作らない
-- wrapperがallowlist diffを検証し、PR commentへ結果を記録する
-
-完了identityは`reviewed implementation HEAD + report-attestation HEAD`とする。条件外のpost-review commitまたはattestation後のrepository-writing Skill実行はverdictを無効化し、normal fix verificationとfresh independent final reviewを要求する。
-
-## Codex review flowとの共通性
-
-Codexでも同じ`review-worker`を使用し、独立最終レビューを必須とする。
-
-### 通常レビューcycle
-
-- `review-enforcer`が専用reviewer sub-agentを起動する。
-- initial reviewとfix verificationは、原則として同じreviewerを継続利用する。
-- finding identity、review criteria、reviewed HEAD、fix context、held、unexploredを維持する。
-- required findingがある場合はimplementation flowへ戻す。
-- normal cycleのreport、tracking、design、implementation、validationはindependent final review前にcommit／pushする。
-- Skill decision、feedback ledger、normal handoffをpre-freeze gateへ含める。
-
-### 独立最終レビュー
-
-通常review cycleとpre-freeze gate完了後、別のfresh reviewer sub-agentを起動する。
-
-- implementation sub-agentと異なること
-- 通常reviewerとは別であること
-- review fixを実装していないこと
-- 原則`fork_turns: "none"`で起動すること
-- frozen reviewed implementation HEADを対象とすること
-- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
-- reviewer identityとindependence evidenceを記録すること
-- 過去review結論を読む前に独立passを行うこと
-- normal review reportとは別にindependent final review reportを作ること
-- passing reportのrepository保存には同じreport-attestation終端規則を使うこと
-
-normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
+実装、review fix、normal reviewを行っていない新規chatでfrozen HEADを独立確認する。passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを許可し、その後repository commitを追加しない。
 
 ## Handoff
 
-- reportとhandoffは別成果物とする
-- `chat-handoff-manager`がhandoff packetのschemaと生成を所有する
-- schema version 3を使用する
-- typed projectionとversioned `source_payloads`を両方保持する
-- source core Skillのcomplete outputをraw payloadとして保持する
-- development policy、planned validation、required failure diagnostics、blocked stateを保持する
-- implementation failure diagnosticsとblocked itemsを保持する
-- reviewer identity、reviewer continuity、independence evidenceを保持する
-- reserved report paths、attestation allowed flag、required first parent、allowed paths、forbidden path classes、validation resultを保持する
-- full findingのidentity、severity、origin、location、description、impact、evidence、required actionを保持する
-- required coverage、held、unexplored、reviewed HEAD、requirements、intentionally untouched、test、CI artifact、implementation commit、report／comment referenceを保持する
-- schema version 1／2のoriginal packetをraw sourceとして保存し、mapping不能fieldを捨てない
-- 欠落fieldはunknownとして理由を記録し、安全な継続ができない場合はblocked／incompleteとする
-- repository write可能時は通常handoffを`reports/handoffs/`へ保存する
-- PRまたはIssueから一意に特定できる場合は次workerがconnectorで取得する
-- 一意に特定できない場合だけ利用者へpathまたはpacket本文を求める
-- 前workerの権限は次chatへ自動継承しない
-- CI evidenceはpacketのtarget HEADと一致させる
-- unknownを推測で補完しない
-- final independent review後のhandoffはinlineまたはPR branch外でtransportする
+handoffは次を保持する。
 
-## Skill dependencyの扱い
+- target repository、Issue、PR、branch、current HEAD
+- task identity、task tracking path、task state、phase、dependencies、exit criteria
+- accepted scope、non-goal、development policy、planned validation
+- implementation evidence、failure diagnostics、blocked items
+- review finding、reviewed HEAD、held、unexplored
+- report、PR comment、workflow run、artifact参照
+- next workerが実行すべきtracking action
 
-- wrapperは必要なcore SkillをSkill名で呼び出す
-- core Skillとwrapperの間で同一fileを共有しない
-- 各Skillは自directory内で完結する
-- dependency Skillが利用できない場合、wrapperはcore処理を複製しない
-- missing dependencyとして停止し、不足しているSkill名を明示する
-- ChatGPT登録用ZIPにはwrapperと必須core Skillを同時に含める
+CI evidenceはpacketのtarget HEADと一致させ、別SHAのrunを代用しない。
 
 ## CodexSkill repositoryの検証方針
 
@@ -411,38 +270,26 @@ CodexSkill repository自身にはTDDを適用しない。
 - Red/Green用testを追加しない
 - この変更専用のcontract testを追加しない
 - TDD用workflowを追加しない
-- 既存lintまたはschema validationがあれば通常検証として使用する
-- Skill front matter、依存Skill、ZIP構造、symlink、外部参照を通常検証する
+- repository validator、Skill dependency validation、ZIP build、配布物構造確認を使用する
 - 自動検証がない部分は設計書、Skill、workflow、Issue、PR説明の整合性をreviewする
-
-Release packaging workflowは製品コードのTDDではなく、配布物生成と構造検証のための運用workflowである。
 
 ## Merge境界
 
-core Skillとwrapperはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
+core Skill、task tracking Skill、wrapperはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
 
 ## 設計書保守方針
 
-既存設計書を更新する場合、構成変更と無関係な節、運用手順、入力例、責務、完了条件を削除しない。新しい構成と矛盾する箇所だけを置換し、必要な説明を追加する。
-
-今回の再構成でも、既存のProject Instruction例、worker flow、各作業の入力例、Codex review flow、worker責務、handoff、検証方針、完了条件を維持する。
+構成変更時はSkill contract、配布ZIP構成、hierarchy design、workflow、task tracking、reportを同期する。新しい構成と矛盾する記述を残さない。
 
 ## 完了条件
 
-- 実装、レビュー、レポートの意味論が親非依存core Skillとして定義されている
-- ChatGPT wrapperがruntime固有責務だけを持つ
-- wrapperとcore SkillがSkill外`shared/`fileへ依存していない
-- wrapperと必須core Skillを単一ZIPで登録できる構造になっている
-- mainへの対象変更反映時に固定通常Release `chatgpt-worker-skills-latest`へZIP Assetが生成または更新される
-- PRマージ時にPR単位のPre-releaseへZIP Assetが生成される
-- 手動Release／Pre-release公開時に同じReleaseへZIP Assetが追加される
-- ChatGPTとCodexの双方で同じreview lifecycleを使用する
-- initial reviewとfix verificationがnormal reviewer continuityを維持する
-- pre-freeze gateがSkill decision、feedback ledger、normal handoff、report、trackingを含む
-- 独立最終レビューが実装者とnormal reviewerから分離されている
-- handoffがtyped projectionとraw source payloadでlosslessにtransportする
-- Project Instruction例が維持されている
-- current HEAD固有CI規則が反映されている
-- reportとhandoffが別成果物として維持されている
-- attestation後にrepository-writing Skillを呼ばない
-- core Skill、wrapper、sub-agent、親agentはmergeしない
+- ChatGPT実装workerが実装前にtask tracking整合を確認する
+- taskが未登録または不十分な場合に専用Skillで分割・更新できる
+- 実装進捗、blocked、検証、完了を専用Skillで同期できる
+- wrapperがtask更新規則を独自実装しない
+- wrapper、core Skill、task tracking Skillを単一ZIPで登録できる
+- ZIP rootが11 Skillと一致する
+- current HEAD固有のvalidation、workflow、artifactを確認できる
+- reportとhandoffが別成果物として維持される
+- TDDをCodexSkill repositoryへ適用しない
+- mergeを実施しない

--- a/design/chat-worker-skill-design.md
+++ b/design/chat-worker-skill-design.md
@@ -4,9 +4,9 @@
 
 利用者が親として複数のChatGPT chatを起動し、実装、レビュー、レポート作成を独立したworker Skillへ割り当てる構成を定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillへ置き、ChatGPT側はruntime固有wrapperからそれらを呼び出す。task trackingの正本更新は専用Skillへ委譲し、ChatGPT workerがtask更新規則を独自実装しない。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillへ置き、ChatGPT側はruntime固有wrapperからそれらを呼び出す。
 
-ChatGPT chat同士は会話履歴を自動共有しない。repository、Issue、PR、task tracking、report、handoffを永続的な引継ぎ情報として使用する。
+ChatGPT chat同士は自動的に会話履歴を共有しない。repository、Issue、PR、report、handoffを永続的な引継ぎ情報として使用する。
 
 Skill外の`shared/`file参照や、複数Skillから同一fileを直接参照する構成には依存しない。
 
@@ -19,11 +19,6 @@ Skill外の`shared/`file参照や、複数Skillから同一fileを直接参照�
 ├─ review-worker
 └─ report-writer
 
-task tracking Skill
-├─ task-breakdown-planner
-├─ task-consistency-manager
-└─ progress-sync-manager
-
 ChatGPT runtime wrapper
 ├─ chat-implementation-worker
 ├─ chat-review-worker
@@ -31,9 +26,9 @@ ChatGPT runtime wrapper
 └─ chat-handoff-manager
 ```
 
-core Skillが作業の意味論を保持する。task tracking Skillはtask分割、開始前整合、進捗・完了同期を所有する。wrapperはChatGPT固有の権限、connector利用、repository／PRへの永続化、chat continuity、handoff transportだけを保持する。
+core Skillが作業の意味論を保持する。wrapperはChatGPT固有の権限、connector利用、repository／PRへの永続化、chat continuity、handoff transportだけを保持する。
 
-依存は同一fileへのpath参照ではなく、install済みSkill名による呼び出しとして表現する。
+wrapperとcore Skillの依存は、同一fileへのpath参照ではなく、install済みSkill名による呼び出しとして表現する。
 
 ## 対象Skill
 
@@ -44,7 +39,7 @@ core Skillが作業の意味論を保持する。task tracking Skillはtask分�
 - `chat-report-writer`
 - `chat-handoff-manager`
 
-各wrapperは別workerまたはsub-agentを起動しない。利用者が親としてchatを開始し、そのchat内で必要なSkillを呼び出す。
+各wrapperは別workerまたはsub-agentを起動しない。利用者が親としてchatを開始し、そのchat内で必要なcore Skillを呼び出す。
 
 ### 親非依存core Skill
 
@@ -53,13 +48,7 @@ core Skillが作業の意味論を保持する。task tracking Skillはtask分�
 - `review-worker`
 - `report-writer`
 
-### task tracking Skill
-
-- `task-breakdown-planner`
-- `task-consistency-manager`
-- `progress-sync-manager`
-
-`task-consistency-manager`は実装開始前に対象作業がcanonical task trackingへ表現されていることを確認する。taskが大きい、曖昧、または未登録の場合は`task-breakdown-planner`で分割・明確化した後に実装へ進む。進捗、blocked、完了、PR、検証結果は`progress-sync-manager`でtask／phaseへ同期する。
+core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存しない。
 
 ## Core Skill責務
 
@@ -103,43 +92,18 @@ core Skillが作業の意味論を保持する。task tracking Skillはtask分�
 - 保存先と永続化はcallerへ委ねる
 - mergeしない
 
-## task tracking Skill責務
-
-### `task-breakdown-planner`
-
-- 未登録または大きすぎる作業を、完了判定可能なtaskへ分割する
-- dependencies、exit criteria、estimate、phaseを明示する
-- canonical tracking fileの更新規則を維持する
-
-### `task-consistency-manager`
-
-- 実装開始前とscope変更時にtask／phaseと実作業を照合する
-- significant workがtrackingへ存在しない場合は実装を開始しない
-- reviewで追加作業が発生した場合は先にtrackingへ反映する
-
-### `progress-sync-manager`
-
-- active、blocked、verification、PR、完了状態をcanonical trackingへ同期する
-- workerの実装結果とtrackingの記述を一致させる
-- task完了時にexit criteriaと検証証拠を記録する
-
 ## ChatGPT wrapper責務
 
 ### `chat-implementation-worker`
 
-次のSkillを順に呼び出す。
+次のSkillを呼び出す。
 
 1. `work-context-manager`
-2. `task-consistency-manager`
-3. 必要時のみ`task-breakdown-planner`
-4. `implementation-worker`
-5. `progress-sync-manager`
-6. `report-writer`
-7. `chat-handoff-manager`
+2. `implementation-worker`
+3. `report-writer`
+4. `chat-handoff-manager`
 
-全7 Skillを配布ZIPへ含める。`task-breakdown-planner`はtaskが未登録、大きい、曖昧、依存またはexit criteria不足の場合だけ実行する。
-
-wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、report保存、PR簡易コメント投稿を管理する。task tracking fileは専用task tracking Skill経由でのみ更新する。
+wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、report保存、PR簡易コメント投稿を管理する。
 
 ### `chat-review-worker`
 
@@ -150,7 +114,7 @@ wrapperはcurrent chatの権限、GitHub connector、commit／push／PR操作、
 3. `report-writer`
 4. `chat-handoff-manager`
 
-review findingが新しい作業を要求する場合は、実装workerへhandoffし、実装workerが`task-consistency-manager`または`task-breakdown-planner`でtrackingへ反映する。
+wrapperはreview mode、reviewer continuity、independent reviewer条件、pre-freeze gate、report保存、PR comment投稿を管理する。
 
 ### `chat-report-writer`
 
@@ -160,15 +124,17 @@ review findingが新しい作業を要求する場合は、実装workerへhandof
 2. `report-writer`
 3. `chat-handoff-manager`
 
+wrapperはsource discovery、保存先、PR comment投稿、権限境界だけを管理し、新しいtechnical judgmentを追加しない。
+
 ### `chat-handoff-manager`
 
 - 独立chat間のhandoff packet schemaを所有する
 - reportとhandoffを別成果物として扱う
 - typed projectionとversioned raw source payloadを両方保持する
-- task identity、task tracking path、tracking state、pending tracking actionを保持する
 - repository write可能時は通常handoffを`reports/handoffs/`へ保存する
 - write不可時は完全なpacket本文を返す
 - 前chatの権限を次chatへ引き継がない
+- target Skill名、mode、必要な権限、参照先を明示する
 
 ## ChatGPT登録用ZIP
 
@@ -177,21 +143,26 @@ GitHub Releaseへ、次の構造を持つ単一ファイル`chatgpt-worker-skill
 ```text
 chatgpt-worker-skills.zip
 ├─ chat-implementation-worker/
+│  └─ SKILL.md
 ├─ chat-review-worker/
+│  └─ SKILL.md
 ├─ chat-report-writer/
+│  └─ SKILL.md
 ├─ chat-handoff-manager/
+│  └─ SKILL.md
 ├─ work-context-manager/
+│  └─ SKILL.md
 ├─ implementation-worker/
+│  └─ SKILL.md
 ├─ review-worker/
-├─ report-writer/
-├─ task-breakdown-planner/
-├─ task-consistency-manager/
-└─ progress-sync-manager/
+│  └─ SKILL.md
+└─ report-writer/
+   └─ SKILL.md
 ```
 
-各directoryは`SKILL.md`を持つ独立Skillである。このZIPをChatGPTのSkill uploadへ指定し、wrapper、core Skill、task tracking Skillを一括登録する。
+このZIPをChatGPTのSkill uploadへ指定し、wrapperと依存core Skillを一括登録する。
 
-build scriptは全`chat-*`wrapper、必須core Skill、必須task tracking Skillを検出し、ZIP rootが期待集合と一致することを検証する。missing Skill、directory名とfront matter nameの不一致、symlink、Skill外`shared/`参照を拒否する。
+各directoryは独立Skillであり、別Skill directory内のfileやrepository外の`shared/`fileを参照しない。
 
 ## Release生成
 
@@ -199,31 +170,92 @@ build scriptは全`chat-*`wrapper、必須core Skill、必須task tracking Skill
 
 ### PR validation build
 
-1. PRの実HEAD SHAをcheckoutする。
-2. repository-wide validatorを実行する。
-3. wrapper、core Skill、task tracking Skillを単一ZIPへ収録する。
-4. ZIP rootと必須Skill集合を照合する。
-5. 生成ZIPをworkflow artifactとして保存する。
-6. PR validationではReleaseを更新しない。
+1. `opened`、`synchronize`、`reopened`で実行する。
+2. PRのsynthetic merge SHAではなく実PR HEAD SHAをcheckoutする。
+3. checkout credentialを保持せず、`contents: read`だけで実行する。
+4. repository-wide validatorで全Skill、dependency、active link、symlink、design同期を確認する。
+5. 全`skills/chat-*/SKILL.md`と必須core Skillを検出する。
+6. directory名とfront matterの`name`が一致することを確認する。
+7. symlink、missing Skill、Skill外`shared/`参照を拒否する。
+8. wrapperとcore Skillを独立root directoryとしてZIPへ収録する。
+9. ZIP rootが検出したSkill集合と一致することを確認する。
+10. 生成ZIPをworkflow artifactとして保存する。
+11. GitHub Releaseは更新しない。
 
-### main反映後
+### Rolling normal Release
 
-main push時に同じvalidationとbuildを実行し、成功したartifactだけをrolling Releaseとversioned pre-releaseへ公開する。
+1. 対象変更が`main`へpushされた場合に実行する。
+2. push後の`main` HEADをcheckoutし、PR validationと同じread-only validation／buildを実行する。
+3. build成功後だけpublish jobへ`contents: write`を付与する。
+4. build jobの検証済みartifactをpublish jobへ渡す。
+5. rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する。
+6. 固定通常Release `ChatGPT Worker Skills`を作成または更新し、`chatgpt-worker-skills.zip`をAssetへ添付または置換する。
+
+### PR merge Pre-release
+
+1. `pull_request.closed`かつ`merged == true`の場合だけ実行する。未merge closeでは実行しない。
+2. `merge_commit_sha`をcheckoutし、PR validationと同じread-only validation／buildを再実行する。
+3. build成功後だけpublish jobへ`contents: write`を付与する。
+4. build jobの検証済みartifactをpublish jobへ渡す。
+5. tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する。
+6. `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成し、`chatgpt-worker-skills.zip`をAssetへ添付する。
+7. job再実行時は同じPR tag／Pre-releaseを更新し、同名Assetを置換する。
+8. この自動Pre-releaseの`release.published`イベントでは再build／再uploadしない。
+
+### 手動Release／Pre-release
+
+1. 利用者がGitHub UIまたはAPIでRelease／Pre-releaseを公開した`release.published`イベントで実行する。
+2. Release tagが指すcommitをcheckoutし、repository validationとZIP buildを実行する。
+3. build成功後だけupload jobへ`contents: write`を付与する。
+4. 検証済み`chatgpt-worker-skills.zip`を、公開された同じReleaseのAssetへ添付する。
+5. 同名Assetが存在する場合は置換する。
+6. 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は二重処理防止のため対象外とする。
+7. Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない。
 
 `workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
+
+Release時の共通file複製とrepository相対linkの書換は行わない。
+
+## Project Instruction
+
+Skill ZIPとは別に、対象ChatGPT ProjectへProject Instructionを設定する。
+
+維持する設定例は`design/chatgpt-project-instruction-example.md`に置く。対象Projectのinstructionが正本であり、設定例をすべてのrepositoryへ強制しない。
+
+### RevMem向け例
+
+```text
+対象リポジトリ:
+https://github.com/ssaattww/RevMem
+
+タスク一覧:
+tasks/tasks-status.md
+
+Skillの参照リポジトリ:
+https://github.com/ssaattww/CodexSkill
+
+必要な作業手順やSkillの構成は、この参照リポジトリを確認してください。
+
+リポジトリの参照・更新、IssueとPRの作成・更新、PRコメントの投稿にはGitHub connectorを使用してください。
+
+作業開始時に、テスト失敗時の原因調査に必要な情報をartifactとして保存するworkflowが存在するか確認してください。存在しない場合は、対象workflowへ追加してください。artifactには、少なくともテスト結果、標準出力、標準エラー、および失敗原因の調査に必要なログを含めてください。
+
+RevMemの実装はTDDを基本とし、先にテストを追加して失敗を確認してから実装してください。このTDD方針と診断artifact workflowの追加方針はRevMemの実装作業に適用し、参照先のCodexSkillリポジトリには適用しません。
+
+変更は、レビュー可能な小さな論理単位でcommit/pushしてください。
+
+作業完了時は、詳細reportをrepositoryへ保存してください。それとは別に、変更内容と検証結果を要約した簡易reportをPRコメントへ投稿してください。
+
+PRの作成または既存PRの更新まで行ってください。mergeは利用者が行うため、workerはmergeしないでください。
+
+「最新のworkflow run」ではなく、対象PRのcurrent HEAD SHAとrunのhead SHAが一致するworkflow runだけをCI確認の対象としてください。HEAD更新後は新しいHEADに紐づくrunを確認してください。一致するrunがない場合はCI未実施として報告し、別SHAのrunを代用しないでください。
+```
 
 ## ChatGPT worker flow
 
 ```text
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
-│  ├─ work-context-manager
-│  ├─ task-consistency-manager
-│  ├─ task-breakdown-planner [必要時]
-│  ├─ implementation-worker
-│  ├─ progress-sync-manager
-│  ├─ report-writer
-│  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
 ├─ Chat A: chat-implementation-worker [review follow-up]
 ├─ Chat B: chat-review-worker [fix verification]
@@ -231,37 +263,146 @@ main push時に同じvalidationとbuildを実行し、成功したartifactだけ
 └─ Report chat: chat-report-writer [必要な場合のみ]
 ```
 
+initial reviewとfix verificationは、利用可能であれば同じnormal review chatを継続する。independent final reviewだけを、implementation、review fix、normal reviewに参加していない新規chatで実施する。
+
 ### 初回実装
 
-`chat-implementation-worker`はIssue、task list、design、branch、PR、validation、current HEADを自己解決する。実装前にtask整合を確認し、必要ならtaskを分割・登録してから`implementation-worker`へ渡す。
+```text
+Issue #<number>を開始してください。
+```
+
+`chat-implementation-worker`は`work-context-manager`でIssue、task list、design、branch、PR、validation、current HEADを自己解決し、`implementation-worker`へ渡す。
+
+### 初回レビュー
+
+```text
+PR #<number>を初回レビューしてください。
+```
+
+normal review chatは`work-context-manager`で対象を解決し、`review-worker`の`initial review`を実行する。全変更file、直接依存、要件、設計、current HEAD固有の検証証拠を確認する。
 
 ### レビュー対応
 
-review findingがtask scopeを追加または変更する場合、実装前にtrackingを同期する。単なる既存taskのfinding解消は同一taskのreview follow-upとして扱い、進捗と検証結果を`progress-sync-manager`で更新する。
+```text
+レビュー結果に対応してください。
+```
+
+初回実装chatを継続し、該当finding、直接原因、影響境界、同一欠陥classのsibling caseだけを対象に`implementation-worker`の`review follow-up`を実行する。
+
+### 修正確認
+
+```text
+PR #<number>の修正確認をしてください。
+```
+
+初回レビューと同じnormal review chatを継続し、previous reviewed HEAD以降のfix、finding解消、regression evidence、影響範囲、新規変更領域を`review-worker`の`fix verification`で確認する。
+
+元のnormal review chatを利用できない場合、implementationへ参加していない別chatがfinding identity、review criteria、reviewed HEAD、fix context、held、unexploredを復元し、continuity変更をreportへ記録する。
 
 ### Pre-freeze gate
 
-独立最終レビュー開始前に、implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report、Skill-gap decision、feedback classification、normal handoff、current-HEAD CI evidenceを保存する。
+独立最終レビュー開始前に、次を完了してrepositoryへ保存する。
+
+- implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report
+- end-of-Issue Skill-gap decision
+- current scopeで必要なSkill update
+- feedback classificationとfeedback ledger
+- repository-backed normal handoff
+- current-HEAD validationとCI evidence
 
 これらの処理でrepositoryが変わった場合はnormal review／fix verificationへ戻る。全pre-freeze変更を含むnormal cycleが収束するまでHEADをfreezeしない。
 
 ### 独立最終レビュー
 
-実装、review fix、normal reviewを行っていない新規chatでfrozen HEADを独立確認する。passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを許可し、その後repository commitを追加しない。
+```text
+PR #<number>を独立レビューしてください。
+```
+
+pre-freeze gate通過後、independent-final-review report pathを予約し、その時点のcurrent HEADを`reviewed implementation HEAD`としてfreezeする。
+
+実装、review fix、normal reviewを行っていない新規chatで、frozen HEADを`review-worker`の`independent final review`として独立確認する。過去reviewの結論は独立pass後に照合する。
+
+独立最終レビューでfindingまたはrepository write obligationが出た場合、freezeを無効化してnormal implementation／fix-verification flowへ戻る。
+
+passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成する。attestation後はPR body／PR commentなどGit HEADを変えない操作だけを行い、final handoffをinlineまたはbranch外で返す。repository commitを追加しない。
+
+## 最終review reportの終端規則
+
+technical verdictは`reviewed implementation HEAD`へ結び付ける。
+
+report-attestation commitは次を全て満たす。
+
+- first parentがreviewed implementation HEADである
+- reviewed implementation HEAD以後のcommitがこの1件だけである
+- 事前予約したindependent-final-review report pathだけを変更する
+- reportにreviewed implementation HEADとadministrative attestationであることを記録する
+- Skill、design、workflow、configuration、tracking、feedback、handoff、implementation、product fileを変更しない
+- attestation後にrepository commitを作らない
+- wrapperがallowlist diffを検証し、PR commentへ結果を記録する
+
+完了identityは`reviewed implementation HEAD + report-attestation HEAD`とする。条件外のpost-review commitまたはattestation後のrepository-writing Skill実行はverdictを無効化し、normal fix verificationとfresh independent final reviewを要求する。
+
+## Codex review flowとの共通性
+
+Codexでも同じ`review-worker`を使用し、独立最終レビューを必須とする。
+
+### 通常レビューcycle
+
+- `review-enforcer`が専用reviewer sub-agentを起動する。
+- initial reviewとfix verificationは、原則として同じreviewerを継続利用する。
+- finding identity、review criteria、reviewed HEAD、fix context、held、unexploredを維持する。
+- required findingがある場合はimplementation flowへ戻す。
+- normal cycleのreport、tracking、design、implementation、validationはindependent final review前にcommit／pushする。
+- Skill decision、feedback ledger、normal handoffをpre-freeze gateへ含める。
+
+### 独立最終レビュー
+
+通常review cycleとpre-freeze gate完了後、別のfresh reviewer sub-agentを起動する。
+
+- implementation sub-agentと異なること
+- 通常reviewerとは別であること
+- review fixを実装していないこと
+- 原則`fork_turns: "none"`で起動すること
+- frozen reviewed implementation HEADを対象とすること
+- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
+- reviewer identityとindependence evidenceを記録すること
+- 過去review結論を読む前に独立passを行うこと
+- normal review reportとは別にindependent final review reportを作ること
+- passing reportのrepository保存には同じreport-attestation終端規則を使うこと
+
+normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
 
 ## Handoff
 
-handoffは次を保持する。
+- reportとhandoffは別成果物とする
+- `chat-handoff-manager`がhandoff packetのschemaと生成を所有する
+- schema version 3を使用する
+- typed projectionとversioned `source_payloads`を両方保持する
+- source core Skillのcomplete outputをraw payloadとして保持する
+- development policy、planned validation、required failure diagnostics、blocked stateを保持する
+- implementation failure diagnosticsとblocked itemsを保持する
+- reviewer identity、reviewer continuity、independence evidenceを保持する
+- reserved report paths、attestation allowed flag、required first parent、allowed paths、forbidden path classes、validation resultを保持する
+- full findingのidentity、severity、origin、location、description、impact、evidence、required actionを保持する
+- required coverage、held、unexplored、reviewed HEAD、requirements、intentionally untouched、test、CI artifact、implementation commit、report／comment referenceを保持する
+- schema version 1／2のoriginal packetをraw sourceとして保存し、mapping不能fieldを捨てない
+- 欠落fieldはunknownとして理由を記録し、安全な継続ができない場合はblocked／incompleteとする
+- repository write可能時は通常handoffを`reports/handoffs/`へ保存する
+- PRまたはIssueから一意に特定できる場合は次workerがconnectorで取得する
+- 一意に特定できない場合だけ利用者へpathまたはpacket本文を求める
+- 前workerの権限は次chatへ自動継承しない
+- CI evidenceはpacketのtarget HEADと一致させる
+- unknownを推測で補完しない
+- final independent review後のhandoffはinlineまたはPR branch外でtransportする
 
-- target repository、Issue、PR、branch、current HEAD
-- task identity、task tracking path、task state、phase、dependencies、exit criteria
-- accepted scope、non-goal、development policy、planned validation
-- implementation evidence、failure diagnostics、blocked items
-- review finding、reviewed HEAD、held、unexplored
-- report、PR comment、workflow run、artifact参照
-- next workerが実行すべきtracking action
+## Skill dependencyの扱い
 
-CI evidenceはpacketのtarget HEADと一致させ、別SHAのrunを代用しない。
+- wrapperは必要なcore SkillをSkill名で呼び出す
+- core Skillとwrapperの間で同一fileを共有しない
+- 各Skillは自directory内で完結する
+- dependency Skillが利用できない場合、wrapperはcore処理を複製しない
+- missing dependencyとして停止し、不足しているSkill名を明示する
+- ChatGPT登録用ZIPにはwrapperと必須core Skillを同時に含める
 
 ## CodexSkill repositoryの検証方針
 
@@ -270,26 +411,38 @@ CodexSkill repository自身にはTDDを適用しない。
 - Red/Green用testを追加しない
 - この変更専用のcontract testを追加しない
 - TDD用workflowを追加しない
-- repository validator、Skill dependency validation、ZIP build、配布物構造確認を使用する
+- 既存lintまたはschema validationがあれば通常検証として使用する
+- Skill front matter、依存Skill、ZIP構造、symlink、外部参照を通常検証する
 - 自動検証がない部分は設計書、Skill、workflow、Issue、PR説明の整合性をreviewする
+
+Release packaging workflowは製品コードのTDDではなく、配布物生成と構造検証のための運用workflowである。
 
 ## Merge境界
 
-core Skill、task tracking Skill、wrapperはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
+core Skillとwrapperはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
 
 ## 設計書保守方針
 
-構成変更時はSkill contract、配布ZIP構成、hierarchy design、workflow、task tracking、reportを同期する。新しい構成と矛盾する記述を残さない。
+既存設計書を更新する場合、構成変更と無関係な節、運用手順、入力例、責務、完了条件を削除しない。新しい構成と矛盾する箇所だけを置換し、必要な説明を追加する。
+
+今回の再構成でも、既存のProject Instruction例、worker flow、各作業の入力例、Codex review flow、worker責務、handoff、検証方針、完了条件を維持する。
 
 ## 完了条件
 
-- ChatGPT実装workerが実装前にtask tracking整合を確認する
-- taskが未登録または不十分な場合に専用Skillで分割・更新できる
-- 実装進捗、blocked、検証、完了を専用Skillで同期できる
-- wrapperがtask更新規則を独自実装しない
-- wrapper、core Skill、task tracking Skillを単一ZIPで登録できる
-- ZIP rootが11 Skillと一致する
-- current HEAD固有のvalidation、workflow、artifactを確認できる
-- reportとhandoffが別成果物として維持される
-- TDDをCodexSkill repositoryへ適用しない
-- mergeを実施しない
+- 実装、レビュー、レポートの意味論が親非依存core Skillとして定義されている
+- ChatGPT wrapperがruntime固有責務だけを持つ
+- wrapperとcore SkillがSkill外`shared/`fileへ依存していない
+- wrapperと必須core Skillを単一ZIPで登録できる構造になっている
+- mainへの対象変更反映時に固定通常Release `chatgpt-worker-skills-latest`へZIP Assetが生成または更新される
+- PRマージ時にPR単位のPre-releaseへZIP Assetが生成される
+- 手動Release／Pre-release公開時に同じReleaseへZIP Assetが追加される
+- ChatGPTとCodexの双方で同じreview lifecycleを使用する
+- initial reviewとfix verificationがnormal reviewer continuityを維持する
+- pre-freeze gateがSkill decision、feedback ledger、normal handoff、report、trackingを含む
+- 独立最終レビューが実装者とnormal reviewerから分離されている
+- handoffがtyped projectionとraw source payloadでlosslessにtransportする
+- Project Instruction例が維持されている
+- current HEAD固有CI規則が反映されている
+- reportとhandoffが別成果物として維持されている
+- attestation後にrepository-writing Skillを呼ばない
+- core Skill、wrapper、sub-agent、親agentはmergeしない

--- a/design/issue-59-chatgpt-task-tracking-extension.md
+++ b/design/issue-59-chatgpt-task-tracking-extension.md
@@ -1,0 +1,120 @@
+# Issue #59 ChatGPT Task Tracking Extension
+
+## 目的
+
+Issue #59「task更新スキルがzipに同封されていないので、chatgpt側からtask更新できない」に必要な差分だけを定義する。
+
+この文書は `design/chat-worker-skill-design.md` と `design/skill-hierarchy-design.md` の既存契約を削除・置換しない。Issue #59に関して、ChatGPT登録用Skill集合、implementation wrapperのtask tracking flow、canonical tracking path、handoff task tracking projectionだけを追加規定する。
+
+review continuity、pre-freeze、independent final review、report attestation、Release publication、Codex review flow、merge境界など既存設計のその他の契約は変更しない。
+
+## 追加するSkill
+
+ChatGPT登録用 `chatgpt-worker-skills.zip` へ、既存の4 wrapper + 4 core Skillに加えて次の3 Skillを含める。
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+したがって配布ZIPは次の11 root Skillを持つ。
+
+```text
+chatgpt-worker-skills.zip
+├─ chat-implementation-worker/
+├─ chat-review-worker/
+├─ chat-report-writer/
+├─ chat-handoff-manager/
+├─ work-context-manager/
+├─ implementation-worker/
+├─ review-worker/
+├─ report-writer/
+├─ task-breakdown-planner/
+├─ task-consistency-manager/
+└─ progress-sync-manager/
+```
+
+各rootは独立Skill directoryであり `SKILL.md` を持つ。既存のsymlink禁止、Skill外shared runtime file依存禁止、front matter name一致、archive root検証は維持する。
+
+## 実行owner
+
+3つのtask tracking SkillはCodex親専用ではなく、canonical tracking writeを所有するauthorized callerが実行するruntime-neutral Skillとする。
+
+- Codex標準flowでは通常parentが実行する。
+- ChatGPT implementation wrapperではcurrent chatが直接実行する。
+- `chat-implementation-worker`はsub-agentを起動しないため、task tracking Skillの実行にsub-agent delegationを要求しない。
+- delegation可能な別runtimeが補助auditを行う場合でも、canonical trackingの最終write ownerはauthorized callerのままとする。
+
+## Canonical tracking path
+
+tracking file名をSkill内で固定しない。
+
+`work-context-manager`はProject Instruction、repository instruction、accepted task/designなどのauthorityから次を解決する。
+
+```yaml
+tracking:
+  task_path: repository_relative_path | unknown
+  phase_path: repository_relative_path | null | unknown
+```
+
+例としてProject Instructionが `tasks/tasks-status.md` を指定している場合、`task_path`はそのpathを完全一致で保持する。`tasks-status.md`というbasenameへ置換してはならない。
+
+`phase_path`は別phase fileを使わないprojectでは`null`を許可する。必要なpathを解決できない場合は推測せずblocked／unknownとする。
+
+3つのtask tracking Skillと`chat-implementation-worker`は、`work-context-manager`が解決したpathを変更せず受け渡す。
+
+## ChatGPT implementation flow
+
+`chat-implementation-worker`は次を実行する。
+
+1. `work-context-manager`
+2. `task-consistency-manager`
+3. trackingが未登録、大きすぎる、曖昧、dependencies／exit criteria不足の場合だけ `task-breakdown-planner`
+4. 3を実行した場合は `task-consistency-manager` を再実行
+5. `implementation-worker`
+6. `progress-sync-manager`
+7. `report-writer`
+8. `chat-handoff-manager`
+
+`progress-sync-manager`は実装進捗、validation、review follow-up、commit／PR、blocked state、完了状態が変化した時点でcanonical trackingを同期する。
+
+canonical task trackingの直接編集ロジックを`chat-implementation-worker`へ複製しない。
+
+## Handoff task tracking projection
+
+`chat-handoff-manager` schema version 3へ次のtyped projectionを追加する。
+
+```yaml
+task_tracking:
+  task_path: repository_relative_path | unknown
+  phase_path: repository_relative_path | null | unknown
+  state: string | unknown
+  phase: string | null | unknown
+  dependencies:
+    - string
+  exit_criteria:
+    - string
+  blockers:
+    - string
+  pending_action: string | null | unknown
+```
+
+canonical pathは`work-context-manager`の出力を完全一致で保持する。task state、phase、dependencies、exit criteria、blockers、pending actionは最新のtask tracking Skill outputから保持する。
+
+従来どおりtyped projectionだけでなく、producing Skillのcomplete outputを`source_payloads`へ保持する。schema version 1／2からversion 3へ読む場合、元schemaに存在しないtask tracking fieldを推測しない。
+
+## Release workflowへの影響
+
+Release publication方式、権限境界、current-HEAD checkout規則は変更しない。
+
+既存build step `scripts/build_chatgpt_worker_skills.py` が4 wrapper、4 core Skillに加えて3 task tracking Skillを必須rootとして収録・検証することだけをIssue #59の変更対象とする。
+
+## 完了条件
+
+- 3 task tracking SkillがChatGPT登録用ZIPに含まれる。
+- 3 SkillがChatGPT current chatからsub-agentなしで実行可能なcontractを持つ。
+- canonical task／phase pathが`work-context-manager`から各task tracking Skillへlosslessに渡る。
+- configured pathをbasenameへ置換または推測しない。
+- `chat-handoff-manager`がtask tracking path/state/phase/dependencies/exit criteria/blocker/pending actionをtyped projectionとして保持する。
+- 既存設計のIssue #59と無関係な契約を削除しない。
+- CodexSkill repository policyに従い、この保守作業へTDDを適用しない。
+- mergeは行わない。

--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -4,9 +4,9 @@
 
 Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker flowを一元的に定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、CodexとChatGPTはruntime wrapperからそれらを呼び出す。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、canonical task trackingの更新はruntime-neutralなtask tracking Skillとして定義する。CodexとChatGPTはruntime wrapperから必要なSkillを呼び出す。
 
-この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。
+この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。Issue #59固有のtask tracking追加契約は`design/issue-59-chatgpt-task-tracking-extension.md`にも記録し、本設計書の該当箇所と一致させる。
 
 ## 実行方式
 
@@ -15,7 +15,7 @@ Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker
 - `利用者が親としてChatGPT chatで実行`: 利用者が独立chatを起動し、そのchatが指定wrapper Skillを直接実行する。
 - `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、Codex親、sub-agent、ChatGPT chat固有の制御を持たずに実作業を行う。
 
-ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。
+ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。task tracking Skill自身もsub-agent起動を要求せず、canonical tracking writeを所有するauthorized callerが実行する。
 
 ## Skill依存アーキテクチャ
 
@@ -25,6 +25,11 @@ ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwra
 ├─ implementation-worker
 ├─ review-worker
 └─ report-writer
+
+runtime-neutral task tracking Skill
+├─ task-breakdown-planner
+├─ task-consistency-manager
+└─ progress-sync-manager
 
 runtime wrapper
 ├─ Codex
@@ -41,7 +46,7 @@ runtime wrapper
 ### Core Skill
 
 - `work-context-manager`
-  - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、write boundaryを解決する
+  - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、canonical tracking path、write boundaryを解決する
 - `implementation-worker`
   - initial implementationとreview follow-upを実行する
 - `review-worker`
@@ -51,11 +56,22 @@ runtime wrapper
 
 全core SkillはCodex親、Codex sub-agent、ChatGPT親chatのいずれにも依存しない。
 
+### Task tracking Skill
+
+- `task-breakdown-planner`
+  - canonical tracking pathを使い、work itemをtask／phase、dependencies、exit criteriaへ分解する
+- `task-consistency-manager`
+  - canonical trackingと実scopeを照合し、実装開始前およびscope変更時の整合を保証する
+- `progress-sync-manager`
+  - implementation、validation、review、commit／PR、blocked、完了状態をcanonical trackingへ同期する
+
+3 Skillは`work-context-manager`が解決したrepository-relative pathを完全一致で使用し、configured pathをbasenameへ置換または推測しない。Codex標準flowでは通常parent、ChatGPT implementation flowではcurrent chatがauthorized callerとなる。
+
 ### Runtime wrapper
 
 Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、fresh independent reviewer、report path、persistence、completion gateを所有する。
 
-ChatGPT wrapperはcurrent-chat permission、connector、repository／PR persistence、chat continuity、cross-chat handoffを所有する。
+ChatGPT wrapperはcurrent-chat permission、connector、repository／PR persistence、chat continuity、cross-chat handoffを所有する。`chat-implementation-worker`はtask tracking Skillをcurrent chatで直接実行し、tracking更新ロジックをwrapperへ複製しない。
 
 共通動作を複数Skillから同一fileとして参照しない。共通動作は独立Skillとして定義し、wrapperまたは他のSkillがSkill名で呼び出す。
 
@@ -213,7 +229,10 @@ attestation後にrepository writeの必要性が判明した場合はterminal st
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
 │  ├─ work-context-manager
+│  ├─ task-consistency-manager
+│  ├─ task-breakdown-planner [必要時のみ]
 │  ├─ implementation-worker
+│  ├─ progress-sync-manager
 │  ├─ report-writer
 │  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
@@ -238,7 +257,7 @@ initial reviewとfix verificationは同じnormal review chatを継続する。in
 Issue #<number>を開始してください。
 ```
 
-`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`と`implementation-worker`を呼び出す。
+`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`でcanonical tracking pathを解決する。`task-consistency-manager`でtrackingを確認し、必要時だけ`task-breakdown-planner`で分割・補完して再確認した後、`implementation-worker`を呼び出す。実装結果は`progress-sync-manager`でcanonical trackingへ同期する。
 
 ### 初回レビュー
 
@@ -254,7 +273,7 @@ PR #<number>を初回レビューしてください。
 レビュー結果に対応してください。
 ```
 
-初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。
+初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。新しいtaskまたはtracking state変更が発生した場合はcanonical pathを使ってtask tracking Skillを実行する。
 
 ### 修正確認
 
@@ -290,7 +309,13 @@ ChatGPTへ登録するwrapper Skillは次の4つである。
 - `review-worker`
 - `report-writer`
 
-GitHub Releaseでは、8 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
+必須task tracking Skillは次の3つである。
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+GitHub Releaseでは、11 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
 
 ```text
 chatgpt-worker-skills.zip
@@ -301,12 +326,15 @@ chatgpt-worker-skills.zip
 ├─ work-context-manager/
 ├─ implementation-worker/
 ├─ review-worker/
-└─ report-writer/
+├─ report-writer/
+├─ task-breakdown-planner/
+├─ task-consistency-manager/
+└─ progress-sync-manager/
 ```
 
 各directoryには少なくとも`SKILL.md`が存在し、front matterの`name`とdirectory名を一致させる。
 
-このZIPをChatGPTへuploadし、wrapperと依存core Skillを一括登録する。
+このZIPをChatGPTへuploadし、wrapper、依存core Skill、task tracking Skillを一括登録する。
 
 ## Handoff
 
@@ -315,7 +343,8 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 - reportとhandoffを別成果物とする
 - schema version 3を使用する
 - typed projectionとversioned `source_payloads`の両方を保持する
-- source core Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
+- source core Skillと実行されたtask tracking Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
+- canonical task／phase tracking path、task state、phase、dependencies、exit criteria、blockers、pending actionを保持する
 - development policy、planned validation、required failure diagnostics、blocked stateを保持する
 - implementation failure diagnosticsとblocked itemsを保持する
 - reviewer identity、reviewer continuity、independence evidenceを保持する
@@ -342,7 +371,7 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 - `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
 - build jobは`contents: read`だけを持ち、checkout credentialを保持しない
 - `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
-- 全`chat-*` wrapperと必須core Skillを検出する
+- 全`chat-*` wrapper、必須core Skill、必須task tracking Skillを検出する
 - missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
 - 単一`chatgpt-worker-skills.zip`を作成する
 - ZIP rootが検出Skill集合と一致することを確認する
@@ -388,7 +417,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 1. workflow開始時にCodexSkillの鮮度を確認する。
 2. 再開時は`restart-handover-manager`で状態を復元する。
-3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、write boundaryを解決する。
+3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、canonical tracking path、write boundaryを解決する。
 4. `development-orchestrator`がtaskを選択する。
 5. `task-consistency-manager`でtrackingを同期する。
 6. 設計影響があれば`design-doc-maintainer`を実行する。
@@ -428,7 +457,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `work-context-manager` | authority、scope、target identity、policy、validation、CI、write boundaryを解決する | runtime非依存Skillとして実行 |
+| `work-context-manager` | authority、scope、target identity、policy、validation、CI、canonical tracking path、write boundaryを解決する | runtime非依存Skillとして実行 |
 | `implementation-worker` | initial implementationとreview follow-upを実施する | runtime非依存Skillとして実行 |
 | `review-worker` | initial review、fix verification、independent final reviewとattestation条件を返す | runtime非依存Skillとして実行 |
 | `report-writer` | evidence-faithfulなreport、簡易PR comment、persistence metadataを生成する | runtime非依存Skillとして実行 |
@@ -437,9 +466,9 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `task-breakdown-planner` | issueをtaskとphaseへ分解する | 親が実行 |
-| `task-consistency-manager` | task、phase、実scopeを同期する | 親が実行 |
-| `progress-sync-manager` | report、tracking、実結果を同期する | 親が実行 |
+| `task-breakdown-planner` | canonical pathを使ってissueをtaskとphaseへ分解する | runtime非依存Skillとしてauthorized callerが実行 |
+| `task-consistency-manager` | canonical task／phaseと実scopeを同期する | runtime非依存Skillとしてauthorized callerが実行 |
+| `progress-sync-manager` | canonical tracking、report、実結果を同期する | runtime非依存Skillとしてauthorized callerが実行 |
 | `restart-handover-manager` | recorded stateから再開位置を復元する | 親が実行 |
 | `handover-memo-writer` | 別chat向けhandover memoを作成する | 親が実行 |
 
@@ -476,15 +505,16 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-upを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-up、canonical task tracking flowを統括する | 利用者が親としてChatGPT chatで実行 |
 | `chat-review-worker` | ChatGPT上のinitial、fix verification、independent final review、report-attestationを統括する | 利用者が親としてChatGPT chatで実行 |
 | `chat-report-writer` | ChatGPT上のsource discovery、report永続化、PR commentを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetを生成する | ChatGPT wrapperから呼び出す |
+| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetとtask tracking stateを生成する | ChatGPT wrapperから呼び出す |
 
 ## 共通規則
 
 - 対象repositoryのProject Instructionを優先する。
 - 解決可能なrepository stateを利用者へ再質問しない。
+- canonical tracking pathはProject／repository authorityから解決し、configured pathをbasenameへ置換または推測しない。
 - CodexSkill repository自身にはTDDを適用しない。
 - implementationは自分の変更へreview verdictを出さない。
 - reviewerはfindingを実装しない。
@@ -493,9 +523,9 @@ Release時の共通file複製とrepository相対link書換は行わない。
 - CIは対象current HEAD SHAに紐づくrunだけを使用する。
 - 別SHAのrunを代用しない。
 - reportとhandoffを混同しない。
-- handoffはtyped projectionとversioned raw source payloadでcore Skill outputを欠落なくtransportする。
+- handoffはtyped projectionとversioned raw source payloadでcore Skillおよび実行されたtask tracking Skill outputを欠落なくtransportする。
 - unknown、blocked、held、unexplored、失敗結果を消さない。
-- core Skillとwrapperは自directory外のshared fileへ依存しない。
+- core Skill、task tracking Skill、wrapperは自directory外のshared fileへ依存しない。
 - dependency Skillが存在しない場合、wrapperは処理を複製せずmissing dependencyとして停止する。
 - end-of-Issue Skill decision、feedback ledger、normal handoff、report、trackingをindependent final review前に確定する。
 - pre-freeze処理でrepositoryが変わった場合はnormal reviewへ戻る。
@@ -511,7 +541,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 - ChatGPT Project Instruction例を変更する場合は`design/chatgpt-project-instruction-example.md`を更新する。
 - review lifecycle変更時は`review-worker`、`review-enforcer`、`chat-review-worker`、`report-writer`、`report-output-manager`、本設計書、専用設計書を同時更新する。
 - handoff schema変更時は`chat-handoff-manager`、ChatGPT wrapper、両設計書、Issue／trackingを同期する。
-- core Skill dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
+- core Skill dependencyまたはChatGPT配布task tracking dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
 - `scripts/verify_skill_repository.py`でactive Markdown link、Skill依存、front matter、symlink、削除済みshared runtime path、hierarchy design同期を検証する。
 - workflow trigger変更時はforbidden pathだけの変更でもvalidatorが起動するcoverageを両設計書とPR説明へ同期する。
 - 既存設計書の変更時は、構成変更と無関係な節を削除せず、矛盾する箇所だけを置換する。

--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -4,7 +4,7 @@
 
 Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker flowを一元的に定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、CodexとChatGPTはruntime wrapperからそれらを呼び出す。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、task trackingは専用Skill、runtime固有処理はwrapperへ分離する。
 
 この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。
 
@@ -13,9 +13,9 @@ Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker
 - `親が実行`: Codex親agentがSkillを直接実行する。
 - `親が呼び出し、sub-agentが実行`: Codex親agentがSkillを通じてsub-agentへ実作業を委譲する。
 - `利用者が親としてChatGPT chatで実行`: 利用者が独立chatを起動し、そのchatが指定wrapper Skillを直接実行する。
-- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、Codex親、sub-agent、ChatGPT chat固有の制御を持たずに実作業を行う。
+- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、runtime固有の制御を持たずに実作業を行う。
 
-ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。
+ChatGPT wrapperは別workerまたはsub-agentを起動しない。CodexとChatGPTは別runtime wrapperを使用するが、implementation、review、reportの意味論は同じcore Skillを使用する。
 
 ## Skill依存アーキテクチャ
 
@@ -25,6 +25,11 @@ ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwra
 ├─ implementation-worker
 ├─ review-worker
 └─ report-writer
+
+task tracking Skill
+├─ task-breakdown-planner
+├─ task-consistency-manager
+└─ progress-sync-manager
 
 runtime wrapper
 ├─ Codex
@@ -38,7 +43,7 @@ runtime wrapper
    └─ chat-handoff-manager
 ```
 
-### Core Skill
+## Core Skill
 
 - `work-context-manager`
   - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、write boundaryを解決する
@@ -49,9 +54,20 @@ runtime wrapper
 - `report-writer`
   - evidenceの意味を変えずにreportと簡易PR commentを生成する
 
-全core SkillはCodex親、Codex sub-agent、ChatGPT親chatのいずれにも依存しない。
+全core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存しない。
 
-### Runtime wrapper
+## task tracking Skill
+
+- `task-breakdown-planner`
+  - taskを完了判定可能な単位へ分割し、dependencies、exit criteria、estimate、phaseを定義する
+- `task-consistency-manager`
+  - significant workの開始前とscope変更時にcanonical task trackingとの整合を確認する
+- `progress-sync-manager`
+  - active、blocked、verification、PR、完了状態をtask／phaseへ同期する
+
+canonical task tracking fileはこれらの専用Skill経由で更新する。runtime wrapperまたはimplementation core Skillがtask更新規則を複製しない。
+
+## Runtime wrapper
 
 Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、fresh independent reviewer、report path、persistence、completion gateを所有する。
 
@@ -66,53 +82,32 @@ development-orchestrator [親]
 ├─ restart-handover-manager
 ├─ work-context-manager
 ├─ task-consistency-manager
+├─ task-breakdown-planner [必要時]
 ├─ design-doc-maintainer
-│  ├─ codex-delegation-executor
-│  │  └─ design-executor
-│  └─ task-consistency-manager
 ├─ tdd-executor [対象repositoryが明示要求する場合だけ]
+├─ implementation-executor [wrapper]
 │  ├─ work-context-manager
-│  ├─ codex-delegation-executor
-│  │  └─ implementation-executor [wrapper]
-│  │     ├─ work-context-manager
-│  │     └─ implementation-worker
-│  └─ sub-agent-task-manager [test evidence]
-├─ codex-delegation-executor
-│  ├─ implementation-executor [wrapper]
-│  │  ├─ work-context-manager
-│  │  └─ implementation-worker
-│  ├─ design-executor
-│  ├─ sub-agent-task-manager [verification]
-│  └─ report-output-manager [wrapper]
-│     ├─ work-context-manager
-│     └─ report-writer
+│  └─ implementation-worker
+├─ progress-sync-manager
 ├─ review-enforcer [wrapper]
 │  ├─ work-context-manager
-│  ├─ markdown-word-checker
-│  ├─ sub-agent-task-manager [normal reviewer]
-│  │  └─ review-worker
-│  ├─ sub-agent-task-manager [fresh independent final reviewer]
-│  │  └─ review-worker
-│  └─ report-output-manager
-│     └─ report-writer
-├─ progress-sync-manager
+│  ├─ review-worker [normal reviewer]
+│  └─ review-worker [fresh independent final reviewer]
+├─ report-output-manager [wrapper]
+│  ├─ work-context-manager
+│  └─ report-writer
 ├─ git-workflow-manager
-│  ├─ git-branch-starter
-│  ├─ git-commit-manager
-│  ├─ git-pr-submitter
-│  └─ git-review-followup-manager
 ├─ feedback-points-manager
-│  └─ feedback-points-sanitizer
 └─ skill-authoring-wrapper
 ```
+
+significant workは`task-consistency-manager`確認後に開始する。taskが未登録、大きい、曖昧、依存またはexit criteria不足の場合だけ`task-breakdown-planner`を実行する。実装、検証、review follow-up、blocked、完了は`progress-sync-manager`で同期する。
 
 ## TDD適用境界
 
 TDD要否は対象repositoryの明示的なinstruction、accepted design、または利用者指示が決める。
 
-- `development-orchestrator`は`work-context-manager`でgoverning sourceを確認する
 - TDDが明示要求される場合だけ`tdd-executor`を呼ぶ
-- `tdd-executor`は`implementation-executor`から`implementation-worker`を呼び出す
 - TDDが要求されない場合は`not applicable`として通常implementationへ進む
 - codeまたはtestを変更するという事実だけではTDD適用理由にならない
 - CodexSkill repository自身の保守にはTDDを適用しない
@@ -125,87 +120,31 @@ Codexでも独立最終レビューを必須とし、技術レビューの意味
 
 ### 通常レビューcycle
 
-1. 実装後に`review-enforcer`を実行する。
-2. 専用normal reviewer sub-agentを選ぶ。
-3. reviewerは`work-context-manager`でtargetとevidenceを解決する。
-4. initial reviewとして`review-worker`を実行する。
-5. finding、review criteria、reviewed HEAD、fix context、held、unexploredをreportへ保持する。
-6. required findingがある場合はimplementation flowへ戻す。
-7. fix後は原則として同じnormal reviewerを継続利用する。
-8. `review-worker`のfix verificationでfinding解消、fix diff、直接影響、同一欠陥class、新規変更領域を確認する。
-9. normal review／fix verification report、implementation report、verification report、tracking、designを保存してcommit／pushする。
-10. required findingが解消または明示的にdispositionされるまで、bounded normal cycleを継続する。
-
-元のnormal reviewerを継続できない場合は、replacement identityと理由を記録し、finding identity、criteria、reviewed HEAD、fix context、held、unexploredを完全に引き継ぐ。
-
-finding identityとsource severityはcontinuity-bearing evidenceとして維持する。severityを変更する場合は、source severity、new severity、evidence-based reason、approving authorityを明示する。downstream reportの転記誤りはhistorical reportを黙って書き換えず、current erratumとして記録する。
+1. 実装後に専用normal reviewerを選ぶ。
+2. `review-worker`のinitial reviewを実行する。
+3. finding、review criteria、reviewed HEAD、fix context、held、unexploredを維持する。
+4. required findingがある場合はimplementation flowへ戻す。
+5. review findingが新しいscopeを要求する場合、実装前にtask trackingへ反映する。
+6. fix後は原則として同じnormal reviewerがfix verificationを行う。
+7. report、tracking、design、validationを保存してcommit／pushする。
 
 ### Pre-freeze gate
 
-normal review cycleが収束した後、independent final reviewのtargetをfreezeする前に、次を完了する。
+normal review cycle収束後、次を完了する。
 
-- parent-owned end-of-Issue Skill-gap decision
-- current scopeで実行する`skill-authoring-wrapper`作業
-- feedback classificationと`feedback-points-manager`によるledger同期
+- end-of-Issue Skill-gap decision
+- feedback classificationとledger同期
 - repository-backed normal handoff
-- implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report
+- implementation、design、workflow、configuration、tracking、各report
 - current-HEAD validationとCI evidence
 
-上記の処理でrepository fileが変わった場合、validation、report、tracking、commit／pushを行い、normal reviewまたはfix verificationへ戻る。新しいrepository writeが残った状態でfreezeしてはならない。
+上記でrepositoryが変わった場合はnormal reviewまたはfix verificationへ戻る。
 
 ### 独立最終レビュー
 
-pre-freeze gateを通過し、全ての非final変更がcommit／pushされた後に、independent-final-review report pathを予約し、その時点のcurrent HEADを`reviewed implementation HEAD`として固定する。
+全非final変更をcommit／pushした後、その時点のHEADを`reviewed implementation HEAD`として固定し、implementation、review fix、normal reviewに参加していないfresh reviewerがindependent final reviewを実行する。
 
-fresh reviewerは次を満たす。
-
-- implementation sub-agentと異なること
-- 通常reviewerと異なること
-- review fixを実装していないこと
-- 原則`fork_turns: "none"`で起動すること
-- frozen reviewed implementation HEADを対象とすること
-- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
-- reviewer identityとindependence evidenceを記録すること
-- `review-worker`のindependent final reviewを実行すること
-- 過去review結論を読む前に独立passを行うこと
-- normal review reportとは別にindependent final review reportを作ること
-
-独立最終レビューでrequired findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationまたはpre-freeze処理へ戻る。HEAD更新後はnormal reviewerでfix verificationを行い、さらに別のfresh reviewerで独立最終レビューをやり直す。
-
-normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
-
-## 最終review reportの終端規則
-
-独立最終レビューのtechnical verdictは`reviewed implementation HEAD`へ結び付ける。
-
-詳細reportをrepositoryへ保存する必要がある場合、次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
-
-- independent-final-review report pathはreview開始前に予約済みである
-- report-attestation commitのfirst parentはreviewed implementation HEADである
-- reviewed implementation HEADの後に存在するcommitはこの1件だけである
-- diffは予約済みindependent-final-review report pathだけを変更する
-- reportはreviewed implementation HEADとadministrative attestationであることを明記する
-- executable、Skill、design、workflow、configuration、tracking、feedback、handoff、product fileを変更しない
-- report-attestation commit以後にrepository commitを作らない
-- 親またはwrapperがallowlist diffを検証し、結果をPR bodyまたはPR commentへ記録する
-
-完了identityは次のpairで表す。
-
-```yaml
-reviewed_implementation_head: full_sha
-report_attestation_head: full_sha | null
-```
-
-report-attestation commitは新しいimplementation contentへverdictを転用するものではない。条件外のpost-review commitが1件でも発生した場合、完了状態を無効化し、normal fix verificationとfresh independent final reviewをやり直す。
-
-attestation後に許可するのはGit HEADを変更しない処理だけである。
-
-- PR body／PR commentの更新
-- review request
-- external Issueの作成または更新
-- inlineまたはPR branch外のhandoff transport
-
-attestation後にrepository writeの必要性が判明した場合はterminal stateを無効化し、normal cycleへ戻る。
+passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを許可する。attestation後はrepository commitを追加しない。
 
 ## ChatGPT chat worker flow
 
@@ -213,7 +152,10 @@ attestation後にrepository writeの必要性が判明した場合はterminal st
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
 │  ├─ work-context-manager
+│  ├─ task-consistency-manager
+│  ├─ task-breakdown-planner [必要時]
 │  ├─ implementation-worker
+│  ├─ progress-sync-manager
 │  ├─ report-writer
 │  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
@@ -230,49 +172,21 @@ attestation後にrepository writeの必要性が判明した場合はterminal st
    └─ chat-handoff-manager
 ```
 
+### ChatGPT実装契約
+
+`chat-implementation-worker`は次の順でSkillを呼び出す。
+
+1. `work-context-manager`
+2. `task-consistency-manager`
+3. 必要時のみ`task-breakdown-planner`
+4. `implementation-worker`
+5. `progress-sync-manager`
+6. `report-writer`
+7. `chat-handoff-manager`
+
+実装開始前にtask tracking整合を確認し、taskが未登録または不十分なら先に更新する。progress、blocked、検証、PR、完了をtrackingへ同期した後にreportとhandoffを確定する。
+
 initial reviewとfix verificationは同じnormal review chatを継続する。independent final reviewは、implementation、review fix、normal reviewに参加していない新規chatで実施する。
-
-### 初回実装
-
-```text
-Issue #<number>を開始してください。
-```
-
-`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`と`implementation-worker`を呼び出す。
-
-### 初回レビュー
-
-```text
-PR #<number>を初回レビューしてください。
-```
-
-`chat-review-worker`がreview modeとreviewer identityを管理し、`review-worker`のinitial reviewを呼び出す。
-
-### レビュー対応
-
-```text
-レビュー結果に対応してください。
-```
-
-初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。
-
-### 修正確認
-
-```text
-PR #<number>の修正確認をしてください。
-```
-
-初回レビューと同じnormal review chatを継続し、`review-worker`のfix verificationを実行する。
-
-### 独立最終レビュー
-
-```text
-PR #<number>を独立レビューしてください。
-```
-
-新規chatでfrozen reviewed implementation HEADを対象に`review-worker`のindependent final reviewを実行する。過去reviewの結論は独立pass後に照合する。
-
-passing reportをrepositoryへ保存する場合は、Codexと同じreport-attestation終端規則を適用する。final handoffはattestation後にinlineで返し、repository commitを追加しない。
 
 ## ChatGPT登録用Skillセット
 
@@ -290,7 +204,13 @@ ChatGPTへ登録するwrapper Skillは次の4つである。
 - `review-worker`
 - `report-writer`
 
-GitHub Releaseでは、8 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
+必須task tracking Skillは次の3つである。
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+GitHub Releaseでは、11 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
 
 ```text
 chatgpt-worker-skills.zip
@@ -301,217 +221,59 @@ chatgpt-worker-skills.zip
 ├─ work-context-manager/
 ├─ implementation-worker/
 ├─ review-worker/
-└─ report-writer/
+├─ report-writer/
+├─ task-breakdown-planner/
+├─ task-consistency-manager/
+└─ progress-sync-manager/
 ```
 
-各directoryには少なくとも`SKILL.md`が存在し、front matterの`name`とdirectory名を一致させる。
-
-このZIPをChatGPTへuploadし、wrapperと依存core Skillを一括登録する。
+build scriptは全`chat-*`wrapper、必須core Skill、必須task tracking Skillを検出し、ZIP root集合と一致することを検証する。
 
 ## Handoff
 
-handoff contractを複数Skillから同一fileとして参照しない。`chat-handoff-manager`を独立Skillとして使用する。
+handoffは次を保持する。
 
-- reportとhandoffを別成果物とする
-- schema version 3を使用する
-- typed projectionとversioned `source_payloads`の両方を保持する
-- source core Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
-- development policy、planned validation、required failure diagnostics、blocked stateを保持する
-- implementation failure diagnosticsとblocked itemsを保持する
-- reviewer identity、reviewer continuity、independence evidenceを保持する
-- reserved report pathsとreport-attestation allowed flag、first-parent、allowlist、forbidden path class、validation resultを保持する
-- full findingのorigin、location、impact、evidence、required actionを保持する
-- reviewed HEAD、required coverage、held、unexplored、requirements、intentionally untouched、test、CI artifact、commit、report／comment referenceを保持する
-- schema version 1／2のoriginal packetを`source_payloads`として保存し、mapping不能fieldを捨てない
-- repository write可能時は通常handoffを`reports/handoffs/`へ保存する
-- PRまたはIssueから一意に特定できる場合は次workerがconnectorで取得する
-- 一意に特定できない場合だけ利用者へpathまたはpacket本文を求める
-- 前workerの権限は次chatへ自動継承しない
-- unknownを推測で補完しない
-- target Skill、mode、必要権限、参照先をpacketへ記録する
-- final independent review後のhandoffはinlineまたはPR branch外でtransportし、report-attestation後のcommitを追加しない
+- target repository、Issue、PR、branch、current HEAD
+- task identity、tracking path、phase、state、dependencies、exit criteria
+- accepted scope、non-goal、development policy、planned validation
+- implementation evidence、failure diagnostics、blocked items
+- finding、reviewed HEAD、held、unexplored
+- report、PR comment、workflow run、artifact参照
+- next workerが実行すべきtracking action
 
-## Release flow
+CI evidenceはpacketのtarget HEADと一致させ、別SHAのrunを代用しない。
 
-`.github/workflows/release-chatgpt-worker-skills.yml`を使用する。
+## Skill dependencyの扱い
 
-### pull request validation
+- wrapperは必要なcore Skillとtask tracking SkillをSkill名で呼び出す
+- Skill間で同一fileを共有しない
+- 各Skillは自directory内で完結する
+- dependency Skillが利用できない場合、wrapperは処理を複製せずmissing dependencyとして停止する
+- ChatGPT登録用ZIPにはwrapper、必須core Skill、必須task tracking Skillを同時に含める
 
-- `AGENTS.md`、`README.md`、全Skill、`shared/**`、design、tasks、reports、builder、repository validator、workflowの変更で実行する
-- forbidden shared runtime pathだけを追加する変更でもvalidation workflowを起動する
-- `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
-- build jobは`contents: read`だけを持ち、checkout credentialを保持しない
-- `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
-- 全`chat-*` wrapperと必須core Skillを検出する
-- missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
-- 単一`chatgpt-worker-skills.zip`を作成する
-- ZIP rootが検出Skill集合と一致することを確認する
-- ZIPをworkflow artifactとして保存する
-- GitHub Releaseは更新しない
+## CodexSkill repositoryの検証方針
 
-### Rolling normal Release
+CodexSkill repository自身にはTDDを適用しない。
 
-- 対象変更が`main`へpushされた場合に実行する
-- push後の`main` HEADでread-only validation／build jobを実行する
-- build成功後だけ別publish jobへ`contents: write`を付与する
-- build jobの検証済みartifactをpublish jobへ渡す
-- rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する
-- 固定通常Release `ChatGPT Worker Skills`へZIPを添付または置換する
+- Red/Green用testを追加しない
+- この変更専用のcontract testを追加しない
+- TDD用workflowを追加しない
+- repository validator、Skill dependency validation、ZIP build、配布物構造確認を使用する
+- 自動検証がない部分は設計書、Skill、workflow、Issue、PR説明の整合性をreviewする
 
-### PR merge Pre-release
+## Merge境界
 
-- `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
-- `merge_commit_sha`でread-only validation／build jobを再実行する
-- build成功後だけ別publish jobへ`contents: write`を付与する
-- build jobの検証済みartifactをpublish jobへ渡す
-- tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する
-- `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成する
-- Pre-releaseへ`chatgpt-worker-skills.zip`を添付する
-- job再実行時は同じPR tag／Pre-releaseとAssetを更新する
-- 自動Pre-releaseの`release.published`イベントはtag prefixで除外し、二重build／uploadしない
+core Skill、task tracking Skill、wrapper、sub-agent、親agentはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
 
-### 手動Release／Pre-release
+## 完了条件
 
-- 利用者がGitHub UIまたはAPIで公開した`release.published`イベントで実行する
-- Release tagが指すcommitでread-only validation／build jobを実行する
-- build成功後だけ別upload jobへ`contents: write`を付与する
-- build jobの検証済みZIPを、公開された同じReleaseへ添付する
-- 同名Assetがある場合は置換する
-- 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
-- Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない
-
-`workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
-
-Release時の共通file複製とrepository相対link書換は行わない。
-
-## 標準作業手順
-
-1. workflow開始時にCodexSkillの鮮度を確認する。
-2. 再開時は`restart-handover-manager`で状態を復元する。
-3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、write boundaryを解決する。
-4. `development-orchestrator`がtaskを選択する。
-5. `task-consistency-manager`でtrackingを同期する。
-6. 設計影響があれば`design-doc-maintainer`を実行する。
-7. 対象repositoryがTDDを要求する場合は`tdd-executor`を実行する。
-8. `implementation-executor`から`implementation-worker`を呼び出して実装する。
-9. focused validationと必要なfull validationを実行する。
-10. `report-output-manager`から`report-writer`を呼び出してimplementation／verification reportを保存する。
-11. `progress-sync-manager`でreportとtrackingを同期し、全非final変更をcommit／pushする。
-12. `review-enforcer`から`review-worker`を呼び出して通常review cycleを完了する。
-13. fixがあれば実装、validation、report、tracking、commit／push、normal fix verificationを繰り返す。
-14. normal cycle収束後、end-of-Issue Skill-gap decisionを行う。
-15. current scopeで必要な`skill-authoring-wrapper`処理を実行し、feedback classification、feedback ledger、normal handoffを保存する。
-16. steps 14から15でrepositoryが変わった場合、validation、report、tracking、commit／push、normal fix verificationを再実施する。
-17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、independent-final-review report pathを予約する。
-18. current HEADをreviewed implementation HEADとしてfreezeする。
-19. 別fresh reviewerによる独立最終reviewを実施する。
-20. repository changeが必要になった場合はfreezeを無効化し、normal cycleへ戻る。
-21. passing reportを保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
-22. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、validation evidenceを記録する。
-23. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
-24. mergeは利用者が行う。
-
-## Skill一覧
-
-### 入口と統括
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `development-orchestrator` | task選定から設計、実装、検証、レビュー、Git提出、pre-freeze gate、final attestation boundaryまでを統括する | 親が実行 |
-| `codex-delegation-executor` | 実作業の委譲先と実行profileを決める | 親が実行 |
-| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、report契約を固定する | 親が実行 |
-| `execution-cost-stabilizer` | retry、parallelism、実行コストを安定化する | 親が実行 |
-| `feedback-autonomy-boundary-manager` | 自律継続と利用者確認の境界を決める | 親が実行 |
-| `skill-authoring-wrapper` | core Skill／runtime wrapperをrepository標準へ揃える | 親が実行 |
-
-### 親非依存core Skill
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `work-context-manager` | authority、scope、target identity、policy、validation、CI、write boundaryを解決する | runtime非依存Skillとして実行 |
-| `implementation-worker` | initial implementationとreview follow-upを実施する | runtime非依存Skillとして実行 |
-| `review-worker` | initial review、fix verification、independent final reviewとattestation条件を返す | runtime非依存Skillとして実行 |
-| `report-writer` | evidence-faithfulなreport、簡易PR comment、persistence metadataを生成する | runtime非依存Skillとして実行 |
-
-### 計画と追跡
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `task-breakdown-planner` | issueをtaskとphaseへ分解する | 親が実行 |
-| `task-consistency-manager` | task、phase、実scopeを同期する | 親が実行 |
-| `progress-sync-manager` | report、tracking、実結果を同期する | 親が実行 |
-| `restart-handover-manager` | recorded stateから再開位置を復元する | 親が実行 |
-| `handover-memo-writer` | 別chat向けhandover memoを作成する | 親が実行 |
-
-### 設計と実装
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `design-doc-maintainer` | 設計影響と更新対象を判断する | 親が実行 |
-| `design-executor` | 決定済み設計変更を編集する | 親が実行 |
-| `tdd-executor` | 対象repositoryが要求するtest-first証拠をcore Skill経由で定義する | 親が実行 |
-| `implementation-executor` | executorを管理し、`implementation-worker`を呼び出すCodex wrapper | 親が実行 |
-
-### レビューと品質
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze gate、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
-| `markdown-word-checker` | Markdown lintと表記ルールを検証する | 親が実行 |
-| `feedback-coding-standards-enforcer` | coding standardを検証する | 親が実行 |
-| `feedback-issue-intake-fallback-manager` | Issue取得失敗時に要件を確保する | 親が実行 |
-
-### Gitとreport
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `git-workflow-manager` | branch、commit、push、PRを統括する | 親が実行 |
-| `git-branch-starter` | 作業branchを準備する | 親が実行 |
-| `git-commit-manager` | scoped commitを作成する | 親が実行 |
-| `git-pr-submitter` | PRを作成または更新する | 親が実行 |
-| `git-review-followup-manager` | review findingをimplementation flowへ戻す | 親が実行 |
-| `report-output-manager` | report path／persistence／report-attestationを管理し、`report-writer`を呼び出すCodex wrapper | 親が実行 |
-
-### ChatGPT runtime wrapper
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-upを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-review-worker` | ChatGPT上のinitial、fix verification、independent final review、report-attestationを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-report-writer` | ChatGPT上のsource discovery、report永続化、PR commentを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetを生成する | ChatGPT wrapperから呼び出す |
-
-## 共通規則
-
-- 対象repositoryのProject Instructionを優先する。
-- 解決可能なrepository stateを利用者へ再質問しない。
-- CodexSkill repository自身にはTDDを適用しない。
-- implementationは自分の変更へreview verdictを出さない。
-- reviewerはfindingを実装しない。
-- finding identityとsource severityを維持し、severity変更はsource／new severity、理由、承認主体を明示する。
-- reviewは詳細reportへ記録する。
-- CIは対象current HEAD SHAに紐づくrunだけを使用する。
-- 別SHAのrunを代用しない。
-- reportとhandoffを混同しない。
-- handoffはtyped projectionとversioned raw source payloadでcore Skill outputを欠落なくtransportする。
-- unknown、blocked、held、unexplored、失敗結果を消さない。
-- core Skillとwrapperは自directory外のshared fileへ依存しない。
-- dependency Skillが存在しない場合、wrapperは処理を複製せずmissing dependencyとして停止する。
-- end-of-Issue Skill decision、feedback ledger、normal handoff、report、trackingをindependent final review前に確定する。
-- pre-freeze処理でrepositoryが変わった場合はnormal reviewへ戻る。
-- independent final review後は条件を満たす1回のreport-attestation commit以外のGit commitを作らない。
-- attestation後はrepository-writing Skillを呼ばない。
-- worker、sub-agent、親agentはmergeしない。
-
-## 保守規則
-
-- Skill追加または責務変更時は本設計書を更新する。
-- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同一内容に保つ。
-- ChatGPT Skill package変更時はRelease workflowと`design/chat-worker-skill-design.md`も更新する。
-- ChatGPT Project Instruction例を変更する場合は`design/chatgpt-project-instruction-example.md`を更新する。
-- review lifecycle変更時は`review-worker`、`review-enforcer`、`chat-review-worker`、`report-writer`、`report-output-manager`、本設計書、専用設計書を同時更新する。
-- handoff schema変更時は`chat-handoff-manager`、ChatGPT wrapper、両設計書、Issue／trackingを同期する。
-- core Skill dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
-- `scripts/verify_skill_repository.py`でactive Markdown link、Skill依存、front matter、symlink、削除済みshared runtime path、hierarchy design同期を検証する。
-- workflow trigger変更時はforbidden pathだけの変更でもvalidatorが起動するcoverageを両設計書とPR説明へ同期する。
-- 既存設計書の変更時は、構成変更と無関係な節を削除せず、矛盾する箇所だけを置換する。
+- implementation、review、reportの意味論が親非依存core Skillとして定義されている
+- task trackingの分割、整合、進捗同期が専用Skillへ分離されている
+- ChatGPT実装workerがtask整合確認後に実装を開始する
+- wrapperがtask更新規則を独自実装しない
+- wrapper、core Skill、task tracking Skillの11 Skillを単一ZIPで登録できる
+- hierarchy design、ChatGPT worker design、Skill contract、build scriptが同期している
+- current HEAD固有CI規則が反映されている
+- CodexSkill repositoryへTDDを適用しない
+- reportとhandoffが別成果物として維持される
+- mergeを実施しない

--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -4,7 +4,7 @@
 
 Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker flowを一元的に定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、task trackingは専用Skill、runtime固有処理はwrapperへ分離する。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、CodexとChatGPTはruntime wrapperからそれらを呼び出す。
 
 この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。
 
@@ -13,9 +13,9 @@ Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker
 - `親が実行`: Codex親agentがSkillを直接実行する。
 - `親が呼び出し、sub-agentが実行`: Codex親agentがSkillを通じてsub-agentへ実作業を委譲する。
 - `利用者が親としてChatGPT chatで実行`: 利用者が独立chatを起動し、そのchatが指定wrapper Skillを直接実行する。
-- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、runtime固有の制御を持たずに実作業を行う。
+- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、Codex親、sub-agent、ChatGPT chat固有の制御を持たずに実作業を行う。
 
-ChatGPT wrapperは別workerまたはsub-agentを起動しない。CodexとChatGPTは別runtime wrapperを使用するが、implementation、review、reportの意味論は同じcore Skillを使用する。
+ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。
 
 ## Skill依存アーキテクチャ
 
@@ -25,11 +25,6 @@ ChatGPT wrapperは別workerまたはsub-agentを起動しない。CodexとChatGP
 ├─ implementation-worker
 ├─ review-worker
 └─ report-writer
-
-task tracking Skill
-├─ task-breakdown-planner
-├─ task-consistency-manager
-└─ progress-sync-manager
 
 runtime wrapper
 ├─ Codex
@@ -43,7 +38,7 @@ runtime wrapper
    └─ chat-handoff-manager
 ```
 
-## Core Skill
+### Core Skill
 
 - `work-context-manager`
   - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、write boundaryを解決する
@@ -54,20 +49,9 @@ runtime wrapper
 - `report-writer`
   - evidenceの意味を変えずにreportと簡易PR commentを生成する
 
-全core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存しない。
+全core SkillはCodex親、Codex sub-agent、ChatGPT親chatのいずれにも依存しない。
 
-## task tracking Skill
-
-- `task-breakdown-planner`
-  - taskを完了判定可能な単位へ分割し、dependencies、exit criteria、estimate、phaseを定義する
-- `task-consistency-manager`
-  - significant workの開始前とscope変更時にcanonical task trackingとの整合を確認する
-- `progress-sync-manager`
-  - active、blocked、verification、PR、完了状態をtask／phaseへ同期する
-
-canonical task tracking fileはこれらの専用Skill経由で更新する。runtime wrapperまたはimplementation core Skillがtask更新規則を複製しない。
-
-## Runtime wrapper
+### Runtime wrapper
 
 Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、fresh independent reviewer、report path、persistence、completion gateを所有する。
 
@@ -82,32 +66,53 @@ development-orchestrator [親]
 ├─ restart-handover-manager
 ├─ work-context-manager
 ├─ task-consistency-manager
-├─ task-breakdown-planner [必要時]
 ├─ design-doc-maintainer
+│  ├─ codex-delegation-executor
+│  │  └─ design-executor
+│  └─ task-consistency-manager
 ├─ tdd-executor [対象repositoryが明示要求する場合だけ]
-├─ implementation-executor [wrapper]
 │  ├─ work-context-manager
-│  └─ implementation-worker
-├─ progress-sync-manager
+│  ├─ codex-delegation-executor
+│  │  └─ implementation-executor [wrapper]
+│  │     ├─ work-context-manager
+│  │     └─ implementation-worker
+│  └─ sub-agent-task-manager [test evidence]
+├─ codex-delegation-executor
+│  ├─ implementation-executor [wrapper]
+│  │  ├─ work-context-manager
+│  │  └─ implementation-worker
+│  ├─ design-executor
+│  ├─ sub-agent-task-manager [verification]
+│  └─ report-output-manager [wrapper]
+│     ├─ work-context-manager
+│     └─ report-writer
 ├─ review-enforcer [wrapper]
 │  ├─ work-context-manager
-│  ├─ review-worker [normal reviewer]
-│  └─ review-worker [fresh independent final reviewer]
-├─ report-output-manager [wrapper]
-│  ├─ work-context-manager
-│  └─ report-writer
+│  ├─ markdown-word-checker
+│  ├─ sub-agent-task-manager [normal reviewer]
+│  │  └─ review-worker
+│  ├─ sub-agent-task-manager [fresh independent final reviewer]
+│  │  └─ review-worker
+│  └─ report-output-manager
+│     └─ report-writer
+├─ progress-sync-manager
 ├─ git-workflow-manager
+│  ├─ git-branch-starter
+│  ├─ git-commit-manager
+│  ├─ git-pr-submitter
+│  └─ git-review-followup-manager
 ├─ feedback-points-manager
+│  └─ feedback-points-sanitizer
 └─ skill-authoring-wrapper
 ```
-
-significant workは`task-consistency-manager`確認後に開始する。taskが未登録、大きい、曖昧、依存またはexit criteria不足の場合だけ`task-breakdown-planner`を実行する。実装、検証、review follow-up、blocked、完了は`progress-sync-manager`で同期する。
 
 ## TDD適用境界
 
 TDD要否は対象repositoryの明示的なinstruction、accepted design、または利用者指示が決める。
 
+- `development-orchestrator`は`work-context-manager`でgoverning sourceを確認する
 - TDDが明示要求される場合だけ`tdd-executor`を呼ぶ
+- `tdd-executor`は`implementation-executor`から`implementation-worker`を呼び出す
 - TDDが要求されない場合は`not applicable`として通常implementationへ進む
 - codeまたはtestを変更するという事実だけではTDD適用理由にならない
 - CodexSkill repository自身の保守にはTDDを適用しない
@@ -120,31 +125,87 @@ Codexでも独立最終レビューを必須とし、技術レビューの意味
 
 ### 通常レビューcycle
 
-1. 実装後に専用normal reviewerを選ぶ。
-2. `review-worker`のinitial reviewを実行する。
-3. finding、review criteria、reviewed HEAD、fix context、held、unexploredを維持する。
-4. required findingがある場合はimplementation flowへ戻す。
-5. review findingが新しいscopeを要求する場合、実装前にtask trackingへ反映する。
-6. fix後は原則として同じnormal reviewerがfix verificationを行う。
-7. report、tracking、design、validationを保存してcommit／pushする。
+1. 実装後に`review-enforcer`を実行する。
+2. 専用normal reviewer sub-agentを選ぶ。
+3. reviewerは`work-context-manager`でtargetとevidenceを解決する。
+4. initial reviewとして`review-worker`を実行する。
+5. finding、review criteria、reviewed HEAD、fix context、held、unexploredをreportへ保持する。
+6. required findingがある場合はimplementation flowへ戻す。
+7. fix後は原則として同じnormal reviewerを継続利用する。
+8. `review-worker`のfix verificationでfinding解消、fix diff、直接影響、同一欠陥class、新規変更領域を確認する。
+9. normal review／fix verification report、implementation report、verification report、tracking、designを保存してcommit／pushする。
+10. required findingが解消または明示的にdispositionされるまで、bounded normal cycleを継続する。
+
+元のnormal reviewerを継続できない場合は、replacement identityと理由を記録し、finding identity、criteria、reviewed HEAD、fix context、held、unexploredを完全に引き継ぐ。
+
+finding identityとsource severityはcontinuity-bearing evidenceとして維持する。severityを変更する場合は、source severity、new severity、evidence-based reason、approving authorityを明示する。downstream reportの転記誤りはhistorical reportを黙って書き換えず、current erratumとして記録する。
 
 ### Pre-freeze gate
 
-normal review cycle収束後、次を完了する。
+normal review cycleが収束した後、independent final reviewのtargetをfreezeする前に、次を完了する。
 
-- end-of-Issue Skill-gap decision
-- feedback classificationとledger同期
+- parent-owned end-of-Issue Skill-gap decision
+- current scopeで実行する`skill-authoring-wrapper`作業
+- feedback classificationと`feedback-points-manager`によるledger同期
 - repository-backed normal handoff
-- implementation、design、workflow、configuration、tracking、各report
+- implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report
 - current-HEAD validationとCI evidence
 
-上記でrepositoryが変わった場合はnormal reviewまたはfix verificationへ戻る。
+上記の処理でrepository fileが変わった場合、validation、report、tracking、commit／pushを行い、normal reviewまたはfix verificationへ戻る。新しいrepository writeが残った状態でfreezeしてはならない。
 
 ### 独立最終レビュー
 
-全非final変更をcommit／pushした後、その時点のHEADを`reviewed implementation HEAD`として固定し、implementation、review fix、normal reviewに参加していないfresh reviewerがindependent final reviewを実行する。
+pre-freeze gateを通過し、全ての非final変更がcommit／pushされた後に、independent-final-review report pathを予約し、その時点のcurrent HEADを`reviewed implementation HEAD`として固定する。
 
-passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを許可する。attestation後はrepository commitを追加しない。
+fresh reviewerは次を満たす。
+
+- implementation sub-agentと異なること
+- 通常reviewerと異なること
+- review fixを実装していないこと
+- 原則`fork_turns: "none"`で起動すること
+- frozen reviewed implementation HEADを対象とすること
+- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
+- reviewer identityとindependence evidenceを記録すること
+- `review-worker`のindependent final reviewを実行すること
+- 過去review結論を読む前に独立passを行うこと
+- normal review reportとは別にindependent final review reportを作ること
+
+独立最終レビューでrequired findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationまたはpre-freeze処理へ戻る。HEAD更新後はnormal reviewerでfix verificationを行い、さらに別のfresh reviewerで独立最終レビューをやり直す。
+
+normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
+
+## 最終review reportの終端規則
+
+独立最終レビューのtechnical verdictは`reviewed implementation HEAD`へ結び付ける。
+
+詳細reportをrepositoryへ保存する必要がある場合、次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
+
+- independent-final-review report pathはreview開始前に予約済みである
+- report-attestation commitのfirst parentはreviewed implementation HEADである
+- reviewed implementation HEADの後に存在するcommitはこの1件だけである
+- diffは予約済みindependent-final-review report pathだけを変更する
+- reportはreviewed implementation HEADとadministrative attestationであることを明記する
+- executable、Skill、design、workflow、configuration、tracking、feedback、handoff、product fileを変更しない
+- report-attestation commit以後にrepository commitを作らない
+- 親またはwrapperがallowlist diffを検証し、結果をPR bodyまたはPR commentへ記録する
+
+完了identityは次のpairで表す。
+
+```yaml
+reviewed_implementation_head: full_sha
+report_attestation_head: full_sha | null
+```
+
+report-attestation commitは新しいimplementation contentへverdictを転用するものではない。条件外のpost-review commitが1件でも発生した場合、完了状態を無効化し、normal fix verificationとfresh independent final reviewをやり直す。
+
+attestation後に許可するのはGit HEADを変更しない処理だけである。
+
+- PR body／PR commentの更新
+- review request
+- external Issueの作成または更新
+- inlineまたはPR branch外のhandoff transport
+
+attestation後にrepository writeの必要性が判明した場合はterminal stateを無効化し、normal cycleへ戻る。
 
 ## ChatGPT chat worker flow
 
@@ -152,10 +213,7 @@ passing reportをrepositoryへ保存する場合は、予約済みreport pathだ
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
 │  ├─ work-context-manager
-│  ├─ task-consistency-manager
-│  ├─ task-breakdown-planner [必要時]
 │  ├─ implementation-worker
-│  ├─ progress-sync-manager
 │  ├─ report-writer
 │  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
@@ -172,21 +230,49 @@ passing reportをrepositoryへ保存する場合は、予約済みreport pathだ
    └─ chat-handoff-manager
 ```
 
-### ChatGPT実装契約
-
-`chat-implementation-worker`は次の順でSkillを呼び出す。
-
-1. `work-context-manager`
-2. `task-consistency-manager`
-3. 必要時のみ`task-breakdown-planner`
-4. `implementation-worker`
-5. `progress-sync-manager`
-6. `report-writer`
-7. `chat-handoff-manager`
-
-実装開始前にtask tracking整合を確認し、taskが未登録または不十分なら先に更新する。progress、blocked、検証、PR、完了をtrackingへ同期した後にreportとhandoffを確定する。
-
 initial reviewとfix verificationは同じnormal review chatを継続する。independent final reviewは、implementation、review fix、normal reviewに参加していない新規chatで実施する。
+
+### 初回実装
+
+```text
+Issue #<number>を開始してください。
+```
+
+`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`と`implementation-worker`を呼び出す。
+
+### 初回レビュー
+
+```text
+PR #<number>を初回レビューしてください。
+```
+
+`chat-review-worker`がreview modeとreviewer identityを管理し、`review-worker`のinitial reviewを呼び出す。
+
+### レビュー対応
+
+```text
+レビュー結果に対応してください。
+```
+
+初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。
+
+### 修正確認
+
+```text
+PR #<number>の修正確認をしてください。
+```
+
+初回レビューと同じnormal review chatを継続し、`review-worker`のfix verificationを実行する。
+
+### 独立最終レビュー
+
+```text
+PR #<number>を独立レビューしてください。
+```
+
+新規chatでfrozen reviewed implementation HEADを対象に`review-worker`のindependent final reviewを実行する。過去reviewの結論は独立pass後に照合する。
+
+passing reportをrepositoryへ保存する場合は、Codexと同じreport-attestation終端規則を適用する。final handoffはattestation後にinlineで返し、repository commitを追加しない。
 
 ## ChatGPT登録用Skillセット
 
@@ -204,13 +290,7 @@ ChatGPTへ登録するwrapper Skillは次の4つである。
 - `review-worker`
 - `report-writer`
 
-必須task tracking Skillは次の3つである。
-
-- `task-breakdown-planner`
-- `task-consistency-manager`
-- `progress-sync-manager`
-
-GitHub Releaseでは、11 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
+GitHub Releaseでは、8 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
 
 ```text
 chatgpt-worker-skills.zip
@@ -221,59 +301,217 @@ chatgpt-worker-skills.zip
 ├─ work-context-manager/
 ├─ implementation-worker/
 ├─ review-worker/
-├─ report-writer/
-├─ task-breakdown-planner/
-├─ task-consistency-manager/
-└─ progress-sync-manager/
+└─ report-writer/
 ```
 
-build scriptは全`chat-*`wrapper、必須core Skill、必須task tracking Skillを検出し、ZIP root集合と一致することを検証する。
+各directoryには少なくとも`SKILL.md`が存在し、front matterの`name`とdirectory名を一致させる。
+
+このZIPをChatGPTへuploadし、wrapperと依存core Skillを一括登録する。
 
 ## Handoff
 
-handoffは次を保持する。
+handoff contractを複数Skillから同一fileとして参照しない。`chat-handoff-manager`を独立Skillとして使用する。
 
-- target repository、Issue、PR、branch、current HEAD
-- task identity、tracking path、phase、state、dependencies、exit criteria
-- accepted scope、non-goal、development policy、planned validation
-- implementation evidence、failure diagnostics、blocked items
-- finding、reviewed HEAD、held、unexplored
-- report、PR comment、workflow run、artifact参照
-- next workerが実行すべきtracking action
+- reportとhandoffを別成果物とする
+- schema version 3を使用する
+- typed projectionとversioned `source_payloads`の両方を保持する
+- source core Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
+- development policy、planned validation、required failure diagnostics、blocked stateを保持する
+- implementation failure diagnosticsとblocked itemsを保持する
+- reviewer identity、reviewer continuity、independence evidenceを保持する
+- reserved report pathsとreport-attestation allowed flag、first-parent、allowlist、forbidden path class、validation resultを保持する
+- full findingのorigin、location、impact、evidence、required actionを保持する
+- reviewed HEAD、required coverage、held、unexplored、requirements、intentionally untouched、test、CI artifact、commit、report／comment referenceを保持する
+- schema version 1／2のoriginal packetを`source_payloads`として保存し、mapping不能fieldを捨てない
+- repository write可能時は通常handoffを`reports/handoffs/`へ保存する
+- PRまたはIssueから一意に特定できる場合は次workerがconnectorで取得する
+- 一意に特定できない場合だけ利用者へpathまたはpacket本文を求める
+- 前workerの権限は次chatへ自動継承しない
+- unknownを推測で補完しない
+- target Skill、mode、必要権限、参照先をpacketへ記録する
+- final independent review後のhandoffはinlineまたはPR branch外でtransportし、report-attestation後のcommitを追加しない
 
-CI evidenceはpacketのtarget HEADと一致させ、別SHAのrunを代用しない。
+## Release flow
 
-## Skill dependencyの扱い
+`.github/workflows/release-chatgpt-worker-skills.yml`を使用する。
 
-- wrapperは必要なcore Skillとtask tracking SkillをSkill名で呼び出す
-- Skill間で同一fileを共有しない
-- 各Skillは自directory内で完結する
-- dependency Skillが利用できない場合、wrapperは処理を複製せずmissing dependencyとして停止する
-- ChatGPT登録用ZIPにはwrapper、必須core Skill、必須task tracking Skillを同時に含める
+### pull request validation
 
-## CodexSkill repositoryの検証方針
+- `AGENTS.md`、`README.md`、全Skill、`shared/**`、design、tasks、reports、builder、repository validator、workflowの変更で実行する
+- forbidden shared runtime pathだけを追加する変更でもvalidation workflowを起動する
+- `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
+- build jobは`contents: read`だけを持ち、checkout credentialを保持しない
+- `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
+- 全`chat-*` wrapperと必須core Skillを検出する
+- missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
+- 単一`chatgpt-worker-skills.zip`を作成する
+- ZIP rootが検出Skill集合と一致することを確認する
+- ZIPをworkflow artifactとして保存する
+- GitHub Releaseは更新しない
 
-CodexSkill repository自身にはTDDを適用しない。
+### Rolling normal Release
 
-- Red/Green用testを追加しない
-- この変更専用のcontract testを追加しない
-- TDD用workflowを追加しない
-- repository validator、Skill dependency validation、ZIP build、配布物構造確認を使用する
-- 自動検証がない部分は設計書、Skill、workflow、Issue、PR説明の整合性をreviewする
+- 対象変更が`main`へpushされた場合に実行する
+- push後の`main` HEADでread-only validation／build jobを実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する
+- 固定通常Release `ChatGPT Worker Skills`へZIPを添付または置換する
 
-## Merge境界
+### PR merge Pre-release
 
-core Skill、task tracking Skill、wrapper、sub-agent、親agentはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
+- `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
+- `merge_commit_sha`でread-only validation／build jobを再実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する
+- `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成する
+- Pre-releaseへ`chatgpt-worker-skills.zip`を添付する
+- job再実行時は同じPR tag／Pre-releaseとAssetを更新する
+- 自動Pre-releaseの`release.published`イベントはtag prefixで除外し、二重build／uploadしない
 
-## 完了条件
+### 手動Release／Pre-release
 
-- implementation、review、reportの意味論が親非依存core Skillとして定義されている
-- task trackingの分割、整合、進捗同期が専用Skillへ分離されている
-- ChatGPT実装workerがtask整合確認後に実装を開始する
-- wrapperがtask更新規則を独自実装しない
-- wrapper、core Skill、task tracking Skillの11 Skillを単一ZIPで登録できる
-- hierarchy design、ChatGPT worker design、Skill contract、build scriptが同期している
-- current HEAD固有CI規則が反映されている
-- CodexSkill repositoryへTDDを適用しない
-- reportとhandoffが別成果物として維持される
-- mergeを実施しない
+- 利用者がGitHub UIまたはAPIで公開した`release.published`イベントで実行する
+- Release tagが指すcommitでread-only validation／build jobを実行する
+- build成功後だけ別upload jobへ`contents: write`を付与する
+- build jobの検証済みZIPを、公開された同じReleaseへ添付する
+- 同名Assetがある場合は置換する
+- 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
+- Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない
+
+`workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
+
+Release時の共通file複製とrepository相対link書換は行わない。
+
+## 標準作業手順
+
+1. workflow開始時にCodexSkillの鮮度を確認する。
+2. 再開時は`restart-handover-manager`で状態を復元する。
+3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、write boundaryを解決する。
+4. `development-orchestrator`がtaskを選択する。
+5. `task-consistency-manager`でtrackingを同期する。
+6. 設計影響があれば`design-doc-maintainer`を実行する。
+7. 対象repositoryがTDDを要求する場合は`tdd-executor`を実行する。
+8. `implementation-executor`から`implementation-worker`を呼び出して実装する。
+9. focused validationと必要なfull validationを実行する。
+10. `report-output-manager`から`report-writer`を呼び出してimplementation／verification reportを保存する。
+11. `progress-sync-manager`でreportとtrackingを同期し、全非final変更をcommit／pushする。
+12. `review-enforcer`から`review-worker`を呼び出して通常review cycleを完了する。
+13. fixがあれば実装、validation、report、tracking、commit／push、normal fix verificationを繰り返す。
+14. normal cycle収束後、end-of-Issue Skill-gap decisionを行う。
+15. current scopeで必要な`skill-authoring-wrapper`処理を実行し、feedback classification、feedback ledger、normal handoffを保存する。
+16. steps 14から15でrepositoryが変わった場合、validation、report、tracking、commit／push、normal fix verificationを再実施する。
+17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、independent-final-review report pathを予約する。
+18. current HEADをreviewed implementation HEADとしてfreezeする。
+19. 別fresh reviewerによる独立最終reviewを実施する。
+20. repository changeが必要になった場合はfreezeを無効化し、normal cycleへ戻る。
+21. passing reportを保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
+22. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、validation evidenceを記録する。
+23. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
+24. mergeは利用者が行う。
+
+## Skill一覧
+
+### 入口と統括
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `development-orchestrator` | task選定から設計、実装、検証、レビュー、Git提出、pre-freeze gate、final attestation boundaryまでを統括する | 親が実行 |
+| `codex-delegation-executor` | 実作業の委譲先と実行profileを決める | 親が実行 |
+| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、report契約を固定する | 親が実行 |
+| `execution-cost-stabilizer` | retry、parallelism、実行コストを安定化する | 親が実行 |
+| `feedback-autonomy-boundary-manager` | 自律継続と利用者確認の境界を決める | 親が実行 |
+| `skill-authoring-wrapper` | core Skill／runtime wrapperをrepository標準へ揃える | 親が実行 |
+
+### 親非依存core Skill
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `work-context-manager` | authority、scope、target identity、policy、validation、CI、write boundaryを解決する | runtime非依存Skillとして実行 |
+| `implementation-worker` | initial implementationとreview follow-upを実施する | runtime非依存Skillとして実行 |
+| `review-worker` | initial review、fix verification、independent final reviewとattestation条件を返す | runtime非依存Skillとして実行 |
+| `report-writer` | evidence-faithfulなreport、簡易PR comment、persistence metadataを生成する | runtime非依存Skillとして実行 |
+
+### 計画と追跡
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `task-breakdown-planner` | issueをtaskとphaseへ分解する | 親が実行 |
+| `task-consistency-manager` | task、phase、実scopeを同期する | 親が実行 |
+| `progress-sync-manager` | report、tracking、実結果を同期する | 親が実行 |
+| `restart-handover-manager` | recorded stateから再開位置を復元する | 親が実行 |
+| `handover-memo-writer` | 別chat向けhandover memoを作成する | 親が実行 |
+
+### 設計と実装
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `design-doc-maintainer` | 設計影響と更新対象を判断する | 親が実行 |
+| `design-executor` | 決定済み設計変更を編集する | 親が実行 |
+| `tdd-executor` | 対象repositoryが要求するtest-first証拠をcore Skill経由で定義する | 親が実行 |
+| `implementation-executor` | executorを管理し、`implementation-worker`を呼び出すCodex wrapper | 親が実行 |
+
+### レビューと品質
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze gate、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
+| `markdown-word-checker` | Markdown lintと表記ルールを検証する | 親が実行 |
+| `feedback-coding-standards-enforcer` | coding standardを検証する | 親が実行 |
+| `feedback-issue-intake-fallback-manager` | Issue取得失敗時に要件を確保する | 親が実行 |
+
+### Gitとreport
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `git-workflow-manager` | branch、commit、push、PRを統括する | 親が実行 |
+| `git-branch-starter` | 作業branchを準備する | 親が実行 |
+| `git-commit-manager` | scoped commitを作成する | 親が実行 |
+| `git-pr-submitter` | PRを作成または更新する | 親が実行 |
+| `git-review-followup-manager` | review findingをimplementation flowへ戻す | 親が実行 |
+| `report-output-manager` | report path／persistence／report-attestationを管理し、`report-writer`を呼び出すCodex wrapper | 親が実行 |
+
+### ChatGPT runtime wrapper
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-upを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-review-worker` | ChatGPT上のinitial、fix verification、independent final review、report-attestationを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-report-writer` | ChatGPT上のsource discovery、report永続化、PR commentを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetを生成する | ChatGPT wrapperから呼び出す |
+
+## 共通規則
+
+- 対象repositoryのProject Instructionを優先する。
+- 解決可能なrepository stateを利用者へ再質問しない。
+- CodexSkill repository自身にはTDDを適用しない。
+- implementationは自分の変更へreview verdictを出さない。
+- reviewerはfindingを実装しない。
+- finding identityとsource severityを維持し、severity変更はsource／new severity、理由、承認主体を明示する。
+- reviewは詳細reportへ記録する。
+- CIは対象current HEAD SHAに紐づくrunだけを使用する。
+- 別SHAのrunを代用しない。
+- reportとhandoffを混同しない。
+- handoffはtyped projectionとversioned raw source payloadでcore Skill outputを欠落なくtransportする。
+- unknown、blocked、held、unexplored、失敗結果を消さない。
+- core Skillとwrapperは自directory外のshared fileへ依存しない。
+- dependency Skillが存在しない場合、wrapperは処理を複製せずmissing dependencyとして停止する。
+- end-of-Issue Skill decision、feedback ledger、normal handoff、report、trackingをindependent final review前に確定する。
+- pre-freeze処理でrepositoryが変わった場合はnormal reviewへ戻る。
+- independent final review後は条件を満たす1回のreport-attestation commit以外のGit commitを作らない。
+- attestation後はrepository-writing Skillを呼ばない。
+- worker、sub-agent、親agentはmergeしない。
+
+## 保守規則
+
+- Skill追加または責務変更時は本設計書を更新する。
+- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同一内容に保つ。
+- ChatGPT Skill package変更時はRelease workflowと`design/chat-worker-skill-design.md`も更新する。
+- ChatGPT Project Instruction例を変更する場合は`design/chatgpt-project-instruction-example.md`を更新する。
+- review lifecycle変更時は`review-worker`、`review-enforcer`、`chat-review-worker`、`report-writer`、`report-output-manager`、本設計書、専用設計書を同時更新する。
+- handoff schema変更時は`chat-handoff-manager`、ChatGPT wrapper、両設計書、Issue／trackingを同期する。
+- core Skill dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
+- `scripts/verify_skill_repository.py`でactive Markdown link、Skill依存、front matter、symlink、削除済みshared runtime path、hierarchy design同期を検証する。
+- workflow trigger変更時はforbidden pathだけの変更でもvalidatorが起動するcoverageを両設計書とPR説明へ同期する。
+- 既存設計書の変更時は、構成変更と無関係な節を削除せず、矛盾する箇所だけを置換する。

--- a/reports/issue-59-chatgpt-task-skills-20260806.md
+++ b/reports/issue-59-chatgpt-task-skills-20260806.md
@@ -70,17 +70,9 @@ canonical task trackingはtask tracking Skill経由で更新し、wrapperが更�
 
 hierarchy designの正本と`skills/design/`配下のmirrorは同一内容とした。
 
-## Commit
-
-- `69d65655b0569f88c421e7dc06893a7017ba23a6`: ChatGPT配布ZIPへtask tracking Skillを追加
-- `478ee3d23e02c485fca9ee8aa741cea5a2e52036`: implementation wrapperへtask tracking flowを追加
-- `349fd609852f25a5638f8a4f30d1ea78b93bc7f4`: ChatGPT worker設計をtask tracking Skill構成へ同期
-- `e5b92dbd5ce9b26cdcfc29e037f7a7c11e55cf17`: hierarchy designをtask tracking Skill構成へ更新
-- `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`: hierarchy design mirrorを同期
-
 ## 検証
 
-最終HEADはPRコメントで記録する。詳細report自身を更新するとHEADが変わるため、本fileでは設計・実装内容を記録し、current HEAD一致CI、artifact ID、digestはPRコメントを最終証拠とする。別SHAのworkflow runは代用しない。
+current HEAD一致CI、artifact ID、digestはPRコメントを最終証拠とする。詳細report自身へCI結果を書き戻すとHEADが変わるため、本fileでは設計・実装内容のみを記録する。別SHAのworkflow runは代用しない。
 
 ## 結果
 

--- a/reports/issue-59-chatgpt-task-skills-20260806.md
+++ b/reports/issue-59-chatgpt-task-skills-20260806.md
@@ -77,25 +77,10 @@ hierarchy designの正本と`skills/design/`配下のmirrorは同一内容とし
 - `349fd609852f25a5638f8a4f30d1ea78b93bc7f4`: ChatGPT worker設計をtask tracking Skill構成へ同期
 - `e5b92dbd5ce9b26cdcfc29e037f7a7c11e55cf17`: hierarchy designをtask tracking Skill構成へ更新
 - `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`: hierarchy design mirrorを同期
-- `5dfd95aa2d93821b55c023c80b39193164f1cdb2`: reportへ設計同期結果を反映
-- `928a94502cd535dc163bc59e07df1fcdf31494e5`: reportへ検証結果を反映
-- `c5f80116620c123b9b6b81756ffb094bde11a1f1`: 最終HEAD
 
 ## 検証
 
-最終HEAD `c5f80116620c123b9b6b81756ffb094bde11a1f1`に一致するGitHub Actions workflow runを確認した。
-
-- Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `31049281139`
-- Run number: `153`
-- Status: `completed`
-- Conclusion: `success`
-- Artifact: `chatgpt-worker-skills-31049281139`
-- Artifact ID: `8947723723`
-- Digest: `sha256:b2e75db1761e3f671d896cc4d956b8518eb370ca8e4190019b4d1fab645ec1f8`
-- Artifact head SHA: `c5f80116620c123b9b6b81756ffb094bde11a1f1`
-
-このrunではrepository Skill architecture／active link validation、hierarchy design mirror一致、ChatGPT Skill ZIP build、11 Skillのarchive listing、artifact uploadが成功した。別SHAのworkflow runは代用していない。
+最終HEADはPRコメントで記録する。詳細report自身を更新するとHEADが変わるため、本fileでは設計・実装内容を記録し、current HEAD一致CI、artifact ID、digestはPRコメントを最終証拠とする。別SHAのworkflow runは代用しない。
 
 ## 結果
 

--- a/reports/issue-59-chatgpt-task-skills-20260806.md
+++ b/reports/issue-59-chatgpt-task-skills-20260806.md
@@ -77,20 +77,23 @@ hierarchy designの正本と`skills/design/`配下のmirrorは同一内容とし
 - `349fd609852f25a5638f8a4f30d1ea78b93bc7f4`: ChatGPT worker設計をtask tracking Skill構成へ同期
 - `e5b92dbd5ce9b26cdcfc29e037f7a7c11e55cf17`: hierarchy designをtask tracking Skill構成へ更新
 - `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`: hierarchy design mirrorを同期
+- `5dfd95aa2d93821b55c023c80b39193164f1cdb2`: 本レポートへ設計同期と最終検証結果を反映
 
 ## 検証
 
-設計書更新後HEAD `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`に一致するGitHub Actions workflow runを確認した。
+最終HEAD `5dfd95aa2d93821b55c023c80b39193164f1cdb2`に一致するGitHub Actions workflow runを確認した。
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `31049088040`
-- Run number: `150`
+- Run ID: `31049158870`
+- Run number: `151`
 - Status: `completed`
 - Conclusion: `success`
+- Artifact: `chatgpt-worker-skills-31049158870`
+- Artifact ID: `8947676260`
+- Digest: `sha256:6f100a3aa5099d17d5a2b4bb23fa629524341dc0ab2dc7c37d32ff591ce645cf`
+- Artifact head SHA: `5dfd95aa2d93821b55c023c80b39193164f1cdb2`
 
-このrunではrepository Skill architecture／active link validation、hierarchy design mirror一致、ChatGPT Skill ZIP build、11 Skillのarchive listing、artifact uploadが成功した。
-
-本report更新後はHEADが更新されるため、新HEADに一致するworkflow runを最終確認する。別SHAのrunは代用しない。
+このrunではrepository Skill architecture／active link validation、hierarchy design mirror一致、ChatGPT Skill ZIP build、11 Skillのarchive listing、artifact uploadが成功した。別SHAのworkflow runは代用していない。
 
 ## 結果
 

--- a/reports/issue-59-chatgpt-task-skills-20260806.md
+++ b/reports/issue-59-chatgpt-task-skills-20260806.md
@@ -78,21 +78,22 @@ hierarchy designの正本と`skills/design/`配下のmirrorは同一内容とし
 - `e5b92dbd5ce9b26cdcfc29e037f7a7c11e55cf17`: hierarchy designをtask tracking Skill構成へ更新
 - `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`: hierarchy design mirrorを同期
 - `5dfd95aa2d93821b55c023c80b39193164f1cdb2`: reportへ設計同期結果を反映
-- `928a94502cd535dc163bc59e07df1fcdf31494e5`: 最終検証用HEAD
+- `928a94502cd535dc163bc59e07df1fcdf31494e5`: reportへ検証結果を反映
+- `c5f80116620c123b9b6b81756ffb094bde11a1f1`: 最終HEAD
 
 ## 検証
 
-最終HEAD `928a94502cd535dc163bc59e07df1fcdf31494e5`に一致するGitHub Actions workflow runを確認した。
+最終HEAD `c5f80116620c123b9b6b81756ffb094bde11a1f1`に一致するGitHub Actions workflow runを確認した。
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `31049222899`
-- Run number: `152`
+- Run ID: `31049281139`
+- Run number: `153`
 - Status: `completed`
 - Conclusion: `success`
-- Artifact: `chatgpt-worker-skills-31049222899`
-- Artifact ID: `8947699074`
-- Digest: `sha256:c7f315942c97ecff7582cb093ac418b1c762054c409fecc77b7cc5b5170e595f`
-- Artifact head SHA: `928a94502cd535dc163bc59e07df1fcdf31494e5`
+- Artifact: `chatgpt-worker-skills-31049281139`
+- Artifact ID: `8947723723`
+- Digest: `sha256:b2e75db1761e3f671d896cc4d956b8518eb370ca8e4190019b4d1fab645ec1f8`
+- Artifact head SHA: `c5f80116620c123b9b6b81756ffb094bde11a1f1`
 
 このrunではrepository Skill architecture／active link validation、hierarchy design mirror一致、ChatGPT Skill ZIP build、11 Skillのarchive listing、artifact uploadが成功した。別SHAのworkflow runは代用していない。
 

--- a/reports/issue-59-chatgpt-task-skills-20260806.md
+++ b/reports/issue-59-chatgpt-task-skills-20260806.md
@@ -77,21 +77,22 @@ hierarchy designの正本と`skills/design/`配下のmirrorは同一内容とし
 - `349fd609852f25a5638f8a4f30d1ea78b93bc7f4`: ChatGPT worker設計をtask tracking Skill構成へ同期
 - `e5b92dbd5ce9b26cdcfc29e037f7a7c11e55cf17`: hierarchy designをtask tracking Skill構成へ更新
 - `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`: hierarchy design mirrorを同期
-- `5dfd95aa2d93821b55c023c80b39193164f1cdb2`: 本レポートへ設計同期と最終検証結果を反映
+- `5dfd95aa2d93821b55c023c80b39193164f1cdb2`: reportへ設計同期結果を反映
+- `928a94502cd535dc163bc59e07df1fcdf31494e5`: 最終検証用HEAD
 
 ## 検証
 
-最終HEAD `5dfd95aa2d93821b55c023c80b39193164f1cdb2`に一致するGitHub Actions workflow runを確認した。
+最終HEAD `928a94502cd535dc163bc59e07df1fcdf31494e5`に一致するGitHub Actions workflow runを確認した。
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `31049158870`
-- Run number: `151`
+- Run ID: `31049222899`
+- Run number: `152`
 - Status: `completed`
 - Conclusion: `success`
-- Artifact: `chatgpt-worker-skills-31049158870`
-- Artifact ID: `8947676260`
-- Digest: `sha256:6f100a3aa5099d17d5a2b4bb23fa629524341dc0ab2dc7c37d32ff591ce645cf`
-- Artifact head SHA: `5dfd95aa2d93821b55c023c80b39193164f1cdb2`
+- Artifact: `chatgpt-worker-skills-31049222899`
+- Artifact ID: `8947699074`
+- Digest: `sha256:c7f315942c97ecff7582cb093ac418b1c762054c409fecc77b7cc5b5170e595f`
+- Artifact head SHA: `928a94502cd535dc163bc59e07df1fcdf31494e5`
 
 このrunではrepository Skill architecture／active link validation、hierarchy design mirror一致、ChatGPT Skill ZIP build、11 Skillのarchive listing、artifact uploadが成功した。別SHAのworkflow runは代用していない。
 

--- a/reports/issue-59-chatgpt-task-skills-20260806.md
+++ b/reports/issue-59-chatgpt-task-skills-20260806.md
@@ -1,0 +1,71 @@
+# Issue #59 実装レポート
+
+## 対象
+
+- Repository: `ssaattww/CodexSkill`
+- Issue: #59 `task更新スキルがzipに同封されていないので、chatgpt側からtask更新できない`
+- PR: #60
+- Branch: `agent/issue-59-chatgpt-task-skills`
+
+## 方針
+
+CodexSkill repository policyに従いTDDは適用していない。既存repository validator、ChatGPT Skill ZIP build、archive root検証、GitHub Actions artifact生成を検証手段とした。
+
+## 原因
+
+`scripts/build_chatgpt_worker_skills.py`は全`chat-*` wrapperと4つのcore Skillだけを配布対象としていた。このため、canonical task trackingの更新を担当する次のSkillがChatGPT登録用ZIPに含まれていなかった。
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+また、`chat-implementation-worker`のRequired Skillsにもtask tracking flowが定義されていなかった。
+
+## 変更
+
+### 配布ZIP
+
+`scripts/build_chatgpt_worker_skills.py`へ`TASK_TRACKING_SKILLS`を追加し、上記3 Skillを必須配布rootとして扱うよう変更した。
+
+builderは各Skillについて従来どおり次を検証する。
+
+- Skill directoryと`SKILL.md`の存在
+- front matter `name`とdirectory名の一致
+- symlink不在
+- repository外shared runtime fileへの依存不在
+- archive rootと期待Skill集合の一致
+- 各rootの`SKILL.md`収録
+
+### ChatGPT implementation wrapper
+
+`chat-implementation-worker`へ次のflowを追加した。
+
+1. `task-consistency-manager`で実装前のtracking整合を確認する。
+2. trackingが欠落、曖昧、または分割必要な場合は`task-breakdown-planner`を使用する。
+3. 実装後、検証後、review follow-up後、blocked state変更後に`progress-sync-manager`でtask／phase状態を同期する。
+4. canonical task trackingをtask tracking Skill外から直接編集しない。
+
+## Commit
+
+- `69d65655b0569f88c421e7dc06893a7017ba23a6`: ChatGPT配布ZIPへtask tracking Skillを追加
+- `478ee3d23e02c485fca9ee8aa741cea5a2e52036`: implementation wrapperへtask tracking flowを追加
+
+## 検証
+
+HEAD `478ee3d23e02c485fca9ee8aa741cea5a2e52036`に一致するGitHub Actions workflow runを確認した。
+
+- Workflow: `Validate and release ChatGPT worker skills`
+- Run ID: `31048416494`
+- Run number: `146`
+- Status: `completed`
+- Conclusion: `success`
+
+このrunではrepository Skill architecture／active link validation、ChatGPT Skill ZIP build、archive listing、artifact uploadが成功した。
+
+本report追加後はHEADが更新されるため、新HEADに一致するworkflow runを別途確認する。別SHAのrunは代用しない。
+
+## 結果
+
+ChatGPT Skill upload用ZIPにtask tracking Skillが同封され、`chat-implementation-worker`からtaskの作成・整合確認・進捗同期をSkill契約に従って実行できる構成となった。
+
+mergeは実施していない。

--- a/reports/issue-59-chatgpt-task-skills-20260806.md
+++ b/reports/issue-59-chatgpt-task-skills-20260806.md
@@ -9,7 +9,7 @@
 
 ## 方針
 
-CodexSkill repository policyに従いTDDは適用していない。既存repository validator、ChatGPT Skill ZIP build、archive root検証、GitHub Actions artifact生成を検証手段とした。
+CodexSkill repository policyに従いTDDは適用していない。既存repository validator、ChatGPT Skill ZIP build、archive root検証、設計同期検証、GitHub Actions artifact生成を検証手段とした。
 
 ## 原因
 
@@ -19,15 +19,15 @@ CodexSkill repository policyに従いTDDは適用していない。既存reposit
 - `task-consistency-manager`
 - `progress-sync-manager`
 
-また、`chat-implementation-worker`のRequired Skillsにもtask tracking flowが定義されていなかった。
+また、`chat-implementation-worker`のRequired Skillsと設計書の配布構成が8 Skill前提のままで、task tracking flowが定義されていなかった。
 
 ## 変更
 
 ### 配布ZIP
 
-`scripts/build_chatgpt_worker_skills.py`へ`TASK_TRACKING_SKILLS`を追加し、上記3 Skillを必須配布rootとして扱うよう変更した。
+`scripts/build_chatgpt_worker_skills.py`へtask tracking Skill集合を追加し、上記3 Skillを必須配布rootとして扱うよう変更した。
 
-builderは各Skillについて従来どおり次を検証する。
+builderは各Skillについて次を検証する。
 
 - Skill directoryと`SKILL.md`の存在
 - front matter `name`とdirectory名の一致
@@ -40,32 +40,60 @@ builderは各Skillについて従来どおり次を検証する。
 
 `chat-implementation-worker`へ次のflowを追加した。
 
-1. `task-consistency-manager`で実装前のtracking整合を確認する。
-2. trackingが欠落、曖昧、または分割必要な場合は`task-breakdown-planner`を使用する。
-3. 実装後、検証後、review follow-up後、blocked state変更後に`progress-sync-manager`でtask／phase状態を同期する。
-4. canonical task trackingをtask tracking Skill外から直接編集しない。
+1. `work-context-manager`で作業contextを解決する。
+2. `task-consistency-manager`で実装前のtracking整合を確認する。
+3. trackingが欠落、曖昧、または分割必要な場合だけ`task-breakdown-planner`を使用する。
+4. `implementation-worker`でaccepted scopeを実装する。
+5. 実装、検証、review follow-up、blocked state、完了を`progress-sync-manager`でtask／phaseへ同期する。
+6. `report-writer`と`chat-handoff-manager`で証拠を永続化する。
+
+canonical task trackingはtask tracking Skill経由で更新し、wrapperが更新規則を複製しない。
+
+### 設計書
+
+次の設計書を11 Skill構成へ同期した。
+
+- `design/chat-worker-skill-design.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+
+設計へ次を反映した。
+
+- core Skill、task tracking Skill、runtime wrapperの3層構成
+- ChatGPT implementation workerのSkill呼び出し順
+- task未登録・曖昧・分割必要時の処理
+- progress、blocked、verification、PR、完了の同期責務
+- ChatGPT登録用ZIPの11 root構成
+- handoffにtask identity、tracking path、state、pending actionを保持する契約
+- CodexSkill repositoryへTDDを適用しない境界
+- current HEADと一致するCIだけを証拠とする規則
+
+hierarchy designの正本と`skills/design/`配下のmirrorは同一内容とした。
 
 ## Commit
 
 - `69d65655b0569f88c421e7dc06893a7017ba23a6`: ChatGPT配布ZIPへtask tracking Skillを追加
 - `478ee3d23e02c485fca9ee8aa741cea5a2e52036`: implementation wrapperへtask tracking flowを追加
+- `349fd609852f25a5638f8a4f30d1ea78b93bc7f4`: ChatGPT worker設計をtask tracking Skill構成へ同期
+- `e5b92dbd5ce9b26cdcfc29e037f7a7c11e55cf17`: hierarchy designをtask tracking Skill構成へ更新
+- `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`: hierarchy design mirrorを同期
 
 ## 検証
 
-HEAD `478ee3d23e02c485fca9ee8aa741cea5a2e52036`に一致するGitHub Actions workflow runを確認した。
+設計書更新後HEAD `712039aba3090c2eca5d1e0385fd0d7c7dc1da97`に一致するGitHub Actions workflow runを確認した。
 
 - Workflow: `Validate and release ChatGPT worker skills`
-- Run ID: `31048416494`
-- Run number: `146`
+- Run ID: `31049088040`
+- Run number: `150`
 - Status: `completed`
 - Conclusion: `success`
 
-このrunではrepository Skill architecture／active link validation、ChatGPT Skill ZIP build、archive listing、artifact uploadが成功した。
+このrunではrepository Skill architecture／active link validation、hierarchy design mirror一致、ChatGPT Skill ZIP build、11 Skillのarchive listing、artifact uploadが成功した。
 
-本report追加後はHEADが更新されるため、新HEADに一致するworkflow runを別途確認する。別SHAのrunは代用しない。
+本report更新後はHEADが更新されるため、新HEADに一致するworkflow runを最終確認する。別SHAのrunは代用しない。
 
 ## 結果
 
-ChatGPT Skill upload用ZIPにtask tracking Skillが同封され、`chat-implementation-worker`からtaskの作成・整合確認・進捗同期をSkill契約に従って実行できる構成となった。
+ChatGPT Skill upload用ZIPにtask tracking Skillが同封され、`chat-implementation-worker`からtaskの分割、整合確認、進捗・完了同期を専用Skill契約に従って実行できる構成となった。Skill contract、ChatGPT worker設計、hierarchy design、build scriptは11 Skill構成で同期した。
 
 mergeは実施していない。

--- a/reports/issue-59-normal-review-20260807053500.md
+++ b/reports/issue-59-normal-review-20260807053500.md
@@ -1,0 +1,207 @@
+# Issue #59 / PR #60 初回レビュー報告
+
+## メタデータ
+
+- Repository: `ssaattww/CodexSkill`
+- Issue: #59
+- PR: #60
+- Review mode: `initial review`
+- Reviewed implementation HEAD: `a39942bdb11397099463135f0d8487aad8f0d7a6`
+- Base: `aa3c1462ece21dce82f644788b9cbc36a38e76a7`
+- Commit range: `aa3c1462ece21dce82f644788b9cbc36a38e76a7..a39942bdb11397099463135f0d8487aad8f0d7a6`
+- Reviewer: ChatGPT normal reviewer (this chat)
+- Reviewer continuity: initial review; previous normal reviewerなし
+- TDD: CodexSkill repository policyにより not applicable
+- Verdict: `fail`
+
+## 対象要件
+
+Issue #59 の要求は、ChatGPT worker配布ZIPにtask更新用Skillが含まれておらずChatGPT側からtask更新できない状態を解消することである。
+
+PRは以下を実装対象としている。
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+をChatGPT配布ZIPへ含める。
+
+- `chat-implementation-worker`からtask整合確認、必要時のtask分割、進捗同期を実行する。
+- 設計書を11 Skill構成へ同期する。
+- handoffへtask tracking情報を保持する。
+
+## 確認範囲
+
+変更ファイル6件を全て確認した。
+
+- `design/chat-worker-skill-design.md`
+- `design/skill-hierarchy-design.md`
+- `reports/issue-59-chatgpt-task-skills-20260806.md`
+- `scripts/build_chatgpt_worker_skills.py`
+- `skills/chat-implementation-worker/SKILL.md`
+- `skills/design/skill-hierarchy-design.md`
+
+直接依存として以下を確認した。
+
+- `skills/task-breakdown-planner/SKILL.md`
+- `skills/task-consistency-manager/SKILL.md`
+- `skills/progress-sync-manager/SKILL.md`
+- `skills/chat-handoff-manager/SKILL.md`
+- `design/chatgpt-project-instruction-example.md`
+- `AGENTS.md`
+
+## CI / validation
+
+Reviewed implementation HEADに一致するworkflow runのみを確認した。
+
+- Workflow: `Validate and release ChatGPT worker skills`
+- Run ID: `31049455223`
+- Head SHA: `a39942bdb11397099463135f0d8487aad8f0d7a6`
+- Conclusion: `success`
+- Build job: `92452963807` / success
+- Artifact: `chatgpt-worker-skills-31049455223`
+- Artifact ID: `8947793340`
+- Digest: `sha256:e22dc58ac5e55cef2f945d040a63ac49d4ac12de02ff01553ca5ee27fa2b9d96`
+
+CIは11 Skill ZIPの構造とrepository validatorを通している。ただし以下のfindingはいずれもSkill contractと設計の意味論に関するもので、現行validator成功では否定できない。
+
+## Findings
+
+### F-60-01 — blocking — ChatGPT workerから呼ぶtask tracking Skillがparent-only contractのまま
+
+**Origin:** introduced_by_change
+
+**Location:**
+
+- `skills/chat-implementation-worker/SKILL.md`
+- `skills/task-breakdown-planner/SKILL.md`
+- `skills/task-consistency-manager/SKILL.md`
+- `skills/progress-sync-manager/SKILL.md`
+
+**Description:**
+
+PRは`chat-implementation-worker`が3つのtask tracking Skillを直接呼ぶ契約へ変更している。一方、配布対象へ追加した3 Skillは全て`## Execution owner`で`Run this skill as: parent`と明記し、canonical trackingの最終更新をparent-ownedとしている。ChatGPT wrapper自身の契約は「The user is the parent」であり、current chatはparentではなくworkerであるため、配布したSkillの実行主体契約とwrapperの呼び出し契約が一致していない。
+
+さらに`task-breakdown-planner`と`task-consistency-manager`はlarge-scope時に`sub-agent-task-manager`を利用するparent flowを記述しているが、`chat-implementation-worker`は別worker/sub-agentを起動しないことをboundaryとしている。
+
+**Impact:**
+
+Issue #59の主目的である「ChatGPT側からtask更新できる」がSkill contract上成立していない。ZIPへ同封されても、ChatGPT workerが正規の実行主体として扱える定義になっていない。
+
+**Required action:**
+
+3つのtask tracking Skillをruntime-neutralにするか、ChatGPT用wrapper/adapterを設けるなどして、ChatGPT workerから実行可能なowner contractを明示すること。parent-only delegation記述もChatGPT wrapper boundaryと矛盾しない形へ整理し、設計とSkill contractを同期すること。
+
+### F-60-02 — blocking — canonical task tracking pathを受け取れず、Project Instructionのpathと契約が不一致
+
+**Origin:** introduced_by_change
+
+**Location:**
+
+- `skills/task-breakdown-planner/SKILL.md`
+- `skills/task-consistency-manager/SKILL.md`
+- `skills/progress-sync-manager/SKILL.md`
+- `design/chatgpt-project-instruction-example.md`
+
+**Description:**
+
+ChatGPT Project Instruction例はtask一覧を`tasks/tasks-status.md`として指定している。しかし配布対象へ追加した3 Skillは、input/update targetとして`tasks-status.md`と`phases-status.md`を固定名で扱い、`work-context-manager`から解決されたcanonical tracking pathを入力として受け取る契約を持たない。
+
+`chat-implementation-worker`は先に`work-context-manager`を呼ぶようになったが、そのresolved pathをtask tracking Skillへ渡すfield/contractは今回追加されていない。
+
+**Impact:**
+
+実際のProject Instructionが`tasks/tasks-status.md`のようなsubdirectoryを指定する場合、workerが正本ではないroot-level fileを探す・作る・更新する余地がある。Issue #59の目的を実環境で満たせない可能性がある。
+
+**Required action:**
+
+3 Skillのinput contractへcanonical task tracking path（必要ならphase tracking pathも）を追加し、`work-context-manager`が解決したpathをwrapperから必ず渡すこと。固定basenameではなく、対象repository/project instructionで解決された正本pathを使用すること。
+
+### F-60-03 — high — 設計で追加したhandoff task情報が`chat-handoff-manager` schemaへ実装されていない
+
+**Origin:** introduced_by_change
+
+**Location:**
+
+- `design/chat-worker-skill-design.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+- `skills/chat-handoff-manager/SKILL.md`
+
+**Description:**
+
+PR後の設計はhandoffがtask identity、tracking path、phase/state、dependencies、exit criteria、pending tracking actionを保持するとしている。一方、`chat-handoff-manager`のschema version 3にはtop-level `task_id`しかなく、task tracking path、task/phase state、dependencies、exit criteria、pending tracking actionのtyped fieldが存在しない。今回`chat-handoff-manager`自体は変更されていない。
+
+**Impact:**
+
+設計が要求するtask tracking stateをchat間handoffでlosslessに保持できず、次workerがtracking actionを再構成する必要が生じる。設計の完了条件「handoffにtask情報を保持」と実装が不一致になる。
+
+**Required action:**
+
+`chat-handoff-manager`のschema/output contractへ必要なtask tracking fieldsを追加し、compatibility/lossless transport rulesも同期すること。schema変更に伴い関連wrapper、設計書、validator対象を必要に応じて更新すること。
+
+### F-60-04 — high — Issue #59と無関係な既存設計契約を大量削除している
+
+**Origin:** introduced_by_change
+
+**Location:**
+
+- `design/chat-worker-skill-design.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+
+**Description:**
+
+PRはtask tracking Skill追加に必要な差分を超えて、既存設計書から次のような独立した契約を大量に削除している。
+
+- Release / pre-release / manual releaseの詳細条件
+- 標準作業手順
+- Skill一覧と実行方式
+- normal review continuity、severity continuity、pre-freeze、independent final review、report-attestationの詳細条件
+- 共通規則、保守規則
+- ChatGPT worker flowの具体的入力例や運用説明
+- Project Instruction例に関する説明
+
+base版の保守規則には「既存設計書の変更時は、構成変更と無関係な節を削除せず、矛盾する箇所だけを置換する」と明記されている。今回の削除はこの既存保守契約に反する。
+
+**Impact:**
+
+Issue #59と無関係な既存仕様・運用契約が正本設計から失われる。今後のworker/release/review実装が簡略化後の設計を正本として参照すると、既存保証を意図せず退行させる。
+
+**Required action:**
+
+baseの既存節を復元し、Issue #59で必要なtask tracking追加だけを局所的に追記・置換すること。既存契約を変更する必要が本当にある箇所は、Issue #59の要求との関連と変更理由を明示して個別に扱うこと。
+
+## Required coverage dispositions
+
+- Requirement/design conformance: `checked_finding` — F-60-01, F-60-02, F-60-03, F-60-04
+- Correctness/edge cases: `checked_finding` — configured tracking pathとruntime owner境界に不整合
+- Scope discipline/unrelated changes: `checked_finding` — F-60-04
+- Changed files/direct dependencies: `checked_finding` — 全6変更fileと4直接依存Skillを確認
+- API/data/config/workflow/compatibility: `checked_finding` — handoff schemaとtask path contract
+- Error handling/failure diagnostics: `checked_no_finding` — 今回の変更は製品test実装ではなく、current HEAD CIは成功
+- Security/secret handling: `not_applicable` — 新規secret/credential処理なし
+- Tests/validation adequacy: `checked_finding` — CI成功だがcontract semantic mismatchを検出できていない
+- Current-HEAD CI evidence: `checked_no_finding` — Run 31049455223がreviewed HEADに一致しsuccess
+- Report/tracking/documentation accuracy: `checked_finding` — implementation reportはhandoff task情報実装済みと読めるがschema未変更
+- Regression/maintainability risk: `checked_finding` — F-60-04
+
+## Held / unexplored
+
+- Held: なし
+- Unexplored: workflow artifactの実ZIP内容はCIのarchive validationとartifact metadataで確認済みとし、artifact binary自体の再展開検査は未実施。F-60-01/F-60-02/F-60-03/F-60-04の判定には影響しない。
+
+## Verdict
+
+`fail`
+
+Blocking finding 2件、高severity finding 2件があるため、修正後に同じnormal review chatでfix verificationが必要。
+
+## 次アクション
+
+1. F-60-01〜F-60-04を実装workerへhandoffする。
+2. task tracking Skillのruntime owner/path contract、handoff schema、設計書の過剰削除を修正する。
+3. 新しいHEADでrepository validator / ZIP build / artifact uploadを実行する。
+4. 新しいHEAD SHAと一致するworkflow runのみを検証証拠としてfix verificationを行う。
+
+mergeは実施しない。

--- a/reports/issue-59-review-followup-20260807054100.md
+++ b/reports/issue-59-review-followup-20260807054100.md
@@ -1,0 +1,118 @@
+# Issue #59 Review Follow-up Report
+
+## 対象
+
+- Repository: `ssaattww/CodexSkill`
+- Issue: #59
+- PR: #60
+- Mode: review follow-up
+- Source review comment: PR conversation comment `5208976404`
+- Source reviewed implementation HEAD: `a39942bdb11397099463135f0d8487aad8f0d7a6`
+
+CodexSkill repository policyに従いTDDは適用していない。
+
+## 指摘対応
+
+### F-60-01 blocking
+
+指摘: 配布対象へ追加したtask tracking Skillが`parent`専用かつsub-agent delegation前提で、ChatGPT wrapperのcurrent-chat execution契約と矛盾する。
+
+対応:
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+を「authorized canonical tracking writeを所有するcaller」が実行するruntime-neutral contractへ変更した。
+
+Codex標準flowでは通常parent、ChatGPT implementation wrapperではcurrent chatが直接実行する。3 Skill自身はsub-agentを要求・起動しない。別runtimeが補助delegationを持つ場合でも、canonical write ownerはcallerに残る。
+
+`chat-implementation-worker`には、dependency Skill内のoptional delegationを実行せずcurrent chatでtask tracking operationを行うboundaryを明記した。
+
+### F-60-02 blocking
+
+指摘: task tracking Skillが`tasks-status.md` / `phases-status.md`を固定名で扱い、Project Instructionの`tasks/tasks-status.md`等と一致しない可能性がある。
+
+対応:
+
+`work-context-manager` outputへ次を追加した。
+
+```yaml
+tracking:
+  task_path: repository_relative_path | unknown
+  phase_path: repository_relative_path | null | unknown
+```
+
+Project/repository authorityからcanonical pathを解決し、configured pathをbasenameへ置換しない。task pathが解決不能ならguessせずblocked／unknownとする。phase fileを利用しないprojectでは`null`を許可する。
+
+3 task tracking Skillと`chat-implementation-worker`はこのresolved pathを完全一致で受け渡すcontractへ変更した。
+
+### F-60-03 high
+
+指摘: 設計がtask tracking stateをhandoffへ保持するとしている一方、`chat-handoff-manager` typed schemaに対応fieldがない。
+
+対応:
+
+schema version 3へ次を追加した。
+
+```yaml
+task_tracking:
+  task_path: repository_relative_path | unknown
+  phase_path: repository_relative_path | null | unknown
+  state: string | unknown
+  phase: string | null | unknown
+  dependencies:
+    - string
+  exit_criteria:
+    - string
+  blockers:
+    - string
+  pending_action: string | null | unknown
+```
+
+canonical pathは`work-context-manager` outputをlosslessに保持し、state等は最新task tracking Skill outputから保持する。task tracking Skill outputも`source_payloads`へ完全保存するcontractへ変更した。
+
+### F-60-04 high
+
+指摘: Issue #59と無関係なRelease詳細、review continuity、pre-freeze、attestation等を既存設計書から大量削除した。
+
+対応:
+
+次の3ファイルをPR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7`のblobへ完全復元した。
+
+- `design/chat-worker-skill-design.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+
+Issue #59固有の設計変更は、新規 `design/issue-59-chatgpt-task-tracking-extension.md` へ分離した。
+
+追補は次だけを規定する。
+
+- ChatGPT ZIPへ3 task tracking Skillを追加し11 rootにする
+- task tracking Skillのruntime-neutral execution owner
+- canonical tracking path contract
+- ChatGPT implementation flow
+- handoff `task_tracking` projection
+- build scriptが3 Skillを必須rootへ追加すること
+
+既存のreview lifecycle、pre-freeze、attestation、Release publication、Codex review flow、merge境界は変更しない。
+
+## Base比較
+
+PR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7` と修正HEAD `4d353e939deebd3cdf929bdf237337745c9c97b7` のcompareで、以前変更していた次の3設計書はchanged file一覧から消えた。
+
+- `design/chat-worker-skill-design.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+
+この時点のPR差分はIssue #59固有のdesign addendum、bundle builder、wrapper／task tracking／handoff／context Skill、implementation report、normal review reportのみである。
+
+## 検証
+
+CodexSkill repository policyによりRed/Green TDDはnot applicable。
+
+最終report commit後のcurrent HEADに一致する `Validate and release ChatGPT worker skills` workflow runを確認する。別SHAのrunは代用しない。
+
+## Merge
+
+mergeは実施しない。

--- a/reports/issue-59-review-followup-20260807054100.md
+++ b/reports/issue-59-review-followup-20260807054100.md
@@ -78,40 +78,77 @@ canonical pathは`work-context-manager` outputをlosslessに保持し、state等
 
 対応:
 
-次の3ファイルをPR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7`のblobへ完全復元した。
+最初に次の3ファイルをPR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7`の内容へ復元し、無関係な大量削除を除去した。
 
 - `design/chat-worker-skill-design.md`
 - `design/skill-hierarchy-design.md`
 - `skills/design/skill-hierarchy-design.md`
 
-Issue #59固有の設計変更は、新規 `design/issue-59-chatgpt-task-tracking-extension.md` へ分離した。
+その後、正本設計と実装の矛盾を残さないため、Issue #59の影響箇所だけを最小差分で再更新した。Release publication、normal review continuity、pre-freeze、independent final review、report attestation、Codex review flow、標準作業手順、merge境界などIssue #59と無関係な既存契約は維持した。
 
-追補は次だけを規定する。
+正本設計では次だけを更新した。
 
-- ChatGPT ZIPへ3 task tracking Skillを追加し11 rootにする
-- task tracking Skillのruntime-neutral execution owner
-- canonical tracking path contract
-- ChatGPT implementation flow
-- handoff `task_tracking` projection
-- build scriptが3 Skillを必須rootへ追加すること
+- 4 wrapper + 4 core Skillへ3 task tracking Skillを加えた11 Skill配布構成
+- task tracking Skillをauthorized callerが実行するruntime-neutral contract
+- `work-context-manager`によるcanonical tracking path解決
+- `chat-implementation-worker`のtask consistency／breakdown／progress sync flow
+- handoffのtask tracking typed projectionとtask tracking raw output保持
+- Release validator／builderが必須task tracking Skillを扱うこと
+- Skill一覧上のtask tracking Skill実行方式
 
-既存のreview lifecycle、pre-freeze、attestation、Release publication、Codex review flow、merge境界は変更しない。
+Issue #59固有の詳細は`design/issue-59-chatgpt-task-tracking-extension.md`にも保持し、正本の該当箇所と整合させた。
+
+`design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`は同一blob `bd3f9f784b2d723fea828c0fe215d109cbd82182`へ同期した。
+
+## Canonical tracking同期
+
+Project Instructionのcanonical task tracking path `tasks/tasks-status.md`と既存phase path `tasks/phases-status.md`を使用した。
+
+- `tasks/tasks-status.md`へIssue #59をT-003として登録した
+- T-003はPhase 8、statusはreview follow-up実装済み／normal fix verification待ち
+- T-002の現在の配布構成表記だけを4 wrapper + 4 core + 3 task tracking Skillへ同期し、Issue #53のreview履歴は変更していない
+- `tasks/phases-status.md`へPhase 8を追加し、F-60-01からF-60-04の対応状態とcurrent-HEAD validation待ちを記録した
 
 ## Base比較
 
-PR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7` と修正HEAD `4d353e939deebd3cdf929bdf237337745c9c97b7` のcompareで、以前変更していた次の3設計書はchanged file一覧から消えた。
+PR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7` とtracking同期HEAD `ed5785a0b1d80d69e2fe3d1d388d128a0763c3b9` のcompareでは、設計差分は次の規模に収まっている。
 
+- `design/chat-worker-skill-design.md`: +77 / -24
+- `design/skill-hierarchy-design.md`: +52 / -22
+- `skills/design/skill-hierarchy-design.md`: +52 / -22
+
+初回対応時に発生していた約1000行規模の無関係な削除は残っていない。
+
+## 主要変更file
+
+- `scripts/build_chatgpt_worker_skills.py`
+- `skills/work-context-manager/SKILL.md`
+- `skills/task-breakdown-planner/SKILL.md`
+- `skills/task-consistency-manager/SKILL.md`
+- `skills/progress-sync-manager/SKILL.md`
+- `skills/chat-implementation-worker/SKILL.md`
+- `skills/chat-handoff-manager/SKILL.md`
 - `design/chat-worker-skill-design.md`
 - `design/skill-hierarchy-design.md`
 - `skills/design/skill-hierarchy-design.md`
+- `design/issue-59-chatgpt-task-tracking-extension.md`
+- `tasks/tasks-status.md`
+- `tasks/phases-status.md`
 
-この時点のPR差分はIssue #59固有のdesign addendum、bundle builder、wrapper／task tracking／handoff／context Skill、implementation report、normal review reportのみである。
+## 検証方針
 
-## 検証
+CodexSkill repository policyによりRed/Green TDDは`not applicable`。
 
-CodexSkill repository policyによりRed/Green TDDはnot applicable。
+本report commit後のcurrent PR HEADに一致する `Validate and release ChatGPT worker skills` workflow runだけをCI evidenceとして使用する。別SHAのrunは代用しない。
 
-最終report commit後のcurrent HEADに一致する `Validate and release ChatGPT worker skills` workflow runを確認する。別SHAのrunは代用しない。
+matching runが存在しない場合はCI未実施として扱う。
+
+## 残作業
+
+- current HEAD固有のrepository validator／11 Skill ZIP build／artifact確認
+- source finding `F-60-01`から`F-60-04`について、同じnormal review continuityでfix verificationを実施する
+
+本implementation worker自身はreview verdictを出さない。
 
 ## Merge
 

--- a/reports/issue-59-review-followup-20260807054100.md
+++ b/reports/issue-59-review-followup-20260807054100.md
@@ -109,6 +109,19 @@ Project Instructionのcanonical task tracking path `tasks/tasks-status.md`と既
 - T-002の現在の配布構成表記だけを4 wrapper + 4 core + 3 task tracking Skillへ同期し、Issue #53のreview履歴は変更していない
 - `tasks/phases-status.md`へPhase 8を追加し、F-60-01からF-60-04の対応状態とcurrent-HEAD validation待ちを記録した
 
+## Repository validator同期
+
+再点検で`scripts/build_chatgpt_worker_skills.py`は11 Skillを必須packageとしていた一方、`scripts/verify_skill_repository.py`の`REQUIRED_RELEASE_SKILLS`と`chat-implementation-worker` dependency contractが8 Skill時点のままであることを確認した。
+
+正本設計との不一致を残さないため、repository validatorへ次を追加した。
+
+- required release Skill: `task-breakdown-planner`
+- required release Skill: `task-consistency-manager`
+- required release Skill: `progress-sync-manager`
+- `chat-implementation-worker` required dependencyとして上記3 Skillを検証
+
+これにより、3 Skillがrepositoryから欠落した場合、または`chat-implementation-worker`がSkill名で依存を宣言しない場合にrepository validationが失敗する。
+
 ## Base比較
 
 PR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7` とtracking同期HEAD `ed5785a0b1d80d69e2fe3d1d388d128a0763c3b9` のcompareでは、設計差分は次の規模に収まっている。
@@ -122,6 +135,7 @@ PR base `aa3c1462ece21dce82f644788b9cbc36a38e76a7` とtracking同期HEAD `ed5785
 ## 主要変更file
 
 - `scripts/build_chatgpt_worker_skills.py`
+- `scripts/verify_skill_repository.py`
 - `skills/work-context-manager/SKILL.md`
 - `skills/task-breakdown-planner/SKILL.md`
 - `skills/task-consistency-manager/SKILL.md`

--- a/scripts/build_chatgpt_worker_skills.py
+++ b/scripts/build_chatgpt_worker_skills.py
@@ -14,6 +14,11 @@ CORE_SKILLS = {
     "review-worker",
     "report-writer",
 }
+TASK_TRACKING_SKILLS = {
+    "task-breakdown-planner",
+    "task-consistency-manager",
+    "progress-sync-manager",
+}
 IGNORED_NAMES = {"__pycache__", ".DS_Store"}
 
 
@@ -24,8 +29,9 @@ class BundleError(RuntimeError):
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Build one ChatGPT Skill-set ZIP containing every chat-* wrapper and "
-            "the parent-independent core Skills they invoke."
+            "Build one ChatGPT Skill-set ZIP containing every chat-* wrapper, "
+            "the parent-independent core Skills they invoke, and the task "
+            "tracking Skills required to update repository task state."
         )
     )
     parser.add_argument(
@@ -58,7 +64,7 @@ def discover_skill_dirs(repo_root: Path) -> list[Path]:
     names = {
         path.parent.name
         for path in skills_root.glob("chat-*/SKILL.md")
-    } | CORE_SKILLS
+    } | CORE_SKILLS | TASK_TRACKING_SKILLS
 
     skill_dirs: list[Path] = []
     for name in sorted(names):

--- a/scripts/verify_skill_repository.py
+++ b/scripts/verify_skill_repository.py
@@ -27,14 +27,20 @@ REQUIRED_RELEASE_SKILLS = {
     "chat-report-writer",
     "chat-review-worker",
     "implementation-worker",
+    "progress-sync-manager",
     "report-writer",
     "review-worker",
+    "task-breakdown-planner",
+    "task-consistency-manager",
     "work-context-manager",
 }
 WRAPPER_DEPENDENCIES = {
     "chat-implementation-worker": {
         "work-context-manager",
+        "task-consistency-manager",
+        "task-breakdown-planner",
         "implementation-worker",
+        "progress-sync-manager",
         "report-writer",
         "chat-handoff-manager",
     },

--- a/skills/chat-handoff-manager/SKILL.md
+++ b/skills/chat-handoff-manager/SKILL.md
@@ -7,7 +7,7 @@ description: Create and validate lossless, transportable handoff packets between
 
 ## Goal
 
-Create a complete handoff packet that lets another user-started ChatGPT chat continue without relying on conversation memory or silently losing context, implementation, review, validation, report, permission, blocked-state, or terminal-gate evidence.
+Create a complete handoff packet that lets another user-started ChatGPT chat continue without relying on conversation memory or silently losing context, implementation, review, validation, report, permission, blocked-state, task-tracking, or terminal-gate evidence.
 
 ## Runtime boundary
 
@@ -17,11 +17,12 @@ This Skill is ChatGPT-specific transport logic. It does not implement, review, w
 
 Accept:
 
-- the structured context from `work-context-manager`,
+- the structured context from `work-context-manager`, including canonical tracking paths,
 - the complete output of `implementation-worker`, `review-worker`, or `report-writer`,
+- task-tracking output from `task-consistency-manager`, `task-breakdown-planner`, or `progress-sync-manager` when those Skills ran,
 - runtime-specific authorization, persistence, PR-comment, attestation-gate, and next-chat information supplied by the wrapper.
 
-Do not summarize away fields required by the producing core Skill. A handoff is a lossless transport envelope for available evidence, not a shorter substitute for that evidence.
+Do not summarize away fields required by the producing Skill. A handoff is a lossless transport envelope for available evidence, not a shorter substitute for that evidence.
 
 ## Required packet
 
@@ -37,6 +38,18 @@ producer:
 repository: owner/name | unknown
 issue_or_pr: string | null
 task_id: string | null
+task_tracking:
+  task_path: repository_relative_path | unknown
+  phase_path: repository_relative_path | null | unknown
+  state: string | unknown
+  phase: string | null | unknown
+  dependencies:
+    - string
+  exit_criteria:
+    - string
+  blockers:
+    - string
+  pending_action: string | null | unknown
 branch: string | unknown
 base_ref: string | null
 target:
@@ -258,8 +271,10 @@ transport:
 ## Lossless transport rules
 
 - Populate the typed projection for every available field defined above.
-- Also preserve each producing core Skill's complete, versioned output under `source_payloads`; typed projection does not replace the raw source payload.
-- Preserve every available field required by the producing core Skill's output contract, including development policy, planned validation, required failure diagnostics, blocked state, failure diagnostics, reviewer identity, reviewer independence, reserved report paths, and exact report-attestation conditions.
+- Preserve canonical `task_tracking.task_path` and `task_tracking.phase_path` exactly as resolved by `work-context-manager`; do not collapse them to basenames or guess replacements.
+- Preserve available task state, phase, dependencies, exit criteria, blockers, and pending tracking action from the latest task-tracking Skill output.
+- Also preserve each producing core or task-tracking Skill's complete, versioned output under `source_payloads`; typed projection does not replace the raw source payload.
+- Preserve every available field required by the producing Skill's output contract, including development policy, planned validation, required failure diagnostics, blocked state, failure diagnostics, reviewer identity, reviewer independence, reserved report paths, and exact report-attestation conditions.
 - Preserve exact finding identity, origin, location, impact, evidence, required action, and reviewed HEAD.
 - Preserve required coverage dispositions, held items, unexplored areas, validation assessment, intentionally untouched areas, commands, tests, CI artifacts, implementation commits, report paths, and PR comment references.
 - Use `extensions` for runtime or future fields that are not yet represented in the typed projection.
@@ -278,7 +293,7 @@ transport:
 - Normalize version 1 or 2 `cold_final_review` to `independent_final_review`.
 - Preserve the complete original version 1 or 2 packet as a `source_payloads` entry before projecting fields into version 3.
 - Preserve every field that exists in an older packet. Mapping failures or fields without a version 3 typed destination must remain in the original `source_payloads` entry or a namespaced `extensions` entry.
-- Map genuinely absent version 3 fields to explicit `unknown` or `not_applicable` entries with the reason `not present in source schema`; do not invent values.
+- Map genuinely absent version 3 fields, including `task_tracking`, to explicit `unknown` or `not_applicable` entries with the reason `not present in source schema`; do not invent values.
 - Do not convert an existing source value into `unknown` merely because no typed mapping exists.
 - When missing fields prevent safe continuation, mark the receiving operation `blocked` or review verdict `incomplete` and identify the exact missing evidence.
 - Unsupported future schema versions remain blocked until a migration rule exists; preserve the untouched future packet as source evidence when safe parsing is possible.
@@ -297,4 +312,4 @@ The packet must record:
 
 ## Completion condition
 
-Complete when the packet's typed projection and preserved source payloads losslessly represent the available core-Skill output, target and reviewed identities are explicit, blocked state and failure-diagnostic requirements remain actionable, reviewer identity and independence are verifiable, report-attestation conditions are reproducible, findings and uncertainty retain their evidence, permissions and transport are explicit, compatibility handling did not discard data, the next chat can continue independently, and no implementation, review verdict change, additional post-attestation commit, or merge was performed.
+Complete when the packet's typed projection and preserved source payloads losslessly represent the available core-Skill and task-tracking output, canonical tracking paths and current task state are explicit or explicitly unknown/not applicable, target and reviewed identities are explicit, blocked state and failure-diagnostic requirements remain actionable, reviewer identity and independence are verifiable, report-attestation conditions are reproducible, findings and uncertainty retain their evidence, permissions and transport are explicit, compatibility handling did not discard data, the next chat can continue independently, and no implementation, review verdict change, additional post-attestation commit, or merge was performed.

--- a/skills/chat-implementation-worker/SKILL.md
+++ b/skills/chat-implementation-worker/SKILL.md
@@ -14,17 +14,23 @@ Act as the ChatGPT runtime wrapper for implementation. The user is the parent. T
 Invoke these Skills in order:
 
 1. `work-context-manager`
-2. `implementation-worker`
-3. `report-writer`
-4. `chat-handoff-manager`
+2. `task-consistency-manager`
+3. `task-breakdown-planner` when tracking is missing, vague, or must be split
+4. `implementation-worker`
+5. `progress-sync-manager`
+6. `report-writer`
+7. `chat-handoff-manager`
 
-All four must be installed. Do not replace them with repository-external shared files.
+`work-context-manager`, `task-consistency-manager`, `implementation-worker`, `progress-sync-manager`, `report-writer`, and `chat-handoff-manager` must be installed. `task-breakdown-planner` must also be installed so the wrapper can invoke it when its condition applies. Do not replace any required Skill with repository-external shared files.
 
 ## Runtime responsibilities
 
 - Use the current chat and available connectors.
 - Resolve permissions before writes.
+- Confirm the accepted work is represented in canonical task tracking before significant implementation starts.
+- Add or split task tracking through `task-breakdown-planner` when required, then re-run `task-consistency-manager`.
 - Apply changes, commit, push, and create or update the PR only when authorized.
+- Synchronize canonical task and phase state through `progress-sync-manager` after implementation progress, validation, review follow-up, or blocking state changes.
 - Persist the detailed implementation report under target-repository rules, or return it in full when writing is unavailable.
 - Post the concise PR comment when authorized, or return its complete body.
 - Persist the handoff under target-repository rules, or return the complete packet for copy and paste.
@@ -40,11 +46,12 @@ Pass the selected mode and resolved context to `implementation-worker`.
 ## Boundaries
 
 - Do not start another worker or sub-agent.
-- Do not implement rules locally when the required Skill is unavailable; report the missing dependency.
+- Do not implement rules locally when a required Skill is unavailable; report the missing dependency.
+- Do not edit canonical task tracking directly outside the task tracking Skills.
 - Do not issue an independent review verdict.
 - Do not exceed current-chat permissions.
 - Do not merge.
 
 ## Completion condition
 
-Complete when the required Skills have produced context, implementation evidence, report output, and a transportable handoff; authorized repository and PR updates are complete; final HEAD and matching CI evidence or explicit absence are recorded; and no merge was performed.
+Complete when the required Skills have produced context, consistent task tracking, implementation evidence, synchronized progress, report output, and a transportable handoff; authorized repository and PR updates are complete; final HEAD and matching CI evidence or explicit absence are recorded; and no merge was performed.

--- a/skills/chat-implementation-worker/SKILL.md
+++ b/skills/chat-implementation-worker/SKILL.md
@@ -21,16 +21,18 @@ Invoke these Skills in order:
 6. `report-writer`
 7. `chat-handoff-manager`
 
-`work-context-manager`, `task-consistency-manager`, `implementation-worker`, `progress-sync-manager`, `report-writer`, and `chat-handoff-manager` must be installed. `task-breakdown-planner` must also be installed so the wrapper can invoke it when its condition applies. Do not replace any required Skill with repository-external shared files.
+All seven Skills must be installed. Do not replace any required Skill with repository-external shared files.
 
 ## Runtime responsibilities
 
 - Use the current chat and available connectors.
 - Resolve permissions before writes.
+- Use `work-context-manager` to resolve the canonical task tracking path and optional canonical phase tracking path from project/repository authority.
+- Pass those resolved tracking paths unchanged to every task tracking Skill; never substitute guessed basenames.
 - Confirm the accepted work is represented in canonical task tracking before significant implementation starts.
 - Add or split task tracking through `task-breakdown-planner` when required, then re-run `task-consistency-manager`.
 - Apply changes, commit, push, and create or update the PR only when authorized.
-- Synchronize canonical task and phase state through `progress-sync-manager` after implementation progress, validation, review follow-up, or blocking state changes.
+- Synchronize canonical task and phase state through `progress-sync-manager` after implementation progress, validation, review follow-up, PR/commit updates, or blocking state changes.
 - Persist the detailed implementation report under target-repository rules, or return it in full when writing is unavailable.
 - Post the concise PR comment when authorized, or return its complete body.
 - Persist the handoff under target-repository rules, or return the complete packet for copy and paste.
@@ -46,12 +48,14 @@ Pass the selected mode and resolved context to `implementation-worker`.
 ## Boundaries
 
 - Do not start another worker or sub-agent.
+- Do not invoke optional sub-agent delegation described by a dependency Skill; this wrapper executes required task tracking operations in the current chat.
 - Do not implement rules locally when a required Skill is unavailable; report the missing dependency.
 - Do not edit canonical task tracking directly outside the task tracking Skills.
+- Do not guess canonical tracking paths when `work-context-manager` cannot resolve them; report the missing path as blocked.
 - Do not issue an independent review verdict.
 - Do not exceed current-chat permissions.
 - Do not merge.
 
 ## Completion condition
 
-Complete when the required Skills have produced context, consistent task tracking, implementation evidence, synchronized progress, report output, and a transportable handoff; authorized repository and PR updates are complete; final HEAD and matching CI evidence or explicit absence are recorded; and no merge was performed.
+Complete when the required Skills have produced context with explicit canonical tracking paths or explicit blocked/unknown state, consistent task tracking, implementation evidence, synchronized progress, report output, and a transportable handoff; authorized repository and PR updates are complete; final HEAD and matching CI evidence or explicit absence are recorded; and no merge was performed.

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -4,9 +4,9 @@
 
 Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker flowを一元的に定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、CodexとChatGPTはruntime wrapperからそれらを呼び出す。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、canonical task trackingの更新はruntime-neutralなtask tracking Skillとして定義する。CodexとChatGPTはruntime wrapperから必要なSkillを呼び出す。
 
-この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。
+この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。Issue #59固有のtask tracking追加契約は`design/issue-59-chatgpt-task-tracking-extension.md`にも記録し、本設計書の該当箇所と一致させる。
 
 ## 実行方式
 
@@ -15,7 +15,7 @@ Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker
 - `利用者が親としてChatGPT chatで実行`: 利用者が独立chatを起動し、そのchatが指定wrapper Skillを直接実行する。
 - `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、Codex親、sub-agent、ChatGPT chat固有の制御を持たずに実作業を行う。
 
-ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。
+ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。task tracking Skill自身もsub-agent起動を要求せず、canonical tracking writeを所有するauthorized callerが実行する。
 
 ## Skill依存アーキテクチャ
 
@@ -25,6 +25,11 @@ ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwra
 ├─ implementation-worker
 ├─ review-worker
 └─ report-writer
+
+runtime-neutral task tracking Skill
+├─ task-breakdown-planner
+├─ task-consistency-manager
+└─ progress-sync-manager
 
 runtime wrapper
 ├─ Codex
@@ -41,7 +46,7 @@ runtime wrapper
 ### Core Skill
 
 - `work-context-manager`
-  - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、write boundaryを解決する
+  - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、canonical tracking path、write boundaryを解決する
 - `implementation-worker`
   - initial implementationとreview follow-upを実行する
 - `review-worker`
@@ -51,11 +56,22 @@ runtime wrapper
 
 全core SkillはCodex親、Codex sub-agent、ChatGPT親chatのいずれにも依存しない。
 
+### Task tracking Skill
+
+- `task-breakdown-planner`
+  - canonical tracking pathを使い、work itemをtask／phase、dependencies、exit criteriaへ分解する
+- `task-consistency-manager`
+  - canonical trackingと実scopeを照合し、実装開始前およびscope変更時の整合を保証する
+- `progress-sync-manager`
+  - implementation、validation、review、commit／PR、blocked、完了状態をcanonical trackingへ同期する
+
+3 Skillは`work-context-manager`が解決したrepository-relative pathを完全一致で使用し、configured pathをbasenameへ置換または推測しない。Codex標準flowでは通常parent、ChatGPT implementation flowではcurrent chatがauthorized callerとなる。
+
 ### Runtime wrapper
 
 Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、fresh independent reviewer、report path、persistence、completion gateを所有する。
 
-ChatGPT wrapperはcurrent-chat permission、connector、repository／PR persistence、chat continuity、cross-chat handoffを所有する。
+ChatGPT wrapperはcurrent-chat permission、connector、repository／PR persistence、chat continuity、cross-chat handoffを所有する。`chat-implementation-worker`はtask tracking Skillをcurrent chatで直接実行し、tracking更新ロジックをwrapperへ複製しない。
 
 共通動作を複数Skillから同一fileとして参照しない。共通動作は独立Skillとして定義し、wrapperまたは他のSkillがSkill名で呼び出す。
 
@@ -213,7 +229,10 @@ attestation後にrepository writeの必要性が判明した場合はterminal st
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
 │  ├─ work-context-manager
+│  ├─ task-consistency-manager
+│  ├─ task-breakdown-planner [必要時のみ]
 │  ├─ implementation-worker
+│  ├─ progress-sync-manager
 │  ├─ report-writer
 │  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
@@ -238,7 +257,7 @@ initial reviewとfix verificationは同じnormal review chatを継続する。in
 Issue #<number>を開始してください。
 ```
 
-`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`と`implementation-worker`を呼び出す。
+`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`でcanonical tracking pathを解決する。`task-consistency-manager`でtrackingを確認し、必要時だけ`task-breakdown-planner`で分割・補完して再確認した後、`implementation-worker`を呼び出す。実装結果は`progress-sync-manager`でcanonical trackingへ同期する。
 
 ### 初回レビュー
 
@@ -254,7 +273,7 @@ PR #<number>を初回レビューしてください。
 レビュー結果に対応してください。
 ```
 
-初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。
+初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。新しいtaskまたはtracking state変更が発生した場合はcanonical pathを使ってtask tracking Skillを実行する。
 
 ### 修正確認
 
@@ -290,7 +309,13 @@ ChatGPTへ登録するwrapper Skillは次の4つである。
 - `review-worker`
 - `report-writer`
 
-GitHub Releaseでは、8 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
+必須task tracking Skillは次の3つである。
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+GitHub Releaseでは、11 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
 
 ```text
 chatgpt-worker-skills.zip
@@ -301,12 +326,15 @@ chatgpt-worker-skills.zip
 ├─ work-context-manager/
 ├─ implementation-worker/
 ├─ review-worker/
-└─ report-writer/
+├─ report-writer/
+├─ task-breakdown-planner/
+├─ task-consistency-manager/
+└─ progress-sync-manager/
 ```
 
 各directoryには少なくとも`SKILL.md`が存在し、front matterの`name`とdirectory名を一致させる。
 
-このZIPをChatGPTへuploadし、wrapperと依存core Skillを一括登録する。
+このZIPをChatGPTへuploadし、wrapper、依存core Skill、task tracking Skillを一括登録する。
 
 ## Handoff
 
@@ -315,7 +343,8 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 - reportとhandoffを別成果物とする
 - schema version 3を使用する
 - typed projectionとversioned `source_payloads`の両方を保持する
-- source core Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
+- source core Skillと実行されたtask tracking Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
+- canonical task／phase tracking path、task state、phase、dependencies、exit criteria、blockers、pending actionを保持する
 - development policy、planned validation、required failure diagnostics、blocked stateを保持する
 - implementation failure diagnosticsとblocked itemsを保持する
 - reviewer identity、reviewer continuity、independence evidenceを保持する
@@ -342,7 +371,7 @@ handoff contractを複数Skillから同一fileとして参照しない。`chat-h
 - `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
 - build jobは`contents: read`だけを持ち、checkout credentialを保持しない
 - `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
-- 全`chat-*` wrapperと必須core Skillを検出する
+- 全`chat-*` wrapper、必須core Skill、必須task tracking Skillを検出する
 - missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
 - 単一`chatgpt-worker-skills.zip`を作成する
 - ZIP rootが検出Skill集合と一致することを確認する
@@ -388,7 +417,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 1. workflow開始時にCodexSkillの鮮度を確認する。
 2. 再開時は`restart-handover-manager`で状態を復元する。
-3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、write boundaryを解決する。
+3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、canonical tracking path、write boundaryを解決する。
 4. `development-orchestrator`がtaskを選択する。
 5. `task-consistency-manager`でtrackingを同期する。
 6. 設計影響があれば`design-doc-maintainer`を実行する。
@@ -428,7 +457,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `work-context-manager` | authority、scope、target identity、policy、validation、CI、write boundaryを解決する | runtime非依存Skillとして実行 |
+| `work-context-manager` | authority、scope、target identity、policy、validation、CI、canonical tracking path、write boundaryを解決する | runtime非依存Skillとして実行 |
 | `implementation-worker` | initial implementationとreview follow-upを実施する | runtime非依存Skillとして実行 |
 | `review-worker` | initial review、fix verification、independent final reviewとattestation条件を返す | runtime非依存Skillとして実行 |
 | `report-writer` | evidence-faithfulなreport、簡易PR comment、persistence metadataを生成する | runtime非依存Skillとして実行 |
@@ -437,9 +466,9 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `task-breakdown-planner` | issueをtaskとphaseへ分解する | 親が実行 |
-| `task-consistency-manager` | task、phase、実scopeを同期する | 親が実行 |
-| `progress-sync-manager` | report、tracking、実結果を同期する | 親が実行 |
+| `task-breakdown-planner` | canonical pathを使ってissueをtaskとphaseへ分解する | runtime非依存Skillとしてauthorized callerが実行 |
+| `task-consistency-manager` | canonical task／phaseと実scopeを同期する | runtime非依存Skillとしてauthorized callerが実行 |
+| `progress-sync-manager` | canonical tracking、report、実結果を同期する | runtime非依存Skillとしてauthorized callerが実行 |
 | `restart-handover-manager` | recorded stateから再開位置を復元する | 親が実行 |
 | `handover-memo-writer` | 別chat向けhandover memoを作成する | 親が実行 |
 
@@ -476,15 +505,16 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-upを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-up、canonical task tracking flowを統括する | 利用者が親としてChatGPT chatで実行 |
 | `chat-review-worker` | ChatGPT上のinitial、fix verification、independent final review、report-attestationを統括する | 利用者が親としてChatGPT chatで実行 |
 | `chat-report-writer` | ChatGPT上のsource discovery、report永続化、PR commentを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetを生成する | ChatGPT wrapperから呼び出す |
+| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetとtask tracking stateを生成する | ChatGPT wrapperから呼び出す |
 
 ## 共通規則
 
 - 対象repositoryのProject Instructionを優先する。
 - 解決可能なrepository stateを利用者へ再質問しない。
+- canonical tracking pathはProject／repository authorityから解決し、configured pathをbasenameへ置換または推測しない。
 - CodexSkill repository自身にはTDDを適用しない。
 - implementationは自分の変更へreview verdictを出さない。
 - reviewerはfindingを実装しない。
@@ -493,9 +523,9 @@ Release時の共通file複製とrepository相対link書換は行わない。
 - CIは対象current HEAD SHAに紐づくrunだけを使用する。
 - 別SHAのrunを代用しない。
 - reportとhandoffを混同しない。
-- handoffはtyped projectionとversioned raw source payloadでcore Skill outputを欠落なくtransportする。
+- handoffはtyped projectionとversioned raw source payloadでcore Skillおよび実行されたtask tracking Skill outputを欠落なくtransportする。
 - unknown、blocked、held、unexplored、失敗結果を消さない。
-- core Skillとwrapperは自directory外のshared fileへ依存しない。
+- core Skill、task tracking Skill、wrapperは自directory外のshared fileへ依存しない。
 - dependency Skillが存在しない場合、wrapperは処理を複製せずmissing dependencyとして停止する。
 - end-of-Issue Skill decision、feedback ledger、normal handoff、report、trackingをindependent final review前に確定する。
 - pre-freeze処理でrepositoryが変わった場合はnormal reviewへ戻る。
@@ -511,7 +541,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 - ChatGPT Project Instruction例を変更する場合は`design/chatgpt-project-instruction-example.md`を更新する。
 - review lifecycle変更時は`review-worker`、`review-enforcer`、`chat-review-worker`、`report-writer`、`report-output-manager`、本設計書、専用設計書を同時更新する。
 - handoff schema変更時は`chat-handoff-manager`、ChatGPT wrapper、両設計書、Issue／trackingを同期する。
-- core Skill dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
+- core Skill dependencyまたはChatGPT配布task tracking dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
 - `scripts/verify_skill_repository.py`でactive Markdown link、Skill依存、front matter、symlink、削除済みshared runtime path、hierarchy design同期を検証する。
 - workflow trigger変更時はforbidden pathだけの変更でもvalidatorが起動するcoverageを両設計書とPR説明へ同期する。
 - 既存設計書の変更時は、構成変更と無関係な節を削除せず、矛盾する箇所だけを置換する。

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -4,7 +4,7 @@
 
 Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker flowを一元的に定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、CodexとChatGPTはruntime wrapperからそれらを呼び出す。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、task trackingは専用Skill、runtime固有処理はwrapperへ分離する。
 
 この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。
 
@@ -13,9 +13,9 @@ Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker
 - `親が実行`: Codex親agentがSkillを直接実行する。
 - `親が呼び出し、sub-agentが実行`: Codex親agentがSkillを通じてsub-agentへ実作業を委譲する。
 - `利用者が親としてChatGPT chatで実行`: 利用者が独立chatを起動し、そのchatが指定wrapper Skillを直接実行する。
-- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、Codex親、sub-agent、ChatGPT chat固有の制御を持たずに実作業を行う。
+- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、runtime固有の制御を持たずに実作業を行う。
 
-ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。
+ChatGPT wrapperは別workerまたはsub-agentを起動しない。CodexとChatGPTは別runtime wrapperを使用するが、implementation、review、reportの意味論は同じcore Skillを使用する。
 
 ## Skill依存アーキテクチャ
 
@@ -25,6 +25,11 @@ ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwra
 ├─ implementation-worker
 ├─ review-worker
 └─ report-writer
+
+task tracking Skill
+├─ task-breakdown-planner
+├─ task-consistency-manager
+└─ progress-sync-manager
 
 runtime wrapper
 ├─ Codex
@@ -38,7 +43,7 @@ runtime wrapper
    └─ chat-handoff-manager
 ```
 
-### Core Skill
+## Core Skill
 
 - `work-context-manager`
   - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、write boundaryを解決する
@@ -49,9 +54,20 @@ runtime wrapper
 - `report-writer`
   - evidenceの意味を変えずにreportと簡易PR commentを生成する
 
-全core SkillはCodex親、Codex sub-agent、ChatGPT親chatのいずれにも依存しない。
+全core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存しない。
 
-### Runtime wrapper
+## task tracking Skill
+
+- `task-breakdown-planner`
+  - taskを完了判定可能な単位へ分割し、dependencies、exit criteria、estimate、phaseを定義する
+- `task-consistency-manager`
+  - significant workの開始前とscope変更時にcanonical task trackingとの整合を確認する
+- `progress-sync-manager`
+  - active、blocked、verification、PR、完了状態をtask／phaseへ同期する
+
+canonical task tracking fileはこれらの専用Skill経由で更新する。runtime wrapperまたはimplementation core Skillがtask更新規則を複製しない。
+
+## Runtime wrapper
 
 Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、fresh independent reviewer、report path、persistence、completion gateを所有する。
 
@@ -66,53 +82,32 @@ development-orchestrator [親]
 ├─ restart-handover-manager
 ├─ work-context-manager
 ├─ task-consistency-manager
+├─ task-breakdown-planner [必要時]
 ├─ design-doc-maintainer
-│  ├─ codex-delegation-executor
-│  │  └─ design-executor
-│  └─ task-consistency-manager
 ├─ tdd-executor [対象repositoryが明示要求する場合だけ]
+├─ implementation-executor [wrapper]
 │  ├─ work-context-manager
-│  ├─ codex-delegation-executor
-│  │  └─ implementation-executor [wrapper]
-│  │     ├─ work-context-manager
-│  │     └─ implementation-worker
-│  └─ sub-agent-task-manager [test evidence]
-├─ codex-delegation-executor
-│  ├─ implementation-executor [wrapper]
-│  │  ├─ work-context-manager
-│  │  └─ implementation-worker
-│  ├─ design-executor
-│  ├─ sub-agent-task-manager [verification]
-│  └─ report-output-manager [wrapper]
-│     ├─ work-context-manager
-│     └─ report-writer
+│  └─ implementation-worker
+├─ progress-sync-manager
 ├─ review-enforcer [wrapper]
 │  ├─ work-context-manager
-│  ├─ markdown-word-checker
-│  ├─ sub-agent-task-manager [normal reviewer]
-│  │  └─ review-worker
-│  ├─ sub-agent-task-manager [fresh independent final reviewer]
-│  │  └─ review-worker
-│  └─ report-output-manager
-│     └─ report-writer
-├─ progress-sync-manager
+│  ├─ review-worker [normal reviewer]
+│  └─ review-worker [fresh independent final reviewer]
+├─ report-output-manager [wrapper]
+│  ├─ work-context-manager
+│  └─ report-writer
 ├─ git-workflow-manager
-│  ├─ git-branch-starter
-│  ├─ git-commit-manager
-│  ├─ git-pr-submitter
-│  └─ git-review-followup-manager
 ├─ feedback-points-manager
-│  └─ feedback-points-sanitizer
 └─ skill-authoring-wrapper
 ```
+
+significant workは`task-consistency-manager`確認後に開始する。taskが未登録、大きい、曖昧、依存またはexit criteria不足の場合だけ`task-breakdown-planner`を実行する。実装、検証、review follow-up、blocked、完了は`progress-sync-manager`で同期する。
 
 ## TDD適用境界
 
 TDD要否は対象repositoryの明示的なinstruction、accepted design、または利用者指示が決める。
 
-- `development-orchestrator`は`work-context-manager`でgoverning sourceを確認する
 - TDDが明示要求される場合だけ`tdd-executor`を呼ぶ
-- `tdd-executor`は`implementation-executor`から`implementation-worker`を呼び出す
 - TDDが要求されない場合は`not applicable`として通常implementationへ進む
 - codeまたはtestを変更するという事実だけではTDD適用理由にならない
 - CodexSkill repository自身の保守にはTDDを適用しない
@@ -125,87 +120,31 @@ Codexでも独立最終レビューを必須とし、技術レビューの意味
 
 ### 通常レビューcycle
 
-1. 実装後に`review-enforcer`を実行する。
-2. 専用normal reviewer sub-agentを選ぶ。
-3. reviewerは`work-context-manager`でtargetとevidenceを解決する。
-4. initial reviewとして`review-worker`を実行する。
-5. finding、review criteria、reviewed HEAD、fix context、held、unexploredをreportへ保持する。
-6. required findingがある場合はimplementation flowへ戻す。
-7. fix後は原則として同じnormal reviewerを継続利用する。
-8. `review-worker`のfix verificationでfinding解消、fix diff、直接影響、同一欠陥class、新規変更領域を確認する。
-9. normal review／fix verification report、implementation report、verification report、tracking、designを保存してcommit／pushする。
-10. required findingが解消または明示的にdispositionされるまで、bounded normal cycleを継続する。
-
-元のnormal reviewerを継続できない場合は、replacement identityと理由を記録し、finding identity、criteria、reviewed HEAD、fix context、held、unexploredを完全に引き継ぐ。
-
-finding identityとsource severityはcontinuity-bearing evidenceとして維持する。severityを変更する場合は、source severity、new severity、evidence-based reason、approving authorityを明示する。downstream reportの転記誤りはhistorical reportを黙って書き換えず、current erratumとして記録する。
+1. 実装後に専用normal reviewerを選ぶ。
+2. `review-worker`のinitial reviewを実行する。
+3. finding、review criteria、reviewed HEAD、fix context、held、unexploredを維持する。
+4. required findingがある場合はimplementation flowへ戻す。
+5. review findingが新しいscopeを要求する場合、実装前にtask trackingへ反映する。
+6. fix後は原則として同じnormal reviewerがfix verificationを行う。
+7. report、tracking、design、validationを保存してcommit／pushする。
 
 ### Pre-freeze gate
 
-normal review cycleが収束した後、independent final reviewのtargetをfreezeする前に、次を完了する。
+normal review cycle収束後、次を完了する。
 
-- parent-owned end-of-Issue Skill-gap decision
-- current scopeで実行する`skill-authoring-wrapper`作業
-- feedback classificationと`feedback-points-manager`によるledger同期
+- end-of-Issue Skill-gap decision
+- feedback classificationとledger同期
 - repository-backed normal handoff
-- implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report
+- implementation、design、workflow、configuration、tracking、各report
 - current-HEAD validationとCI evidence
 
-上記の処理でrepository fileが変わった場合、validation、report、tracking、commit／pushを行い、normal reviewまたはfix verificationへ戻る。新しいrepository writeが残った状態でfreezeしてはならない。
+上記でrepositoryが変わった場合はnormal reviewまたはfix verificationへ戻る。
 
 ### 独立最終レビュー
 
-pre-freeze gateを通過し、全ての非final変更がcommit／pushされた後に、independent-final-review report pathを予約し、その時点のcurrent HEADを`reviewed implementation HEAD`として固定する。
+全非final変更をcommit／pushした後、その時点のHEADを`reviewed implementation HEAD`として固定し、implementation、review fix、normal reviewに参加していないfresh reviewerがindependent final reviewを実行する。
 
-fresh reviewerは次を満たす。
-
-- implementation sub-agentと異なること
-- 通常reviewerと異なること
-- review fixを実装していないこと
-- 原則`fork_turns: "none"`で起動すること
-- frozen reviewed implementation HEADを対象とすること
-- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
-- reviewer identityとindependence evidenceを記録すること
-- `review-worker`のindependent final reviewを実行すること
-- 過去review結論を読む前に独立passを行うこと
-- normal review reportとは別にindependent final review reportを作ること
-
-独立最終レビューでrequired findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationまたはpre-freeze処理へ戻る。HEAD更新後はnormal reviewerでfix verificationを行い、さらに別のfresh reviewerで独立最終レビューをやり直す。
-
-normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
-
-## 最終review reportの終端規則
-
-独立最終レビューのtechnical verdictは`reviewed implementation HEAD`へ結び付ける。
-
-詳細reportをrepositoryへ保存する必要がある場合、次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
-
-- independent-final-review report pathはreview開始前に予約済みである
-- report-attestation commitのfirst parentはreviewed implementation HEADである
-- reviewed implementation HEADの後に存在するcommitはこの1件だけである
-- diffは予約済みindependent-final-review report pathだけを変更する
-- reportはreviewed implementation HEADとadministrative attestationであることを明記する
-- executable、Skill、design、workflow、configuration、tracking、feedback、handoff、product fileを変更しない
-- report-attestation commit以後にrepository commitを作らない
-- 親またはwrapperがallowlist diffを検証し、結果をPR bodyまたはPR commentへ記録する
-
-完了identityは次のpairで表す。
-
-```yaml
-reviewed_implementation_head: full_sha
-report_attestation_head: full_sha | null
-```
-
-report-attestation commitは新しいimplementation contentへverdictを転用するものではない。条件外のpost-review commitが1件でも発生した場合、完了状態を無効化し、normal fix verificationとfresh independent final reviewをやり直す。
-
-attestation後に許可するのはGit HEADを変更しない処理だけである。
-
-- PR body／PR commentの更新
-- review request
-- external Issueの作成または更新
-- inlineまたはPR branch外のhandoff transport
-
-attestation後にrepository writeの必要性が判明した場合はterminal stateを無効化し、normal cycleへ戻る。
+passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを許可する。attestation後はrepository commitを追加しない。
 
 ## ChatGPT chat worker flow
 
@@ -213,7 +152,10 @@ attestation後にrepository writeの必要性が判明した場合はterminal st
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
 │  ├─ work-context-manager
+│  ├─ task-consistency-manager
+│  ├─ task-breakdown-planner [必要時]
 │  ├─ implementation-worker
+│  ├─ progress-sync-manager
 │  ├─ report-writer
 │  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
@@ -230,49 +172,21 @@ attestation後にrepository writeの必要性が判明した場合はterminal st
    └─ chat-handoff-manager
 ```
 
+### ChatGPT実装契約
+
+`chat-implementation-worker`は次の順でSkillを呼び出す。
+
+1. `work-context-manager`
+2. `task-consistency-manager`
+3. 必要時のみ`task-breakdown-planner`
+4. `implementation-worker`
+5. `progress-sync-manager`
+6. `report-writer`
+7. `chat-handoff-manager`
+
+実装開始前にtask tracking整合を確認し、taskが未登録または不十分なら先に更新する。progress、blocked、検証、PR、完了をtrackingへ同期した後にreportとhandoffを確定する。
+
 initial reviewとfix verificationは同じnormal review chatを継続する。independent final reviewは、implementation、review fix、normal reviewに参加していない新規chatで実施する。
-
-### 初回実装
-
-```text
-Issue #<number>を開始してください。
-```
-
-`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`と`implementation-worker`を呼び出す。
-
-### 初回レビュー
-
-```text
-PR #<number>を初回レビューしてください。
-```
-
-`chat-review-worker`がreview modeとreviewer identityを管理し、`review-worker`のinitial reviewを呼び出す。
-
-### レビュー対応
-
-```text
-レビュー結果に対応してください。
-```
-
-初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。
-
-### 修正確認
-
-```text
-PR #<number>の修正確認をしてください。
-```
-
-初回レビューと同じnormal review chatを継続し、`review-worker`のfix verificationを実行する。
-
-### 独立最終レビュー
-
-```text
-PR #<number>を独立レビューしてください。
-```
-
-新規chatでfrozen reviewed implementation HEADを対象に`review-worker`のindependent final reviewを実行する。過去reviewの結論は独立pass後に照合する。
-
-passing reportをrepositoryへ保存する場合は、Codexと同じreport-attestation終端規則を適用する。final handoffはattestation後にinlineで返し、repository commitを追加しない。
 
 ## ChatGPT登録用Skillセット
 
@@ -290,7 +204,13 @@ ChatGPTへ登録するwrapper Skillは次の4つである。
 - `review-worker`
 - `report-writer`
 
-GitHub Releaseでは、8 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
+必須task tracking Skillは次の3つである。
+
+- `task-breakdown-planner`
+- `task-consistency-manager`
+- `progress-sync-manager`
+
+GitHub Releaseでは、11 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
 
 ```text
 chatgpt-worker-skills.zip
@@ -301,217 +221,59 @@ chatgpt-worker-skills.zip
 ├─ work-context-manager/
 ├─ implementation-worker/
 ├─ review-worker/
-└─ report-writer/
+├─ report-writer/
+├─ task-breakdown-planner/
+├─ task-consistency-manager/
+└─ progress-sync-manager/
 ```
 
-各directoryには少なくとも`SKILL.md`が存在し、front matterの`name`とdirectory名を一致させる。
-
-このZIPをChatGPTへuploadし、wrapperと依存core Skillを一括登録する。
+build scriptは全`chat-*`wrapper、必須core Skill、必須task tracking Skillを検出し、ZIP root集合と一致することを検証する。
 
 ## Handoff
 
-handoff contractを複数Skillから同一fileとして参照しない。`chat-handoff-manager`を独立Skillとして使用する。
+handoffは次を保持する。
 
-- reportとhandoffを別成果物とする
-- schema version 3を使用する
-- typed projectionとversioned `source_payloads`の両方を保持する
-- source core Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
-- development policy、planned validation、required failure diagnostics、blocked stateを保持する
-- implementation failure diagnosticsとblocked itemsを保持する
-- reviewer identity、reviewer continuity、independence evidenceを保持する
-- reserved report pathsとreport-attestation allowed flag、first-parent、allowlist、forbidden path class、validation resultを保持する
-- full findingのorigin、location、impact、evidence、required actionを保持する
-- reviewed HEAD、required coverage、held、unexplored、requirements、intentionally untouched、test、CI artifact、commit、report／comment referenceを保持する
-- schema version 1／2のoriginal packetを`source_payloads`として保存し、mapping不能fieldを捨てない
-- repository write可能時は通常handoffを`reports/handoffs/`へ保存する
-- PRまたはIssueから一意に特定できる場合は次workerがconnectorで取得する
-- 一意に特定できない場合だけ利用者へpathまたはpacket本文を求める
-- 前workerの権限は次chatへ自動継承しない
-- unknownを推測で補完しない
-- target Skill、mode、必要権限、参照先をpacketへ記録する
-- final independent review後のhandoffはinlineまたはPR branch外でtransportし、report-attestation後のcommitを追加しない
+- target repository、Issue、PR、branch、current HEAD
+- task identity、tracking path、phase、state、dependencies、exit criteria
+- accepted scope、non-goal、development policy、planned validation
+- implementation evidence、failure diagnostics、blocked items
+- finding、reviewed HEAD、held、unexplored
+- report、PR comment、workflow run、artifact参照
+- next workerが実行すべきtracking action
 
-## Release flow
+CI evidenceはpacketのtarget HEADと一致させ、別SHAのrunを代用しない。
 
-`.github/workflows/release-chatgpt-worker-skills.yml`を使用する。
+## Skill dependencyの扱い
 
-### pull request validation
+- wrapperは必要なcore Skillとtask tracking SkillをSkill名で呼び出す
+- Skill間で同一fileを共有しない
+- 各Skillは自directory内で完結する
+- dependency Skillが利用できない場合、wrapperは処理を複製せずmissing dependencyとして停止する
+- ChatGPT登録用ZIPにはwrapper、必須core Skill、必須task tracking Skillを同時に含める
 
-- `AGENTS.md`、`README.md`、全Skill、`shared/**`、design、tasks、reports、builder、repository validator、workflowの変更で実行する
-- forbidden shared runtime pathだけを追加する変更でもvalidation workflowを起動する
-- `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
-- build jobは`contents: read`だけを持ち、checkout credentialを保持しない
-- `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
-- 全`chat-*` wrapperと必須core Skillを検出する
-- missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
-- 単一`chatgpt-worker-skills.zip`を作成する
-- ZIP rootが検出Skill集合と一致することを確認する
-- ZIPをworkflow artifactとして保存する
-- GitHub Releaseは更新しない
+## CodexSkill repositoryの検証方針
 
-### Rolling normal Release
+CodexSkill repository自身にはTDDを適用しない。
 
-- 対象変更が`main`へpushされた場合に実行する
-- push後の`main` HEADでread-only validation／build jobを実行する
-- build成功後だけ別publish jobへ`contents: write`を付与する
-- build jobの検証済みartifactをpublish jobへ渡す
-- rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する
-- 固定通常Release `ChatGPT Worker Skills`へZIPを添付または置換する
+- Red/Green用testを追加しない
+- この変更専用のcontract testを追加しない
+- TDD用workflowを追加しない
+- repository validator、Skill dependency validation、ZIP build、配布物構造確認を使用する
+- 自動検証がない部分は設計書、Skill、workflow、Issue、PR説明の整合性をreviewする
 
-### PR merge Pre-release
+## Merge境界
 
-- `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
-- `merge_commit_sha`でread-only validation／build jobを再実行する
-- build成功後だけ別publish jobへ`contents: write`を付与する
-- build jobの検証済みartifactをpublish jobへ渡す
-- tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する
-- `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成する
-- Pre-releaseへ`chatgpt-worker-skills.zip`を添付する
-- job再実行時は同じPR tag／Pre-releaseとAssetを更新する
-- 自動Pre-releaseの`release.published`イベントはtag prefixで除外し、二重build／uploadしない
+core Skill、task tracking Skill、wrapper、sub-agent、親agentはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
 
-### 手動Release／Pre-release
+## 完了条件
 
-- 利用者がGitHub UIまたはAPIで公開した`release.published`イベントで実行する
-- Release tagが指すcommitでread-only validation／build jobを実行する
-- build成功後だけ別upload jobへ`contents: write`を付与する
-- build jobの検証済みZIPを、公開された同じReleaseへ添付する
-- 同名Assetがある場合は置換する
-- 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
-- Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない
-
-`workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
-
-Release時の共通file複製とrepository相対link書換は行わない。
-
-## 標準作業手順
-
-1. workflow開始時にCodexSkillの鮮度を確認する。
-2. 再開時は`restart-handover-manager`で状態を復元する。
-3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、write boundaryを解決する。
-4. `development-orchestrator`がtaskを選択する。
-5. `task-consistency-manager`でtrackingを同期する。
-6. 設計影響があれば`design-doc-maintainer`を実行する。
-7. 対象repositoryがTDDを要求する場合は`tdd-executor`を実行する。
-8. `implementation-executor`から`implementation-worker`を呼び出して実装する。
-9. focused validationと必要なfull validationを実行する。
-10. `report-output-manager`から`report-writer`を呼び出してimplementation／verification reportを保存する。
-11. `progress-sync-manager`でreportとtrackingを同期し、全非final変更をcommit／pushする。
-12. `review-enforcer`から`review-worker`を呼び出して通常review cycleを完了する。
-13. fixがあれば実装、validation、report、tracking、commit／push、normal fix verificationを繰り返す。
-14. normal cycle収束後、end-of-Issue Skill-gap decisionを行う。
-15. current scopeで必要な`skill-authoring-wrapper`処理を実行し、feedback classification、feedback ledger、normal handoffを保存する。
-16. steps 14から15でrepositoryが変わった場合、validation、report、tracking、commit／push、normal fix verificationを再実施する。
-17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、independent-final-review report pathを予約する。
-18. current HEADをreviewed implementation HEADとしてfreezeする。
-19. 別fresh reviewerによる独立最終reviewを実施する。
-20. repository changeが必要になった場合はfreezeを無効化し、normal cycleへ戻る。
-21. passing reportを保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
-22. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、validation evidenceを記録する。
-23. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
-24. mergeは利用者が行う。
-
-## Skill一覧
-
-### 入口と統括
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `development-orchestrator` | task選定から設計、実装、検証、レビュー、Git提出、pre-freeze gate、final attestation boundaryまでを統括する | 親が実行 |
-| `codex-delegation-executor` | 実作業の委譲先と実行profileを決める | 親が実行 |
-| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、report契約を固定する | 親が実行 |
-| `execution-cost-stabilizer` | retry、parallelism、実行コストを安定化する | 親が実行 |
-| `feedback-autonomy-boundary-manager` | 自律継続と利用者確認の境界を決める | 親が実行 |
-| `skill-authoring-wrapper` | core Skill／runtime wrapperをrepository標準へ揃える | 親が実行 |
-
-### 親非依存core Skill
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `work-context-manager` | authority、scope、target identity、policy、validation、CI、write boundaryを解決する | runtime非依存Skillとして実行 |
-| `implementation-worker` | initial implementationとreview follow-upを実施する | runtime非依存Skillとして実行 |
-| `review-worker` | initial review、fix verification、independent final reviewとattestation条件を返す | runtime非依存Skillとして実行 |
-| `report-writer` | evidence-faithfulなreport、簡易PR comment、persistence metadataを生成する | runtime非依存Skillとして実行 |
-
-### 計画と追跡
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `task-breakdown-planner` | issueをtaskとphaseへ分解する | 親が実行 |
-| `task-consistency-manager` | task、phase、実scopeを同期する | 親が実行 |
-| `progress-sync-manager` | report、tracking、実結果を同期する | 親が実行 |
-| `restart-handover-manager` | recorded stateから再開位置を復元する | 親が実行 |
-| `handover-memo-writer` | 別chat向けhandover memoを作成する | 親が実行 |
-
-### 設計と実装
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `design-doc-maintainer` | 設計影響と更新対象を判断する | 親が実行 |
-| `design-executor` | 決定済み設計変更を編集する | 親が実行 |
-| `tdd-executor` | 対象repositoryが要求するtest-first証拠をcore Skill経由で定義する | 親が実行 |
-| `implementation-executor` | executorを管理し、`implementation-worker`を呼び出すCodex wrapper | 親が実行 |
-
-### レビューと品質
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze gate、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
-| `markdown-word-checker` | Markdown lintと表記ルールを検証する | 親が実行 |
-| `feedback-coding-standards-enforcer` | coding standardを検証する | 親が実行 |
-| `feedback-issue-intake-fallback-manager` | Issue取得失敗時に要件を確保する | 親が実行 |
-
-### Gitとreport
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `git-workflow-manager` | branch、commit、push、PRを統括する | 親が実行 |
-| `git-branch-starter` | 作業branchを準備する | 親が実行 |
-| `git-commit-manager` | scoped commitを作成する | 親が実行 |
-| `git-pr-submitter` | PRを作成または更新する | 親が実行 |
-| `git-review-followup-manager` | review findingをimplementation flowへ戻す | 親が実行 |
-| `report-output-manager` | report path／persistence／report-attestationを管理し、`report-writer`を呼び出すCodex wrapper | 親が実行 |
-
-### ChatGPT runtime wrapper
-
-| Skill | 役割 | 実行方式 |
-| --- | --- | --- |
-| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-upを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-review-worker` | ChatGPT上のinitial、fix verification、independent final review、report-attestationを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-report-writer` | ChatGPT上のsource discovery、report永続化、PR commentを統括する | 利用者が親としてChatGPT chatで実行 |
-| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetを生成する | ChatGPT wrapperから呼び出す |
-
-## 共通規則
-
-- 対象repositoryのProject Instructionを優先する。
-- 解決可能なrepository stateを利用者へ再質問しない。
-- CodexSkill repository自身にはTDDを適用しない。
-- implementationは自分の変更へreview verdictを出さない。
-- reviewerはfindingを実装しない。
-- finding identityとsource severityを維持し、severity変更はsource／new severity、理由、承認主体を明示する。
-- reviewは詳細reportへ記録する。
-- CIは対象current HEAD SHAに紐づくrunだけを使用する。
-- 別SHAのrunを代用しない。
-- reportとhandoffを混同しない。
-- handoffはtyped projectionとversioned raw source payloadでcore Skill outputを欠落なくtransportする。
-- unknown、blocked、held、unexplored、失敗結果を消さない。
-- core Skillとwrapperは自directory外のshared fileへ依存しない。
-- dependency Skillが存在しない場合、wrapperは処理を複製せずmissing dependencyとして停止する。
-- end-of-Issue Skill decision、feedback ledger、normal handoff、report、trackingをindependent final review前に確定する。
-- pre-freeze処理でrepositoryが変わった場合はnormal reviewへ戻る。
-- independent final review後は条件を満たす1回のreport-attestation commit以外のGit commitを作らない。
-- attestation後はrepository-writing Skillを呼ばない。
-- worker、sub-agent、親agentはmergeしない。
-
-## 保守規則
-
-- Skill追加または責務変更時は本設計書を更新する。
-- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同一内容に保つ。
-- ChatGPT Skill package変更時はRelease workflowと`design/chat-worker-skill-design.md`も更新する。
-- ChatGPT Project Instruction例を変更する場合は`design/chatgpt-project-instruction-example.md`を更新する。
-- review lifecycle変更時は`review-worker`、`review-enforcer`、`chat-review-worker`、`report-writer`、`report-output-manager`、本設計書、専用設計書を同時更新する。
-- handoff schema変更時は`chat-handoff-manager`、ChatGPT wrapper、両設計書、Issue／trackingを同期する。
-- core Skill dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
-- `scripts/verify_skill_repository.py`でactive Markdown link、Skill依存、front matter、symlink、削除済みshared runtime path、hierarchy design同期を検証する。
-- workflow trigger変更時はforbidden pathだけの変更でもvalidatorが起動するcoverageを両設計書とPR説明へ同期する。
-- 既存設計書の変更時は、構成変更と無関係な節を削除せず、矛盾する箇所だけを置換する。
+- implementation、review、reportの意味論が親非依存core Skillとして定義されている
+- task trackingの分割、整合、進捗同期が専用Skillへ分離されている
+- ChatGPT実装workerがtask整合確認後に実装を開始する
+- wrapperがtask更新規則を独自実装しない
+- wrapper、core Skill、task tracking Skillの11 Skillを単一ZIPで登録できる
+- hierarchy design、ChatGPT worker design、Skill contract、build scriptが同期している
+- current HEAD固有CI規則が反映されている
+- CodexSkill repositoryへTDDを適用しない
+- reportとhandoffが別成果物として維持される
+- mergeを実施しない

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -4,7 +4,7 @@
 
 Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker flowを一元的に定義する。
 
-実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、task trackingは専用Skill、runtime固有処理はwrapperへ分離する。
+実装、レビュー、レポート生成の意味論は親runtimeに依存しないcore Skillとして定義し、CodexとChatGPTはruntime wrapperからそれらを呼び出す。
 
 この設計書をSkill hierarchyの正本とし、`skills/design/skill-hierarchy-design.md`と同一内容に保つ。
 
@@ -13,9 +13,9 @@ Codex向け親／sub-agent flowと、利用者が親となるChatGPT chat worker
 - `親が実行`: Codex親agentがSkillを直接実行する。
 - `親が呼び出し、sub-agentが実行`: Codex親agentがSkillを通じてsub-agentへ実作業を委譲する。
 - `利用者が親としてChatGPT chatで実行`: 利用者が独立chatを起動し、そのchatが指定wrapper Skillを直接実行する。
-- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、runtime固有の制御を持たずに実作業を行う。
+- `runtime非依存Skillとして実行`: 親またはwrapperから渡されたcontextを使用し、Codex親、sub-agent、ChatGPT chat固有の制御を持たずに実作業を行う。
 
-ChatGPT wrapperは別workerまたはsub-agentを起動しない。CodexとChatGPTは別runtime wrapperを使用するが、implementation、review、reportの意味論は同じcore Skillを使用する。
+ChatGPT wrapperは別workerまたはsub-agentを起動しない。Codex向けwrapperとChatGPT向けwrapperは別の実行系として扱うが、実装、レビュー、レポートの意味論は同じcore Skillを使用する。
 
 ## Skill依存アーキテクチャ
 
@@ -25,11 +25,6 @@ ChatGPT wrapperは別workerまたはsub-agentを起動しない。CodexとChatGP
 ├─ implementation-worker
 ├─ review-worker
 └─ report-writer
-
-task tracking Skill
-├─ task-breakdown-planner
-├─ task-consistency-manager
-└─ progress-sync-manager
 
 runtime wrapper
 ├─ Codex
@@ -43,7 +38,7 @@ runtime wrapper
    └─ chat-handoff-manager
 ```
 
-## Core Skill
+### Core Skill
 
 - `work-context-manager`
   - authority、scope、target identity、development policy、validation target、current-HEAD CI evidence、write boundaryを解決する
@@ -54,20 +49,9 @@ runtime wrapper
 - `report-writer`
   - evidenceの意味を変えずにreportと簡易PR commentを生成する
 
-全core SkillはCodex親、Codex sub-agent、ChatGPT chatのいずれにも依存しない。
+全core SkillはCodex親、Codex sub-agent、ChatGPT親chatのいずれにも依存しない。
 
-## task tracking Skill
-
-- `task-breakdown-planner`
-  - taskを完了判定可能な単位へ分割し、dependencies、exit criteria、estimate、phaseを定義する
-- `task-consistency-manager`
-  - significant workの開始前とscope変更時にcanonical task trackingとの整合を確認する
-- `progress-sync-manager`
-  - active、blocked、verification、PR、完了状態をtask／phaseへ同期する
-
-canonical task tracking fileはこれらの専用Skill経由で更新する。runtime wrapperまたはimplementation core Skillがtask更新規則を複製しない。
-
-## Runtime wrapper
+### Runtime wrapper
 
 Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、fresh independent reviewer、report path、persistence、completion gateを所有する。
 
@@ -82,32 +66,53 @@ development-orchestrator [親]
 ├─ restart-handover-manager
 ├─ work-context-manager
 ├─ task-consistency-manager
-├─ task-breakdown-planner [必要時]
 ├─ design-doc-maintainer
+│  ├─ codex-delegation-executor
+│  │  └─ design-executor
+│  └─ task-consistency-manager
 ├─ tdd-executor [対象repositoryが明示要求する場合だけ]
-├─ implementation-executor [wrapper]
 │  ├─ work-context-manager
-│  └─ implementation-worker
-├─ progress-sync-manager
+│  ├─ codex-delegation-executor
+│  │  └─ implementation-executor [wrapper]
+│  │     ├─ work-context-manager
+│  │     └─ implementation-worker
+│  └─ sub-agent-task-manager [test evidence]
+├─ codex-delegation-executor
+│  ├─ implementation-executor [wrapper]
+│  │  ├─ work-context-manager
+│  │  └─ implementation-worker
+│  ├─ design-executor
+│  ├─ sub-agent-task-manager [verification]
+│  └─ report-output-manager [wrapper]
+│     ├─ work-context-manager
+│     └─ report-writer
 ├─ review-enforcer [wrapper]
 │  ├─ work-context-manager
-│  ├─ review-worker [normal reviewer]
-│  └─ review-worker [fresh independent final reviewer]
-├─ report-output-manager [wrapper]
-│  ├─ work-context-manager
-│  └─ report-writer
+│  ├─ markdown-word-checker
+│  ├─ sub-agent-task-manager [normal reviewer]
+│  │  └─ review-worker
+│  ├─ sub-agent-task-manager [fresh independent final reviewer]
+│  │  └─ review-worker
+│  └─ report-output-manager
+│     └─ report-writer
+├─ progress-sync-manager
 ├─ git-workflow-manager
+│  ├─ git-branch-starter
+│  ├─ git-commit-manager
+│  ├─ git-pr-submitter
+│  └─ git-review-followup-manager
 ├─ feedback-points-manager
+│  └─ feedback-points-sanitizer
 └─ skill-authoring-wrapper
 ```
-
-significant workは`task-consistency-manager`確認後に開始する。taskが未登録、大きい、曖昧、依存またはexit criteria不足の場合だけ`task-breakdown-planner`を実行する。実装、検証、review follow-up、blocked、完了は`progress-sync-manager`で同期する。
 
 ## TDD適用境界
 
 TDD要否は対象repositoryの明示的なinstruction、accepted design、または利用者指示が決める。
 
+- `development-orchestrator`は`work-context-manager`でgoverning sourceを確認する
 - TDDが明示要求される場合だけ`tdd-executor`を呼ぶ
+- `tdd-executor`は`implementation-executor`から`implementation-worker`を呼び出す
 - TDDが要求されない場合は`not applicable`として通常implementationへ進む
 - codeまたはtestを変更するという事実だけではTDD適用理由にならない
 - CodexSkill repository自身の保守にはTDDを適用しない
@@ -120,31 +125,87 @@ Codexでも独立最終レビューを必須とし、技術レビューの意味
 
 ### 通常レビューcycle
 
-1. 実装後に専用normal reviewerを選ぶ。
-2. `review-worker`のinitial reviewを実行する。
-3. finding、review criteria、reviewed HEAD、fix context、held、unexploredを維持する。
-4. required findingがある場合はimplementation flowへ戻す。
-5. review findingが新しいscopeを要求する場合、実装前にtask trackingへ反映する。
-6. fix後は原則として同じnormal reviewerがfix verificationを行う。
-7. report、tracking、design、validationを保存してcommit／pushする。
+1. 実装後に`review-enforcer`を実行する。
+2. 専用normal reviewer sub-agentを選ぶ。
+3. reviewerは`work-context-manager`でtargetとevidenceを解決する。
+4. initial reviewとして`review-worker`を実行する。
+5. finding、review criteria、reviewed HEAD、fix context、held、unexploredをreportへ保持する。
+6. required findingがある場合はimplementation flowへ戻す。
+7. fix後は原則として同じnormal reviewerを継続利用する。
+8. `review-worker`のfix verificationでfinding解消、fix diff、直接影響、同一欠陥class、新規変更領域を確認する。
+9. normal review／fix verification report、implementation report、verification report、tracking、designを保存してcommit／pushする。
+10. required findingが解消または明示的にdispositionされるまで、bounded normal cycleを継続する。
+
+元のnormal reviewerを継続できない場合は、replacement identityと理由を記録し、finding identity、criteria、reviewed HEAD、fix context、held、unexploredを完全に引き継ぐ。
+
+finding identityとsource severityはcontinuity-bearing evidenceとして維持する。severityを変更する場合は、source severity、new severity、evidence-based reason、approving authorityを明示する。downstream reportの転記誤りはhistorical reportを黙って書き換えず、current erratumとして記録する。
 
 ### Pre-freeze gate
 
-normal review cycle収束後、次を完了する。
+normal review cycleが収束した後、independent final reviewのtargetをfreezeする前に、次を完了する。
 
-- end-of-Issue Skill-gap decision
-- feedback classificationとledger同期
+- parent-owned end-of-Issue Skill-gap decision
+- current scopeで実行する`skill-authoring-wrapper`作業
+- feedback classificationと`feedback-points-manager`によるledger同期
 - repository-backed normal handoff
-- implementation、design、workflow、configuration、tracking、各report
+- implementation、design、workflow、configuration、tracking、normal review report、fix-verification report、verification report
 - current-HEAD validationとCI evidence
 
-上記でrepositoryが変わった場合はnormal reviewまたはfix verificationへ戻る。
+上記の処理でrepository fileが変わった場合、validation、report、tracking、commit／pushを行い、normal reviewまたはfix verificationへ戻る。新しいrepository writeが残った状態でfreezeしてはならない。
 
 ### 独立最終レビュー
 
-全非final変更をcommit／pushした後、その時点のHEADを`reviewed implementation HEAD`として固定し、implementation、review fix、normal reviewに参加していないfresh reviewerがindependent final reviewを実行する。
+pre-freeze gateを通過し、全ての非final変更がcommit／pushされた後に、independent-final-review report pathを予約し、その時点のcurrent HEADを`reviewed implementation HEAD`として固定する。
 
-passing reportをrepositoryへ保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを許可する。attestation後はrepository commitを追加しない。
+fresh reviewerは次を満たす。
+
+- implementation sub-agentと異なること
+- 通常reviewerと異なること
+- review fixを実装していないこと
+- 原則`fork_turns: "none"`で起動すること
+- frozen reviewed implementation HEADを対象とすること
+- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
+- reviewer identityとindependence evidenceを記録すること
+- `review-worker`のindependent final reviewを実行すること
+- 過去review結論を読む前に独立passを行うこと
+- normal review reportとは別にindependent final review reportを作ること
+
+独立最終レビューでrequired findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationまたはpre-freeze処理へ戻る。HEAD更新後はnormal reviewerでfix verificationを行い、さらに別のfresh reviewerで独立最終レビューをやり直す。
+
+normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
+
+## 最終review reportの終端規則
+
+独立最終レビューのtechnical verdictは`reviewed implementation HEAD`へ結び付ける。
+
+詳細reportをrepositoryへ保存する必要がある場合、次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
+
+- independent-final-review report pathはreview開始前に予約済みである
+- report-attestation commitのfirst parentはreviewed implementation HEADである
+- reviewed implementation HEADの後に存在するcommitはこの1件だけである
+- diffは予約済みindependent-final-review report pathだけを変更する
+- reportはreviewed implementation HEADとadministrative attestationであることを明記する
+- executable、Skill、design、workflow、configuration、tracking、feedback、handoff、product fileを変更しない
+- report-attestation commit以後にrepository commitを作らない
+- 親またはwrapperがallowlist diffを検証し、結果をPR bodyまたはPR commentへ記録する
+
+完了identityは次のpairで表す。
+
+```yaml
+reviewed_implementation_head: full_sha
+report_attestation_head: full_sha | null
+```
+
+report-attestation commitは新しいimplementation contentへverdictを転用するものではない。条件外のpost-review commitが1件でも発生した場合、完了状態を無効化し、normal fix verificationとfresh independent final reviewをやり直す。
+
+attestation後に許可するのはGit HEADを変更しない処理だけである。
+
+- PR body／PR commentの更新
+- review request
+- external Issueの作成または更新
+- inlineまたはPR branch外のhandoff transport
+
+attestation後にrepository writeの必要性が判明した場合はterminal stateを無効化し、normal cycleへ戻る。
 
 ## ChatGPT chat worker flow
 
@@ -152,10 +213,7 @@ passing reportをrepositoryへ保存する場合は、予約済みreport pathだ
 利用者 [親]
 ├─ Chat A: chat-implementation-worker [initial implementation]
 │  ├─ work-context-manager
-│  ├─ task-consistency-manager
-│  ├─ task-breakdown-planner [必要時]
 │  ├─ implementation-worker
-│  ├─ progress-sync-manager
 │  ├─ report-writer
 │  └─ chat-handoff-manager
 ├─ Chat B: chat-review-worker [initial review]
@@ -172,21 +230,49 @@ passing reportをrepositoryへ保存する場合は、予約済みreport pathだ
    └─ chat-handoff-manager
 ```
 
-### ChatGPT実装契約
-
-`chat-implementation-worker`は次の順でSkillを呼び出す。
-
-1. `work-context-manager`
-2. `task-consistency-manager`
-3. 必要時のみ`task-breakdown-planner`
-4. `implementation-worker`
-5. `progress-sync-manager`
-6. `report-writer`
-7. `chat-handoff-manager`
-
-実装開始前にtask tracking整合を確認し、taskが未登録または不十分なら先に更新する。progress、blocked、検証、PR、完了をtrackingへ同期した後にreportとhandoffを確定する。
-
 initial reviewとfix verificationは同じnormal review chatを継続する。independent final reviewは、implementation、review fix、normal reviewに参加していない新規chatで実施する。
+
+### 初回実装
+
+```text
+Issue #<number>を開始してください。
+```
+
+`chat-implementation-worker`がrepository stateと権限を管理し、`work-context-manager`と`implementation-worker`を呼び出す。
+
+### 初回レビュー
+
+```text
+PR #<number>を初回レビューしてください。
+```
+
+`chat-review-worker`がreview modeとreviewer identityを管理し、`review-worker`のinitial reviewを呼び出す。
+
+### レビュー対応
+
+```text
+レビュー結果に対応してください。
+```
+
+初回実装chatを継続し、`implementation-worker`のreview follow-upでfinding、直接原因、影響境界、同一欠陥classだけを修正する。
+
+### 修正確認
+
+```text
+PR #<number>の修正確認をしてください。
+```
+
+初回レビューと同じnormal review chatを継続し、`review-worker`のfix verificationを実行する。
+
+### 独立最終レビュー
+
+```text
+PR #<number>を独立レビューしてください。
+```
+
+新規chatでfrozen reviewed implementation HEADを対象に`review-worker`のindependent final reviewを実行する。過去reviewの結論は独立pass後に照合する。
+
+passing reportをrepositoryへ保存する場合は、Codexと同じreport-attestation終端規則を適用する。final handoffはattestation後にinlineで返し、repository commitを追加しない。
 
 ## ChatGPT登録用Skillセット
 
@@ -204,13 +290,7 @@ ChatGPTへ登録するwrapper Skillは次の4つである。
 - `review-worker`
 - `report-writer`
 
-必須task tracking Skillは次の3つである。
-
-- `task-breakdown-planner`
-- `task-consistency-manager`
-- `progress-sync-manager`
-
-GitHub Releaseでは、11 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
+GitHub Releaseでは、8 Skillをそれぞれ独立したroot directoryとして含む単一ZIPを配布する。
 
 ```text
 chatgpt-worker-skills.zip
@@ -221,59 +301,217 @@ chatgpt-worker-skills.zip
 ├─ work-context-manager/
 ├─ implementation-worker/
 ├─ review-worker/
-├─ report-writer/
-├─ task-breakdown-planner/
-├─ task-consistency-manager/
-└─ progress-sync-manager/
+└─ report-writer/
 ```
 
-build scriptは全`chat-*`wrapper、必須core Skill、必須task tracking Skillを検出し、ZIP root集合と一致することを検証する。
+各directoryには少なくとも`SKILL.md`が存在し、front matterの`name`とdirectory名を一致させる。
+
+このZIPをChatGPTへuploadし、wrapperと依存core Skillを一括登録する。
 
 ## Handoff
 
-handoffは次を保持する。
+handoff contractを複数Skillから同一fileとして参照しない。`chat-handoff-manager`を独立Skillとして使用する。
 
-- target repository、Issue、PR、branch、current HEAD
-- task identity、tracking path、phase、state、dependencies、exit criteria
-- accepted scope、non-goal、development policy、planned validation
-- implementation evidence、failure diagnostics、blocked items
-- finding、reviewed HEAD、held、unexplored
-- report、PR comment、workflow run、artifact参照
-- next workerが実行すべきtracking action
+- reportとhandoffを別成果物とする
+- schema version 3を使用する
+- typed projectionとversioned `source_payloads`の両方を保持する
+- source core Skillのcomplete outputをraw payloadとして保持し、typed fieldに表現できない情報を失わない
+- development policy、planned validation、required failure diagnostics、blocked stateを保持する
+- implementation failure diagnosticsとblocked itemsを保持する
+- reviewer identity、reviewer continuity、independence evidenceを保持する
+- reserved report pathsとreport-attestation allowed flag、first-parent、allowlist、forbidden path class、validation resultを保持する
+- full findingのorigin、location、impact、evidence、required actionを保持する
+- reviewed HEAD、required coverage、held、unexplored、requirements、intentionally untouched、test、CI artifact、commit、report／comment referenceを保持する
+- schema version 1／2のoriginal packetを`source_payloads`として保存し、mapping不能fieldを捨てない
+- repository write可能時は通常handoffを`reports/handoffs/`へ保存する
+- PRまたはIssueから一意に特定できる場合は次workerがconnectorで取得する
+- 一意に特定できない場合だけ利用者へpathまたはpacket本文を求める
+- 前workerの権限は次chatへ自動継承しない
+- unknownを推測で補完しない
+- target Skill、mode、必要権限、参照先をpacketへ記録する
+- final independent review後のhandoffはinlineまたはPR branch外でtransportし、report-attestation後のcommitを追加しない
 
-CI evidenceはpacketのtarget HEADと一致させ、別SHAのrunを代用しない。
+## Release flow
 
-## Skill dependencyの扱い
+`.github/workflows/release-chatgpt-worker-skills.yml`を使用する。
 
-- wrapperは必要なcore Skillとtask tracking SkillをSkill名で呼び出す
-- Skill間で同一fileを共有しない
-- 各Skillは自directory内で完結する
-- dependency Skillが利用できない場合、wrapperは処理を複製せずmissing dependencyとして停止する
-- ChatGPT登録用ZIPにはwrapper、必須core Skill、必須task tracking Skillを同時に含める
+### pull request validation
 
-## CodexSkill repositoryの検証方針
+- `AGENTS.md`、`README.md`、全Skill、`shared/**`、design、tasks、reports、builder、repository validator、workflowの変更で実行する
+- forbidden shared runtime pathだけを追加する変更でもvalidation workflowを起動する
+- `opened`、`synchronize`、`reopened`では実PR HEAD SHAをcheckoutする
+- build jobは`contents: read`だけを持ち、checkout credentialを保持しない
+- `scripts/verify_skill_repository.py`で全Skillのfront matter、Skill名依存、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
+- 全`chat-*` wrapperと必須core Skillを検出する
+- missing Skill、front matter name不一致、symlink、Skill外shared参照を拒否する
+- 単一`chatgpt-worker-skills.zip`を作成する
+- ZIP rootが検出Skill集合と一致することを確認する
+- ZIPをworkflow artifactとして保存する
+- GitHub Releaseは更新しない
 
-CodexSkill repository自身にはTDDを適用しない。
+### Rolling normal Release
 
-- Red/Green用testを追加しない
-- この変更専用のcontract testを追加しない
-- TDD用workflowを追加しない
-- repository validator、Skill dependency validation、ZIP build、配布物構造確認を使用する
-- 自動検証がない部分は設計書、Skill、workflow、Issue、PR説明の整合性をreviewする
+- 対象変更が`main`へpushされた場合に実行する
+- push後の`main` HEADでread-only validation／build jobを実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- rolling tag `chatgpt-worker-skills-latest`を対象HEADへ更新する
+- 固定通常Release `ChatGPT Worker Skills`へZIPを添付または置換する
 
-## Merge境界
+### PR merge Pre-release
 
-core Skill、task tracking Skill、wrapper、sub-agent、親agentはいずれもmergeを行わず、利用者がmerge判断と実行を所有する。
+- `pull_request.closed`かつ`merged == true`の場合だけ実行し、未merge closeでは実行しない
+- `merge_commit_sha`でread-only validation／build jobを再実行する
+- build成功後だけ別publish jobへ`contents: write`を付与する
+- build jobの検証済みartifactをpublish jobへ渡す
+- tag `chatgpt-worker-skills-pr-<PR番号>`をmerge commitへ作成する
+- `ChatGPT Worker Skills PR #<PR番号>`をPre-releaseとして作成する
+- Pre-releaseへ`chatgpt-worker-skills.zip`を添付する
+- job再実行時は同じPR tag／Pre-releaseとAssetを更新する
+- 自動Pre-releaseの`release.published`イベントはtag prefixで除外し、二重build／uploadしない
 
-## 完了条件
+### 手動Release／Pre-release
 
-- implementation、review、reportの意味論が親非依存core Skillとして定義されている
-- task trackingの分割、整合、進捗同期が専用Skillへ分離されている
-- ChatGPT実装workerがtask整合確認後に実装を開始する
-- wrapperがtask更新規則を独自実装しない
-- wrapper、core Skill、task tracking Skillの11 Skillを単一ZIPで登録できる
-- hierarchy design、ChatGPT worker design、Skill contract、build scriptが同期している
-- current HEAD固有CI規則が反映されている
-- CodexSkill repositoryへTDDを適用しない
-- reportとhandoffが別成果物として維持される
-- mergeを実施しない
+- 利用者がGitHub UIまたはAPIで公開した`release.published`イベントで実行する
+- Release tagが指すcommitでread-only validation／build jobを実行する
+- build成功後だけ別upload jobへ`contents: write`を付与する
+- build jobの検証済みZIPを、公開された同じReleaseへ添付する
+- 同名Assetがある場合は置換する
+- 自動PR merge Pre-release用tag prefix `chatgpt-worker-skills-pr-`は対象外とする
+- Workflowの`GITHUB_TOKEN`で作成または更新したReleaseイベントは再帰的なWorkflow runを生成しない
+
+`workflow_dispatch`はread-only validation／buildだけを行い、Releaseを更新しない。
+
+Release時の共通file複製とrepository相対link書換は行わない。
+
+## 標準作業手順
+
+1. workflow開始時にCodexSkillの鮮度を確認する。
+2. 再開時は`restart-handover-manager`で状態を復元する。
+3. `work-context-manager`でauthority、scope、target identity、development policy、validation target、write boundaryを解決する。
+4. `development-orchestrator`がtaskを選択する。
+5. `task-consistency-manager`でtrackingを同期する。
+6. 設計影響があれば`design-doc-maintainer`を実行する。
+7. 対象repositoryがTDDを要求する場合は`tdd-executor`を実行する。
+8. `implementation-executor`から`implementation-worker`を呼び出して実装する。
+9. focused validationと必要なfull validationを実行する。
+10. `report-output-manager`から`report-writer`を呼び出してimplementation／verification reportを保存する。
+11. `progress-sync-manager`でreportとtrackingを同期し、全非final変更をcommit／pushする。
+12. `review-enforcer`から`review-worker`を呼び出して通常review cycleを完了する。
+13. fixがあれば実装、validation、report、tracking、commit／push、normal fix verificationを繰り返す。
+14. normal cycle収束後、end-of-Issue Skill-gap decisionを行う。
+15. current scopeで必要な`skill-authoring-wrapper`処理を実行し、feedback classification、feedback ledger、normal handoffを保存する。
+16. steps 14から15でrepositoryが変わった場合、validation、report、tracking、commit／push、normal fix verificationを再実施する。
+17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、independent-final-review report pathを予約する。
+18. current HEADをreviewed implementation HEADとしてfreezeする。
+19. 別fresh reviewerによる独立最終reviewを実施する。
+20. repository changeが必要になった場合はfreezeを無効化し、normal cycleへ戻る。
+21. passing reportを保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
+22. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、validation evidenceを記録する。
+23. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
+24. mergeは利用者が行う。
+
+## Skill一覧
+
+### 入口と統括
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `development-orchestrator` | task選定から設計、実装、検証、レビュー、Git提出、pre-freeze gate、final attestation boundaryまでを統括する | 親が実行 |
+| `codex-delegation-executor` | 実作業の委譲先と実行profileを決める | 親が実行 |
+| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、report契約を固定する | 親が実行 |
+| `execution-cost-stabilizer` | retry、parallelism、実行コストを安定化する | 親が実行 |
+| `feedback-autonomy-boundary-manager` | 自律継続と利用者確認の境界を決める | 親が実行 |
+| `skill-authoring-wrapper` | core Skill／runtime wrapperをrepository標準へ揃える | 親が実行 |
+
+### 親非依存core Skill
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `work-context-manager` | authority、scope、target identity、policy、validation、CI、write boundaryを解決する | runtime非依存Skillとして実行 |
+| `implementation-worker` | initial implementationとreview follow-upを実施する | runtime非依存Skillとして実行 |
+| `review-worker` | initial review、fix verification、independent final reviewとattestation条件を返す | runtime非依存Skillとして実行 |
+| `report-writer` | evidence-faithfulなreport、簡易PR comment、persistence metadataを生成する | runtime非依存Skillとして実行 |
+
+### 計画と追跡
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `task-breakdown-planner` | issueをtaskとphaseへ分解する | 親が実行 |
+| `task-consistency-manager` | task、phase、実scopeを同期する | 親が実行 |
+| `progress-sync-manager` | report、tracking、実結果を同期する | 親が実行 |
+| `restart-handover-manager` | recorded stateから再開位置を復元する | 親が実行 |
+| `handover-memo-writer` | 別chat向けhandover memoを作成する | 親が実行 |
+
+### 設計と実装
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `design-doc-maintainer` | 設計影響と更新対象を判断する | 親が実行 |
+| `design-executor` | 決定済み設計変更を編集する | 親が実行 |
+| `tdd-executor` | 対象repositoryが要求するtest-first証拠をcore Skill経由で定義する | 親が実行 |
+| `implementation-executor` | executorを管理し、`implementation-worker`を呼び出すCodex wrapper | 親が実行 |
+
+### レビューと品質
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze gate、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
+| `markdown-word-checker` | Markdown lintと表記ルールを検証する | 親が実行 |
+| `feedback-coding-standards-enforcer` | coding standardを検証する | 親が実行 |
+| `feedback-issue-intake-fallback-manager` | Issue取得失敗時に要件を確保する | 親が実行 |
+
+### Gitとreport
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `git-workflow-manager` | branch、commit、push、PRを統括する | 親が実行 |
+| `git-branch-starter` | 作業branchを準備する | 親が実行 |
+| `git-commit-manager` | scoped commitを作成する | 親が実行 |
+| `git-pr-submitter` | PRを作成または更新する | 親が実行 |
+| `git-review-followup-manager` | review findingをimplementation flowへ戻す | 親が実行 |
+| `report-output-manager` | report path／persistence／report-attestationを管理し、`report-writer`を呼び出すCodex wrapper | 親が実行 |
+
+### ChatGPT runtime wrapper
+
+| Skill | 役割 | 実行方式 |
+| --- | --- | --- |
+| `chat-implementation-worker` | ChatGPT上の初回実装とreview follow-upを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-review-worker` | ChatGPT上のinitial、fix verification、independent final review、report-attestationを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-report-writer` | ChatGPT上のsource discovery、report永続化、PR commentを統括する | 利用者が親としてChatGPT chatで実行 |
+| `chat-handoff-manager` | 独立chat間のlossless typed／raw handoff packetを生成する | ChatGPT wrapperから呼び出す |
+
+## 共通規則
+
+- 対象repositoryのProject Instructionを優先する。
+- 解決可能なrepository stateを利用者へ再質問しない。
+- CodexSkill repository自身にはTDDを適用しない。
+- implementationは自分の変更へreview verdictを出さない。
+- reviewerはfindingを実装しない。
+- finding identityとsource severityを維持し、severity変更はsource／new severity、理由、承認主体を明示する。
+- reviewは詳細reportへ記録する。
+- CIは対象current HEAD SHAに紐づくrunだけを使用する。
+- 別SHAのrunを代用しない。
+- reportとhandoffを混同しない。
+- handoffはtyped projectionとversioned raw source payloadでcore Skill outputを欠落なくtransportする。
+- unknown、blocked、held、unexplored、失敗結果を消さない。
+- core Skillとwrapperは自directory外のshared fileへ依存しない。
+- dependency Skillが存在しない場合、wrapperは処理を複製せずmissing dependencyとして停止する。
+- end-of-Issue Skill decision、feedback ledger、normal handoff、report、trackingをindependent final review前に確定する。
+- pre-freeze処理でrepositoryが変わった場合はnormal reviewへ戻る。
+- independent final review後は条件を満たす1回のreport-attestation commit以外のGit commitを作らない。
+- attestation後はrepository-writing Skillを呼ばない。
+- worker、sub-agent、親agentはmergeしない。
+
+## 保守規則
+
+- Skill追加または責務変更時は本設計書を更新する。
+- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同一内容に保つ。
+- ChatGPT Skill package変更時はRelease workflowと`design/chat-worker-skill-design.md`も更新する。
+- ChatGPT Project Instruction例を変更する場合は`design/chatgpt-project-instruction-example.md`を更新する。
+- review lifecycle変更時は`review-worker`、`review-enforcer`、`chat-review-worker`、`report-writer`、`report-output-manager`、本設計書、専用設計書を同時更新する。
+- handoff schema変更時は`chat-handoff-manager`、ChatGPT wrapper、両設計書、Issue／trackingを同期する。
+- core Skill dependency変更時はCodex wrapper、ChatGPT wrapper、Release builder、repository validator、両設計書を同時更新する。
+- `scripts/verify_skill_repository.py`でactive Markdown link、Skill依存、front matter、symlink、削除済みshared runtime path、hierarchy design同期を検証する。
+- workflow trigger変更時はforbidden pathだけの変更でもvalidatorが起動するcoverageを両設計書とPR説明へ同期する。
+- 既存設計書の変更時は、構成変更と無関係な節を削除せず、矛盾する箇所だけを置換する。

--- a/skills/progress-sync-manager/SKILL.md
+++ b/skills/progress-sync-manager/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: progress-sync-manager
-description: Synchronize tasks-status.md, phases-status.md, reports references, and related progress records with actual work results. Use after planning changes, after review, after commit/PR creation, or whenever tracking no longer matches the real state of the work.
+description: Synchronize canonical task and phase tracking, report references, and related progress records with actual work results. Use after planning changes, after review, after commit/PR creation, or whenever tracking no longer matches the real state of the work.
 ---
 
 # Progress Sync Manager
 
-Keep tracking files truthful and current.
+Keep canonical tracking truthful and current.
 
 ## Goal
 
@@ -13,61 +13,67 @@ Make recorded project status reflect actual execution state without delay.
 
 ## Execution owner
 
-Run this skill as: `parent`
+Run this Skill in the caller that owns authorized canonical tracking writes.
 
-- This skill updates canonical tracking files and should remain under parent control.
+- In the Codex standard flow, that owner is normally the parent.
+- In a ChatGPT worker flow, the current chat may execute this Skill directly when the wrapper has write authorization.
+- This Skill does not require or start a sub-agent.
 
 ## Inputs
 
-Before running this skill, gather:
+Before running this Skill, gather:
 
-- latest task, review, verification, commit, or PR outcome
-- current `tasks-status.md` and `phases-status.md`
-- relevant `reports/` references to sync
+- latest task, review, verification, commit, or PR outcome,
+- structured context from `work-context-manager`, including `tracking.task_path` and `tracking.phase_path`,
+- current content of the resolved canonical tracking files,
+- relevant report references to sync.
+
+Do not hardcode `tasks-status.md` or `phases-status.md`. Use the resolved repository-relative paths exactly. If `tracking.task_path` is unknown, stop as blocked instead of guessing. If `tracking.phase_path` is null, do not create a phase file unless an authoritative project rule requires one. If it is unknown and phase tracking is required, stop as blocked.
 
 ## Update targets
 
-Update as relevant:
+Update as relevant at the resolved canonical paths:
 
-- `tasks-status.md`
-- `phases-status.md`
-- progress summary sections
-- overall progress sections
-- report references
-- PR references if tracked
+- task tracking,
+- phase tracking when configured,
+- progress summary sections,
+- overall progress sections,
+- report references,
+- PR references if tracked.
 
-If `tasks-status.md` or `phases-status.md` must be created during sync, include a top-of-file rule stating that the file may be updated only through `task-breakdown-planner`, `task-consistency-manager`, or `progress-sync-manager`.
+If a canonical tracking file must be created according to authoritative project rules, include a top-of-file rule stating that the file may be updated only through `task-breakdown-planner`, `task-consistency-manager`, or `progress-sync-manager`.
 
 ## Required timing
 
-Run this skill:
+Run this Skill:
 
-- after tasks are added or split
-- after significant implementation milestones
-- after review
-- after commit and PR creation
-- whenever tracking is discovered to be stale
+- after tasks are added or split,
+- after significant implementation milestones,
+- after review,
+- after commit and PR creation,
+- after blocked state changes,
+- whenever tracking is discovered to be stale.
 
-## Rules for tasks-status.md
-
-Ensure it reflects:
-
-- current active task
-- completed tasks
-- new tasks from review or discoveries
-- dependencies
-- exit criteria
-- PR/commit completion if part of done
-
-## Rules for phases-status.md
+## Rules for canonical task tracking
 
 Ensure it reflects:
 
-- current phase position
-- remaining phase count
-- changed exit criteria
-- completed milestones
-- honest remaining estimates
+- current active task,
+- completed tasks,
+- new tasks from review or discoveries,
+- dependencies,
+- exit criteria,
+- PR/commit completion if part of done.
+
+## Rules for canonical phase tracking
+
+When a separate phase tracking path is configured, ensure it reflects:
+
+- current phase position,
+- remaining phase count,
+- changed exit criteria,
+- completed milestones,
+- honest remaining estimates.
 
 ## Strong rule
 
@@ -75,16 +81,23 @@ Do not leave tracking updates as optional end-of-day cleanup. Update close to th
 
 ## Outputs
 
-After this skill runs, tracking should reflect:
+After this Skill runs, return:
 
-- the current task and phase state
-- latest report and PR references when applicable
-- the real completion status of recent work
+- canonical task tracking path,
+- canonical phase tracking path or null,
+- current task state,
+- current phase when applicable,
+- dependencies and exit criteria,
+- latest report and PR references when applicable,
+- latest validation state,
+- blockers,
+- next pending tracking action,
+- real completion status of recent work.
 
 ## Completion condition
 
-This skill is complete only when canonical tracking matches the actual execution state.
+This Skill is complete only when canonical tracking matches the actual execution state and no guessed tracking path was used.
 
 ## Cross-cutting rule
 
-If stale tracking is a recurring problem, call `feedback-points-manager`.
+If stale tracking is a recurring problem, call `feedback-points-manager` when that Skill is available in the current runtime.

--- a/skills/task-breakdown-planner/SKILL.md
+++ b/skills/task-breakdown-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-breakdown-planner
-description: Break an issue, request, or large work item into concrete tasks and phases with dependencies and exit criteria. Use when starting a new issue, when an existing task is too large, when planning remaining work to completion, or when rescoping after new requirements appear.
+description: Break an issue, request, or large work item into concrete tasks and phases with dependencies and exit criteria using the target project's canonical tracking paths. Use when starting a new issue, when an existing task is too large, when planning remaining work to completion, or when rescoping after new requirements appear.
 ---
 
 # Task Breakdown Planner
@@ -13,56 +13,46 @@ Create a task structure that allows one-task-at-a-time execution without hidden 
 
 ## Execution owner
 
-Run this skill as: `parent`
+Run this Skill in the caller that owns authorized canonical tracking writes.
 
-- Task and phase design set the execution contract and should stay under parent control.
-- For large or noisy scope, the parent may request a bounded planning draft from a `sub-agent`, but final task/phase adoption remains parent work.
+- In the Codex standard flow, that owner is normally the parent.
+- In a ChatGPT worker flow, the current chat may execute this Skill directly when the wrapper has write authorization.
+- This Skill does not require or start a sub-agent.
+- A caller with its own delegation capability may obtain a bounded planning draft separately, but final task and phase adoption remains with the authorized caller and delegation is never required by this Skill.
 
 ## Inputs
 
-Before running this skill, gather:
+Before running this Skill, gather:
 
-- issue or request scope
-- known constraints and dependencies
-- current `tasks-status.md` and `phases-status.md` when they already exist
+- issue or request scope,
+- known constraints and dependencies,
+- structured context from `work-context-manager`, including `tracking.task_path` and `tracking.phase_path`,
+- current content of the resolved canonical tracking files when they already exist.
+
+Do not hardcode `tasks-status.md` or `phases-status.md`. Use the resolved repository-relative paths exactly. If `tracking.task_path` is unknown, stop as blocked instead of guessing. If `tracking.phase_path` is null, do not invent a separate phase file. If it is unknown and phase tracking is required by the project, stop as blocked.
 
 ## Outputs
 
-Produce or revise:
+Produce or revise at the resolved canonical paths:
 
-- phase entries in `phases-status.md`
-- task entries in `tasks-status.md`
-- dependencies
-- exit criteria
-- size estimates
+- task entries,
+- phase entries when the project uses a separate phase tracking file,
+- dependencies,
+- exit criteria,
+- size estimates.
 
-If `tasks-status.md` or `phases-status.md` must be created from scratch, write a top-of-file rule stating that the file may be updated only through `task-breakdown-planner`, `task-consistency-manager`, or `progress-sync-manager`.
+Return the canonical task tracking path, canonical phase tracking path or null, created or revised task identities, phases when applicable, dependencies, exit criteria, estimates, and next executable task.
+
+If a canonical tracking file must be created according to authoritative project rules, write a top-of-file rule stating that the file may be updated only through `task-breakdown-planner`, `task-consistency-manager`, or `progress-sync-manager`.
 
 ## Completion condition
 
-This skill is complete only when:
+This Skill is complete only when:
 
-- task and phase breakdown is explicit
-- dependencies and exit criteria are recorded
-- another agent could execute the next task without guessing
-
-## Large-scope delegation
-
-If the issue or remaining work is large enough that a first-pass breakdown would be expensive to do inline, the parent may:
-
-1. use `sub-agent-task-manager`
-2. ask a `sub-agent` for a bounded draft of tasks, phases, dependencies, and exit criteria
-3. require a report under `reports/`
-4. review and finalize the adopted breakdown in the parent
-
-Do not let the `sub-agent` become the final owner of task structure.
-
-Use these provisional thresholds as the default trigger:
-
-- expected task candidates are 5 or more
-- expected phases are 3 or more
-- explicit dependency edges to reason about are 4 or more
-- the parent would otherwise need to read 4 or more source documents before drafting the breakdown
+- task and phase breakdown is explicit,
+- dependencies and exit criteria are recorded,
+- another agent or chat could execute the next task without guessing,
+- no guessed tracking path was used.
 
 ## Breakdown rules
 
@@ -70,13 +60,13 @@ Prefer tasks that can move all the way to commit and PR.
 
 Split by workflow boundaries such as:
 
-- investigation
-- design update
-- failing tests
-- implementation
-- review fixes
-- integration or E2E verification
-- documentation or tracking sync
+- investigation,
+- design update,
+- failing tests when the target project requires them,
+- implementation,
+- review fixes,
+- integration or E2E verification,
+- documentation or tracking sync.
 
 Do not create tasks that are so broad that they hide multiple implementation cycles.
 
@@ -84,12 +74,12 @@ Do not create tasks that are so broad that they hide multiple implementation cyc
 
 A task is acceptable only if another agent could execute it without guessing:
 
-- what to change
-- how to prove it works
-- when to stop
+- what to change,
+- how to prove it works,
+- when to stop.
 
 ## Phase rules
 
-Create or update phases when the work introduces a meaningful milestone or exit checkpoint.
+Create or update phases only when the target project uses phases and the work introduces a meaningful milestone or exit checkpoint.
 
 Keep remaining phases truthful. Do not leave stale estimates or completed work in remaining sections.

--- a/skills/task-consistency-manager/SKILL.md
+++ b/skills/task-consistency-manager/SKILL.md
@@ -1,102 +1,95 @@
 ---
 name: task-consistency-manager
-description: Validate that intended work is explicitly represented in tasks-status.md and phases-status.md before and during implementation. Use when starting a task, when implementation reveals missing scope, dependencies, or exit criteria, or when review uncovers new work that must be tracked before proceeding.
+description: Validate that intended work is explicitly represented in canonical task and phase tracking before and during implementation. Use when starting a task, when implementation reveals missing scope, dependencies, or exit criteria, or when review uncovers new work that must be tracked before proceeding.
 ---
 
 # Task Consistency Manager
 
-Ensure that no meaningful work proceeds unless it exists in task tracking.
+Ensure that no meaningful work proceeds unless it exists in canonical task tracking.
 
 ## Goal
 
-Keep `tasks-status.md` and `phases-status.md` aligned with actual implementation scope.
+Keep the configured canonical task and phase tracking aligned with actual implementation scope.
 
 ## Execution owner
 
-Run this skill as: `parent`
+Run this Skill in the caller that owns authorized canonical tracking writes.
 
-- This skill updates canonical task tracking and should remain parent-owned.
-- For large tracking diffs or many discoveries, the parent may request a consistency audit from a `sub-agent`, but final tracking updates remain parent work.
+- In the Codex standard flow, that owner is normally the parent.
+- In a ChatGPT worker flow, the current chat may execute this Skill directly when the wrapper has write authorization.
+- This Skill does not require or start a sub-agent.
+- A caller with its own delegation capability may obtain a bounded audit separately, but final canonical tracking writes remain with the authorized caller and delegation is never required by this Skill.
 
 ## Inputs
 
-Before running this skill, gather:
+Before running this Skill, gather:
 
-- current intended work item
-- `tasks-status.md`
-- `phases-status.md`
-- any newly discovered scope from implementation or review
+- current intended work item,
+- structured context from `work-context-manager`, including `tracking.task_path` and `tracking.phase_path`,
+- current content of the resolved canonical tracking files,
+- any newly discovered scope from implementation or review.
 
-## Run this skill
+Do not hardcode `tasks-status.md` or `phases-status.md`. Use the resolved repository-relative paths exactly. If `tracking.task_path` is unknown, stop as blocked instead of guessing. If `tracking.phase_path` is null, do not create a phase file unless an authoritative project rule requires one. If it is unknown and phase tracking is required, stop as blocked.
 
-Run this skill:
+## Run this Skill
 
-- before starting any task
-- when implementation reveals missing work
-- when a task is too large or vague
-- when review creates follow-up work
-- when phase scope or exit criteria have changed
+Run this Skill:
+
+- before starting any task,
+- when implementation reveals missing work,
+- when a task is too large or vague,
+- when review creates follow-up work,
+- when phase scope or exit criteria have changed.
 
 ## Required checks
 
 Check whether the current work item has:
 
-- a task entry
-- a phase assignment
-- dependencies
-- exit criteria
-- an estimate or expected size
-- wording precise enough to decide done vs not done
+- a task entry,
+- a phase assignment when the project uses phases,
+- dependencies,
+- exit criteria,
+- an estimate or expected size,
+- wording precise enough to decide done vs not done.
 
 ## Required actions
 
-If the task is missing, add or revise tracking before implementation continues.
+If the task is missing, add or revise canonical tracking before implementation continues.
 
-If the task is too large, split it into smaller tasks.
+If the task is too large, invoke `task-breakdown-planner` using the same resolved tracking paths.
 
 If the task implies additional work not yet tracked, add the missing tasks first.
 
-If the task changes phase scope, update `phases-status.md` as well.
+If the task changes phase scope and a canonical phase tracking file exists, update that resolved phase path as well.
 
-If `tasks-status.md` or `phases-status.md` does not exist yet and must be created, include a top-of-file rule stating that the file may be updated only through `task-breakdown-planner`, `task-consistency-manager`, or `progress-sync-manager`.
+If a canonical tracking file must be created according to authoritative project rules, include a top-of-file rule stating that the file may be updated only through `task-breakdown-planner`, `task-consistency-manager`, or `progress-sync-manager`.
 
 ## Strong rule
 
-Do not implement significant work that is not represented in `tasks-status.md`.
+Do not implement significant work that is not represented in the resolved canonical task tracking file.
 
 Allow exceptions only for tiny corrections such as obvious typos or purely mechanical renames with no behavior or contract impact.
 
 ## Outputs
 
-After this skill runs, tracking must make the next step unambiguous:
+After this Skill runs, return:
 
-- which task is active
-- what blocks it
-- what exits it
-- whether additional tasks were added
+- canonical task tracking path,
+- canonical phase tracking path or null,
+- active task identity,
+- current tracking state,
+- phase when applicable,
+- dependencies,
+- exit criteria,
+- blockers,
+- whether additional tasks were added or split,
+- next pending tracking action.
 
 ## Completion condition
 
-This skill is complete only when:
+This Skill is complete only when:
 
-- tracking reflects the real current scope
-- any missing or split tasks are recorded
-- the next implementation step is unambiguous from tracking
-
-## Large-scope delegation
-
-If tracking review would span many tasks, many review findings, or a noisy mismatch between execution and tracking, the parent may:
-
-1. use `sub-agent-task-manager`
-2. ask a `sub-agent` for a bounded audit of missing tasks, stale entries, and ambiguous wording
-3. require a report under `reports/`
-4. apply and confirm the final tracking changes in the parent
-
-Do not let the `sub-agent` silently rewrite canonical tracking without parent review.
-
-Use these provisional thresholds as the default trigger:
-
-- suspected stale or missing tracking points are 3 or more
-- affected task rows are 5 or more
-- review findings or implementation discoveries to reconcile are 3 or more
-- `tasks-status.md` and `phases-status.md` both need coordinated edits across 2 or more sections each
+- tracking reflects the real current scope,
+- any missing or split tasks are recorded,
+- the next implementation step is unambiguous from canonical tracking,
+- no guessed tracking path was used.

--- a/skills/work-context-manager/SKILL.md
+++ b/skills/work-context-manager/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: work-context-manager
-description: Resolve authoritative task context, repository state, scope, target identity, validation policy, and write boundaries without depending on a Codex parent or ChatGPT chat runtime.
+description: Resolve authoritative task context, repository state, scope, target identity, validation policy, canonical tracking paths, and write boundaries without depending on a Codex parent or ChatGPT chat runtime.
 ---
 
 # Work Context Manager
 
 ## Goal
 
-Produce a runtime-neutral work context that another Skill can use for implementation, review, or report generation.
+Produce a runtime-neutral work context that another Skill can use for implementation, review, report generation, or canonical task tracking.
 
 ## Runtime independence
 
@@ -40,6 +40,7 @@ Resolve as much as the available evidence permits:
 
 - repository and repository instructions,
 - Issue, task, phase, accepted scope, and non-goals,
+- canonical task tracking path and canonical phase tracking path when configured,
 - branch, base ref, PR, current HEAD, and relevant commit range,
 - requirements and design references,
 - changed files, target files, and direct dependencies,
@@ -50,6 +51,8 @@ Resolve as much as the available evidence permits:
 - report and handoff naming rules,
 - allowed and forbidden writes,
 - unknown, blocked, unexplored, and not-applicable items.
+
+Resolve tracking paths from explicit project or repository configuration when available. Do not replace a configured path such as `tasks/tasks-status.md` with a guessed basename such as `tasks-status.md`. If no canonical task tracking path is configured or discoverable, return it as unknown rather than inventing one. A phase tracking path may be null when the target project does not use a separate phase file.
 
 An Issue or PR identifier is normally sufficient when repository evidence determines the remaining state unambiguously.
 
@@ -84,6 +87,9 @@ Return a structured context containing:
 repository: owner/name | unknown
 issue_or_pr: string | null
 task_id: string | null
+tracking:
+  task_path: repository_relative_path | unknown
+  phase_path: repository_relative_path | null | unknown
 mode: implementation | review | report | unknown
 branch: string | unknown
 base_ref: string | null
@@ -127,4 +133,4 @@ This Skill does not merge and does not grant merge permission to its caller.
 
 ## Completion condition
 
-Complete when discoverable state has been resolved, conflicts and unknowns remain explicit, scope and target identity are usable by the next Skill, and no runtime-specific execution or persistence behavior has been assumed.
+Complete when discoverable state has been resolved, canonical tracking paths are explicit or marked unknown/not applicable, conflicts and unknowns remain explicit, scope and target identity are usable by the next Skill, and no runtime-specific execution or persistence behavior has been assumed.

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -2,7 +2,7 @@
 
 このファイルは `task-breakdown-planner`、`task-consistency-manager`、`progress-sync-manager` のみが更新する。
 
-- Updated: 2026-07-30
+- Updated: 2026-08-29
 
 ## Phase 1: 契約・設計
 
@@ -96,3 +96,21 @@
   - passing reportを保存する場合だけ予約済みpathを変更する1回のreport-attestation commitを作成する
   - report-attestation diffをallowlist検証する
   - attestation後にrepository commitまたはrepository-writing Skillを実行しない
+
+## Phase 8: Issue #59 ChatGPT task tracking Skill配布
+
+- Status: In Progress
+- Notes:
+  - `task-breakdown-planner`、`task-consistency-manager`、`progress-sync-manager`をChatGPT配布ZIPの必須rootへ追加した
+  - 3 Skillをparent-onlyからauthorized caller実行のruntime-neutral contractへ変更し、ChatGPT current chatからsub-agentなしで実行可能にした
+  - `work-context-manager`がcanonical task／phase tracking pathをauthorityから解決し、configured pathをbasenameへ置換または推測しないcontractを追加した
+  - `chat-handoff-manager` schema version 3へtask tracking path、state、phase、dependencies、exit criteria、blockers、pending actionのtyped projectionを追加した
+  - task tracking Skillのcomplete outputをhandoff `source_payloads`へ保持するcontractを追加した
+  - 初回reviewは`F-60-01`、`F-60-02` blocking、`F-60-03`、`F-60-04` highの4件でfailとなった
+  - `F-60-04`対応として無関係に削除していた既存設計を復元し、正本設計のIssue #59影響箇所だけを11 Skill構成へ同期した
+  - `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同一blobへ同期した
+  - canonical task trackingへT-003として本Issueを登録した
+  - CodexSkill repository policyによりTDDは`not applicable`
+  - current implementation HEADに一致するrepository validator、11 Skill ZIP build、artifactを確認する
+  - 同じnormal review continuityで`F-60-01`から`F-60-04`のfix verificationを行う
+  - mergeは利用者が行う

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -2,7 +2,7 @@
 
 このファイルは `task-breakdown-planner`、`task-consistency-manager`、`progress-sync-manager` のみが更新する。
 
-- Updated: 2026-07-30
+- Updated: 2026-08-29
 
 ## In Progress
 
@@ -29,7 +29,7 @@
     - `source_payloads`が4 core Skillのcomplete outputをfield名と構造を変えず保持する
     - `report-writer` payloadが`complete_body`全文と`severity_records`を保持する
     - Project Instruction例の対象固有リポジトリ名は最初の対象URLだけで指定し、後続instructionでは一般名で参照する
-    - 4 ChatGPT wrapperと4 core Skillが独立root directoryとして単一ZIPへ含まれる
+    - 4 ChatGPT wrapper、4 core Skill、3 task tracking Skillが独立root directoryとして単一ZIPへ含まれる
     - repository-wide validatorがfront matter、Skill dependency、active Markdown link、symlink、削除済みshared runtime path、hierarchy design同期を検証する
     - PRとmain pushのworkflow triggerが`shared/**`だけの変更でもrepository validatorを実行する
     - PR buildがread-onlyかつ実PR HEAD SHAをcheckoutし、main反映後のrelease jobだけがwrite権限を持つ
@@ -118,6 +118,49 @@
     - artifact `chatgpt-worker-skills-6fb76ce5f4cf3e358c5d70c5139a024d9495186f`、ID `8741787240`、digest `sha256:03286426413470e9a9ad64ed13e003cfb562a8e87b978f3ab4d8a7e4c2e09eb9`
     - 本pre-freeze follow-upとtracking更新後HEADのmatching workflow／artifactを確認する
     - fresh independent final reviewは未実施
+
+- T-003: Issue #59でChatGPT配布ZIPへtask tracking Skillを同封し、canonical tracking contractを整合する
+  - Status: review follow-up実装済み、normal fix verification待ち
+  - Phase: Phase 8
+  - Estimate: M
+  - Depends on: T-002
+  - Exit Criteria:
+    - `task-breakdown-planner`、`task-consistency-manager`、`progress-sync-manager`がChatGPT登録用ZIPへ含まれる
+    - 4 wrapper、4 core Skill、3 task tracking Skillの11 root構成をbuilderと正本設計が一致して定義する
+    - 3 task tracking Skillがauthorized callerで実行でき、ChatGPT current chatからsub-agentなしで利用できる
+    - `work-context-manager`がcanonical `tracking.task_path`とoptional `tracking.phase_path`をauthorityから解決する
+    - task tracking Skillがconfigured pathをbasenameへ置換または推測しない
+    - `chat-handoff-manager`がtask tracking path、state、phase、dependencies、exit criteria、blockers、pending actionをtyped projectionとして保持する
+    - 実行されたtask tracking Skillのcomplete outputをhandoff `source_payloads`へ保持する
+    - `design/chat-worker-skill-design.md`と2つのskill hierarchy designがIssue #59影響箇所だけを更新し、Release、review continuity、pre-freeze、attestationなど無関係な既存契約を維持する
+    - `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`がbyte-identicalである
+    - current implementation HEAD固有のrepository validator、11 Skill ZIP build、artifact生成が成功する
+    - `F-60-01`から`F-60-04`がnormal fix verificationでresolvedになる
+    - mergeを行わない
+  - Output:
+    - `scripts/build_chatgpt_worker_skills.py`
+    - `skills/work-context-manager/SKILL.md`
+    - `skills/task-breakdown-planner/SKILL.md`
+    - `skills/task-consistency-manager/SKILL.md`
+    - `skills/progress-sync-manager/SKILL.md`
+    - `skills/chat-implementation-worker/SKILL.md`
+    - `skills/chat-handoff-manager/SKILL.md`
+    - `design/chat-worker-skill-design.md`
+    - `design/skill-hierarchy-design.md`
+    - `skills/design/skill-hierarchy-design.md`
+    - `design/issue-59-chatgpt-task-tracking-extension.md`
+    - `reports/issue-59-chatgpt-task-skills-20260806.md`
+    - `reports/issue-59-normal-review-20260807053500.md`
+    - `reports/issue-59-review-followup-20260807054100.md`
+  - Review Findings:
+    - `F-60-01` blocking: task tracking Skillのparent-only／sub-agent contract不整合へ対応済み、fix verification待ち
+    - `F-60-02` blocking: canonical tracking path contract不足へ対応済み、fix verification待ち
+    - `F-60-03` high: handoff typed task tracking state不足へ対応済み、fix verification待ち
+    - `F-60-04` high: 設計書の無関係な大量削除を復元し、正本のIssue #59影響箇所だけを同期済み、fix verification待ち
+  - Verification:
+    - TDDはCodexSkill repository policyにより`not applicable`
+    - current HEAD一致のGitHub Actions runを確認する。別SHAのrunは代用しない
+    - normal fix verificationは未実施
 
 ## Backlog
 


### PR DESCRIPTION
## 概要

Issue #59 に対応し、ChatGPT worker配布ZIPへtask tracking Skillを同封します。

## 変更

- `task-breakdown-planner`
- `task-consistency-manager`
- `progress-sync-manager`

を配布対象へ追加します。

`chat-implementation-worker`は`work-context-manager`が解決したcanonical tracking pathをそのまま使用し、実装開始前のtask整合確認、必要時のtask分割、進捗・完了時のtask/phase同期を各Skill経由で実行します。

レビュー指摘 F-60-01〜F-60-04 に対応し、task tracking Skillのruntime-neutral caller contract、canonical path contract、handoff task tracking projectionを整備します。既存設計のIssue #59と無関係な契約は維持し、正本設計の影響箇所だけを11 Skill構成へ同期します。

## 検証方針

CodexSkillリポジトリ方針に従いTDDは適用しません。repository validator、ZIP build、配布物root構造をcurrent HEADに一致するGitHub Actions runで確認します。

Closes #59