### PR TITLE
feat: task特性に応じてsub-agent profileを自動選定する

### DIFF
--- a/design/adaptive-agent-assignment-design.md
+++ b/design/adaptive-agent-assignment-design.md
@@ -1,0 +1,351 @@
+# 適応型agent割当設計
+
+## 目的
+
+delegated taskの性質に応じて、sub-agentへ適切なモデル、推論強度、fork方式を割り当てる。
+
+単純なfile数や一律のreviewer設定ではなく、工程、判断負荷、不確実性、変更半径、重要度、反復性、分割可能性を評価する。選定結果と実際にruntimeへ適用されたprofileを分離し、割当理由とfallbackをreportへ残す。
+
+本設計はIssue #13の「sub-agentの使用モデルがSkillへ定義されていない」という問題を解消する。
+
+## 背景
+
+既存flowには次の要素があった。
+
+- `codex-delegation-executor`によるmain agentとsub-agentのexecutor選択
+- `sub-agent-task-manager`によるbounded taskとreport契約
+- `spawn-agent-model-overrides.md`によるhidden model overrideの適用方法
+- `development-orchestrator`によるimplementation modelの事前ユーザー確認
+
+一方、taskの性質からmodelとreasoning effortを選ぶ中央規則がなかった。そのため、callerごとにprofileが固定または手動選択され、次を区別できなかった。
+
+- 既に手順が決まった反復作業
+- 通常のbounded implementation
+- 要件、設計、難しいdebug、reviewのような判断中心作業
+- 一つの難問へ深く取り組む場合
+- 複数の独立workstreamへ分割する場合
+
+## 設計原則
+
+### モデルと推論強度を別軸にする
+
+モデルtierはtaskが要求する判断能力を表す。
+
+- Luna: 決定済みの機械的・反復的・高volume作業
+- Terra: 通常のbounded technical work
+- Sol: 不確実、判断中心、高重要度、cross-system、design、難しいdebug、review
+
+推論強度は同じ問題へどれだけ慎重に取り組むかを表す。
+
+- `low`: exactな低risk変換
+- `medium`: 通常実装またはdeterministic evidence
+- `high`: 複数条件、debug、design、review
+- `xhigh`: boundedかつ網羅性または重要度が高いaudit
+- `max`: 一つの非常に難しく分割不能な問題
+
+モデルtierを上げる条件とreasoning effortを上げる条件を混同しない。
+
+### Ultraをreasoning effortにしない
+
+参考記事のUltra相当は、単一agentの推論強度ではなく、独立workstreamへ分割し親が統合するmulti-agent戦略として扱う。
+
+- `codex-delegation-executor`が分割可否を判断する
+- 各bounded taskへ`sub-agent-task-manager`が個別profileを選ぶ
+- `reasoning_effort: ultra`は生成しない
+
+### 行数より変更半径を重視する
+
+小さなdiffでもsecurity、authorization、migration、concurrency、compatibility、public API、releaseへ影響する場合は高重要度とする。
+
+大きなdiffでも、手順と期待結果が完全に決まりdeterministic validatorがある反復処理ならLuna候補になりうる。
+
+### requestedとappliedを分離する
+
+runtime制約により、選択したprofileがそのまま適用されない場合がある。
+
+- full-history forkはparent profileを継承する
+- hidden overrideがbackendでrejectされる可能性がある
+- runtimeでmodelが利用不能な場合がある
+
+reportでは`requested`と`applied`、`application_status`を別に記録し、未適用profileを適用済みとしない。
+
+## 責務配置
+
+### `development-orchestrator`
+
+- workflow開始時にroutineなimplementation model確認を要求しない
+- userまたはrepositoryが明示したoverrideやbudget制約だけを取得する
+- executor、assessment、requested/applied profileをlifecycle evidenceとして保持する
+
+### `codex-delegation-executor`
+
+- main agent、single sub-agent、multi-agent decompositionを選ぶ
+- taskを次の軸で評価する
+  - `task_kind`
+  - `work_class`
+  - `uncertainty`
+  - `change_radius`
+  - `criticality`
+  - `repetition`
+  - `decomposability`
+  - `context_need`
+- multi-agent分割のwrite ownership、blocking dependency、synthesisを確認する
+- modelとreasoning effortの中央tableは持たない
+
+### `sub-agent-task-manager`
+
+- 各bounded taskのmodel tier、reasoning effort、fork policyを選ぶ
+- explicit overrideの優先順位を適用する
+- requested profileをruntimeへ適用する
+- applied profileとfallbackをreportへ記録する
+- taskが独立分割可能になった場合はdispatch前に`codex-delegation-executor`へ戻す
+
+### `execution-cost-stabilizer`
+
+- `max`またはmulti-agentを使う前に、再実行、過剰parallelism、evidence再利用を確認する
+- costだけを理由に必要なmodel floorを下げない
+
+## 処理flow
+
+```text
+development-orchestrator
+  |
+  | explicit override / repository policy / task context
+  v
+codex-delegation-executor
+  |-- executor decision
+  |-- delegation assessment
+  |-- single vs multi-agent decision
+  |
+  +--> main agent
+  |
+  +--> bounded sub-agent task(s)
+          |
+          v
+      sub-agent-task-manager
+          |-- model tier selection
+          |-- reasoning effort selection
+          |-- fork policy selection
+          |-- requested -> applied resolution
+          |-- report pre-creation
+          v
+      collaboration.spawn_agent
+```
+
+## 選定入力
+
+```yaml
+task_kind: implementation | design | investigation | review | verification | environment_verification | intake_verification | standards | other
+work_class: mechanical | bounded_technical | judgment_heavy
+uncertainty: low | medium | high
+change_radius: local | cross_module | cross_system
+criticality: ordinary | high
+repetition: single | high_volume
+decomposability: single | sequential_dependencies | independent_workstreams
+context_need: fresh | bounded_history | full_history
+constraints:
+  user_override: null
+  repository_policy: null
+  runtime_availability: known | unknown
+```
+
+非自明な分類にはsource evidenceを付ける。不明な場合は低く見積もらず、uncertaintyを上げる。
+
+## profile選定
+
+### model floor
+
+| 条件 | 最低tier |
+| --- | --- |
+| low uncertainty、local、ordinary、deterministic、mechanical | Luna |
+| 通常のbounded implementationまたはfocused verification | Terra |
+| requirement/design、open-ended investigation、cross-system、高重要度、review | Sol |
+
+複数条件が該当する場合は最も高いfloorを採用する。
+
+### task default
+
+| task | default |
+| --- | --- |
+| exact repetitive transformation | Luna `low` |
+| deterministic build/test execution | Luna `medium` |
+| ordinary bounded implementation | Terra `medium` |
+| cross-module implementation | Terra `high` |
+| localized debug with concrete hypothesis | Terra `high` |
+| design / requirement interpretation | Sol `high` |
+| open-ended or cross-layer investigation | Sol `high` |
+| initial normal review | Sol `high` |
+| focused fix verification | Terra `high` |
+| independent final review / release audit | Sol `xhigh` |
+
+失敗したdeterministic verificationは同じLuna taskとして再実行せず、investigationへ再分類する。
+
+### `max` gate
+
+`max`は次を全て満たす場合だけ使用する。
+
+- 一つの問題が主要blockerである
+- workstreamへ安全に分割できない
+- `high`または`xhigh`で不足する具体的理由がある
+- `execution-cost-stabilizer`でscopeとevidence再利用を確認した
+
+### multi-agent gate
+
+複数agentへ分割するには次を全て満たす。
+
+- 独立workstreamが2件以上ある
+- scope、non-goals、evidence、report ownerを各taskへ定義できる
+- write ownershipが重複しない、またはread-onlyである
+- blocking investigation dependencyがない
+- parent synthesisが定義されている
+- parallelismの実益がある
+
+各taskは別々にprofile選定する。
+
+## override優先順位
+
+1. 明示的なuser instruction
+2. authoritative repository policy
+3. runtime capabilityとmodel availability
+4. automatic selection
+
+explicit overrideがautomatic floorを下回る場合も、silentに置換しない。mismatchを記録し、governing authorityに従う。
+
+model tierだけが指定された場合はreasoning effortを自動選定できる。reasoning effortだけが指定された場合はmodel tierを自動選定できる。
+
+## dispatch profile schema
+
+```yaml
+dispatch_profile:
+  schema_version: 1
+  selection_source: automatic | user_override | repository_policy
+  task_kind: review
+  signals:
+    work_class: judgment_heavy
+    uncertainty: high
+    change_radius: cross_module
+    criticality: high
+    repetition: single
+    decomposability: single
+    context_need: fresh
+  requested:
+    model_tier: sol
+    model: gpt-5.6-sol
+    reasoning_effort: xhigh
+    fork_turns: none
+    parallelism_mode: single_agent
+  applied:
+    model: gpt-5.6-sol
+    reasoning_effort: xhigh
+    fork_turns: none
+  application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+  reasons: []
+  constraints: []
+  escalation_triggers: []
+```
+
+## fork制約
+
+- fresh specialistとoverrideを組み合わせる場合は`fork_turns: "none"`
+- bounded historyだけ必要なら明示的なpositive partial fork
+- full-history forkはparent profileを継承し、`inherited_parent_profile`として記録
+- model specializationを優先する場合は、必要contextをtask-local promptへ明示してfresh spawnする
+
+## 再分類とescalation
+
+新しいevidenceがtask kind、不確実性、変更半径、重要度を変えた場合、profileを再計算する。
+
+- 問題自体は同じだが慎重さが不足する場合: reasoning effortを上げる
+- 問題の性質または必要判断能力が変わる場合: model tierを上げる
+- 独立workstreamが判明した場合: multi-agent分割判断へ戻る
+- runtime rejectionの場合: spawn適用contractに従いrequested/appliedを分離する
+
+理由のないretry escalationは禁止する。
+
+## 代表例
+
+### formatting対象が多数ある
+
+- mechanical
+- low uncertainty
+- local
+- ordinary
+- high volume
+
+選定: Luna `low`。validator解釈が必要ならLuna `medium`。
+
+### accepted designに基づく通常実装
+
+- bounded technical
+- lowからmedium uncertainty
+- localまたはcross-module
+- ordinary
+
+選定: Terra `medium`。module間regression reasoningが必要ならTerra `high`。
+
+### intermittent concurrency failureの原因調査
+
+- judgment heavy
+- high uncertainty
+- cross-moduleまたはcross-system
+- high criticality
+
+選定: Sol `high`。一つの非分割root causeへ深い証明が必要な場合だけSol `max`。
+
+### independent final review
+
+- judgment heavy
+- high uncertainty
+- scopeに応じたchange radius
+- release criticality
+
+選定: Sol `xhigh`。過去review conclusionを引き継がないfresh spawnを使う。
+
+### frontend、backend、migrationが独立している
+
+単一のSol `max`へまとめない。write ownershipとdependencyを確認し、3 bounded taskへ分割する。各taskは個別にTerraまたはSolを選定し、parentが統合する。
+
+## 既存設計との関係
+
+Skill hierarchyのtopologyは変更しない。
+
+- `codex-delegation-executor`から`sub-agent-task-manager`へ委譲する既存関係を維持する
+- model overrideの実applicationは既存referenceを拡張する
+- 新規runtime wrapperまたはcore Skillは追加しない
+
+このため`design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`の同期対象内容は変更しない。
+
+## 検証方針
+
+CodexSkill repositoryの方針に従いTDDは適用しない。
+
+- `python3 scripts/verify_skill_repository.py`
+- `python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip`
+- active relative Markdown link検証
+- current PR HEAD SHAと一致するGitHub Actions runの確認
+- selected/applied profile、Ultraとreasoning effort、full-history forkのcontract review
+
+## 非対象
+
+- Codex runtime本体へのmodel router実装
+- runtime model availability APIの新設
+- model価格に基づく自動optimization
+- userのexplicit overrideをsilentに変更すること
+- full-history forkへ異なるmodelを強制すること
+- `reasoning_effort: ultra`の追加
+- automatic merge
+
+## 関連file
+
+- [Codex Delegation Executor](../skills/codex-delegation-executor/SKILL.md)
+- [Sub-Agent Task Manager](../skills/sub-agent-task-manager/SKILL.md)
+- [Agent profile selection](../skills/sub-agent-task-manager/references/agent-profile-selection.md)
+- [Spawn-agent model overrides](../skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md)
+- [Development Orchestrator](../skills/development-orchestrator/SKILL.md)
+- [Execution Cost Stabilizer](../skills/execution-cost-stabilizer/SKILL.md)
+
+## 参考資料
+
+- [役割分担で回すGPT-5.6 Luna / Terra / Sol](https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb)
+- [OpenAI model catalog](https://developers.openai.com/api/docs/models)
+- [OpenAI latest-model guidance](https://developers.openai.com/api/docs/guides/latest-model)

--- a/design/adaptive-agent-assignment-design.md
+++ b/design/adaptive-agent-assignment-design.md
@@ -16,10 +16,13 @@ delegated taskの性質に応じて、sub-agentへ適切なモデル、推論強
 - `sub-agent-task-manager`によるbounded taskとreport契約
 - `spawn-agent-model-overrides.md`によるhidden model overrideの適用方法
 - `development-orchestrator`によるworkflow lifecycle管理
+- `review-enforcer`によるnormal reviewer continuityとindependent final reviewer lifecycle
 
 一方、taskの性質からmodelとreasoning effortを選ぶ中央規則がなかった。そのため、callerごとにprofileが固定または手動選択され、機械的作業、通常実装、判断中心作業、難しい単一問題、独立workstream分割を区別できなかった。
 
 また、`Sol xhigh`と`Sol max`は実行コストが高いため、品質要件だけで自動選定すると意図せず高コストなdispatchが発生する。そこで、この2 profileは自動選定の最終結果ではなく、ユーザー承認が必要なproposalとして扱う。
+
+reviewでは別の制約もある。initial reviewとfix verificationで同じreviewerを再利用する場合、fix verificationのtask defaultへmodelを切り替える新規spawnは存在しない。このため、新規reviewerのprofile選定と既存reviewerのcontinuity reuseを明確に分離する。
 
 ## 設計原則
 
@@ -86,6 +89,17 @@ profile stateは次の3段階を区別する。
 
 full-history fork、hidden override rejection、runtime model unavailableなどにより`requested`と`applied`が異なる場合がある。未承認proposalを`requested`または`applied`として記録してはならない。
 
+### reviewer continuityは新規profile選定ではない
+
+既存normal reviewerまたはindependent reviewerをfix verification／finding closureで再利用するときは、新しいagentを作らない。
+
+- original reviewerのapplied model、reasoning effort、fork contextを維持する
+- task default tableを再適用しない
+- `application_status: reused_existing_agent_profile`を記録する
+- reviewer identity、original applied profile evidence、continued review modeをcontinuity evidenceとして残す
+- 同一review lifecycleで既に承認済みの`Sol xhigh` / `Sol max` reviewerを再利用する場合は新しい高コストprofile選定ではないため再承認を要求しない
+- replacement reviewerまたは新しいtask lifecycleは新規dispatchとしてprofile selectionとapproval gateを通す
+
 ## 責務配置
 
 ### `development-orchestrator`
@@ -112,12 +126,21 @@ full-history fork、hidden override rejection、runtime model unavailableなど�
 
 ### `sub-agent-task-manager`
 
-- 各bounded taskのmodel tier、reasoning effort、fork policyを選ぶ
+- 新規bounded taskのmodel tier、reasoning effort、fork policyを選ぶ
 - `Sol xhigh` / `Sol max`ではproposalを生成し、approvalがない限りdispatchしない
 - explicit overrideの優先順位を適用する
 - approved requested profileをruntimeへ適用する
 - applied profileとfallbackをreportへ記録する
 - taskが独立分割可能になった場合はdispatch前に`codex-delegation-executor`へ戻す
+- fixed report templateの`Dispatch profile` sectionへselection／approval／requested／applied／application statusを記録させる
+
+### `review-enforcer`
+
+- reviewer identity、normal reviewer continuity、independent reviewer independenceを所有する
+- 新しく作るnormal reviewer、replacement reviewer、independent reviewerは必ず`sub-agent-task-manager`経由でdispatchする
+- `Sol xhigh` / `Sol max` proposalが返った場合はreviewer spawn前にparentへstopを返す
+- fix verification／finding closureで既存reviewerを再利用するときはoriginal applied profileを維持する
+- reuse時は`reused_existing_agent_profile`として証跡化し、新しいprofileを適用したと主張しない
 
 ### `execution-cost-stabilizer`
 
@@ -158,6 +181,21 @@ codex-delegation-executor
       collaboration.spawn_agent
 ```
 
+reviewer作成も同じselectorを通す。
+
+```text
+review-enforcer
+  |-- new normal / replacement / independent reviewer
+  |       v
+  |   sub-agent-task-manager
+  |       |-- expensive proposal -> USER APPROVAL STOP before spawn
+  |       `-- approved/ordinary -> spawn reviewer
+  |
+  `-- existing reviewer continuity
+          `-- no spawn / no reselection
+              application_status = reused_existing_agent_profile
+```
+
 ## 選定入力
 
 ```yaml
@@ -176,6 +214,9 @@ constraints:
 approval:
   required: false
   status: not_required | pending | approved | rejected
+continuity:
+  existing_agent: null
+  original_applied_profile: null
 ```
 
 非自明な分類にはsource evidenceを付ける。不明な場合は低く見積もらず、uncertaintyを上げる。
@@ -194,6 +235,8 @@ approval:
 
 ### task default
 
+新規agentを作るときだけ次のdefaultを使う。既存reviewer reuseではoriginal applied profileを維持する。
+
 | task | default |
 | --- | --- |
 | exact repetitive transformation | Luna `low` |
@@ -204,7 +247,7 @@ approval:
 | design / requirement interpretation | Sol `high` |
 | open-ended or cross-layer investigation | Sol `high` |
 | initial normal review | Sol `high` |
-| focused fix verification | Terra `high` |
+| focused fix verification, new reviewer only | Terra `high` |
 | independent final review / release audit | propose Sol `xhigh`, then stop for approval |
 
 失敗したdeterministic verificationは同じLuna taskとして再実行せず、investigationへ再分類する。
@@ -250,9 +293,10 @@ Sol `max`は次を全て満たす場合だけproposal可能とする。
 
 1. 明示的なcurrent-task user instruction
 2. 未承認Sol `xhigh` / `Sol max`に対するmandatory user-approval gate
-3. authoritative repository policy
-4. runtime capabilityとmodel availability
-5. automatic selection
+3. existing reviewer continuity reuse
+4. authoritative repository policy
+5. runtime capabilityとmodel availability
+6. automatic selection
 
 explicit overrideがautomatic floorを下回る場合も、silentに置換しない。mismatchを記録し、governing authorityに従う。
 
@@ -307,7 +351,45 @@ dispatch_profile:
     - higher reasoning effort increases execution cost
 ```
 
+reviewer continuity:
+
+```yaml
+dispatch_profile:
+  schema_version: 2
+  selection_source: continuity_reuse
+  task_kind: review
+  requested: null
+  applied:
+    model: <original applied model>
+    reasoning_effort: <original applied effort>
+    fork_turns: <original fork policy>
+  application_status: reused_existing_agent_profile
+  continuity:
+    reviewer_identity: <existing reviewer>
+    continued_mode: fix_verification | finding_ci_delta_closure
+    original_profile_evidence: <report or spawn evidence>
+```
+
 承認後はapproval evidenceを保存し、approved proposalを`requested`へ昇格してからruntime applicationへ進む。
+
+## report schema
+
+全てのdispatched sub-agent reportは固定の`## Dispatch profile` sectionを持つ。
+
+最低限、次のplaceholderをtemplateで事前作成する。
+
+- selection inputs
+- selection source
+- proposed profile
+- approval status / evidence
+- requested profile
+- applied profile
+- application status
+- reviewer continuity
+- fork policy
+- reasons / constraints
+
+childはreport構造を変更せず、これらのblank fieldだけを埋める。これによりfixed-format制約とdispatch-profile evidence必須制約を両立する。
 
 ## fork制約
 
@@ -316,16 +398,18 @@ dispatch_profile:
 - full-history forkはparent profileを継承し、`inherited_parent_profile`として記録
 - model specializationを優先する場合は、必要contextをtask-local promptへ明示してfresh spawnする
 - approvalはfork制約を上書きしない
+- reviewer continuity reuseは新規forkではない
 
 ## 再分類とescalation
 
-新しいevidenceがtask kind、不確実性、変更半径、重要度を変えた場合、profileを再計算する。
+新しいevidenceがtask kind、不確実性、変更半径、重要度を変え、新しいagentを作る場合はprofileを再計算する。
 
 - 問題自体は同じだが慎重さが不足する場合: reasoning effortを上げる
 - 問題の性質または必要判断能力が変わる場合: model tierを上げる
 - 独立workstreamが判明した場合: multi-agent分割判断へ戻る
 - escalation結果がSol `xhigh`またはSol `max`ならproposalへ変換し、user approval stopへ入る
 - runtime rejectionの場合: spawn適用contractに従いrequested/appliedを分離する
+- existing reviewerがinitial reviewからfix verificationへ移るだけではprofileを再計算しない
 
 理由のないretry escalationは禁止する。
 
@@ -343,9 +427,13 @@ dispatch_profile:
 
 通常はSol `high`。一つの非分割root causeへ深い証明が必要でSol `high`では不足すると判断した場合はSol `max`を提案し、ユーザー承認まで停止する。
 
+### normal reviewとfix verification
+
+initial normal reviewerは新規dispatchとして通常Sol `high`を選ぶ。finding修正後に同じreviewerを再利用する場合、focused fix verificationのTerra `high` defaultへ切り替えず、元のSol `high`を維持して`reused_existing_agent_profile`を記録する。
+
 ### independent final review
 
-release-criticalな独立final reviewではSol `xhigh`を候補として提案する。Sol `high`との差とcost noticeを提示し、ユーザー承認前にはreviewerをdispatchしない。
+release-criticalな独立final reviewではSol `xhigh`を候補として提案する。Sol `high`との差とcost noticeを提示し、ユーザー承認前にはreviewerをdispatchしない。承認後に作ったindependent reviewerをfinding closureで再利用する場合は、そのoriginal applied profileを継続する。
 
 ### frontend、backend、migrationが独立している
 
@@ -356,6 +444,7 @@ release-criticalな独立final reviewではSol `xhigh`を候補として提案�
 Skill hierarchyのtopologyは変更しない。
 
 - `codex-delegation-executor`から`sub-agent-task-manager`へ委譲する既存関係を維持する
+- `review-enforcer`配下のnew reviewer dispatchは既存hierarchyどおり`sub-agent-task-manager`を通す
 - model overrideの実applicationは既存referenceを拡張する
 - 新規runtime wrapperまたはcore Skillは追加しない
 
@@ -370,6 +459,9 @@ CodexSkill repositoryの方針に従いTDDは適用しない。
 - active relative Markdown link検証
 - current PR HEAD SHAと一致するGitHub Actions runの確認
 - proposed/requested/applied profile、approval gate、Ultraとreasoning effort、full-history forkのcontract review
+- review-enforcerからnew reviewerが`sub-agent-task-manager`を通ることのcontract review
+- reviewer continuityがoriginal applied profileを保持することのcontract review
+- fixed `Dispatch profile` report templateとSkill section orderingの整合確認
 
 ## 非対象
 
@@ -388,6 +480,8 @@ CodexSkill repositoryの方針に従いTDDは適用しない。
 - [Agent profile selection](../skills/sub-agent-task-manager/references/agent-profile-selection.md)
 - [Spawn-agent model overrides](../skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md)
 - [Development Orchestrator](../skills/development-orchestrator/SKILL.md)
+- [Review Enforcer](../skills/review-enforcer/SKILL.md)
+- [Sub-agent report template](../skills/report-output-manager/references/sub-agent-report-template.md)
 - [Execution Cost Stabilizer](../skills/execution-cost-stabilizer/SKILL.md)
 
 ## 参考資料

--- a/design/adaptive-agent-assignment-design.md
+++ b/design/adaptive-agent-assignment-design.md
@@ -4,7 +4,7 @@
 
 delegated taskの性質に応じて、sub-agentへ適切なmodel tier、reasoning effort、fork方式を割り当てる。
 
-単純なfile数ではなく、task kind、判断負荷、不確実性、変更半径、重要度、反復性、分割可能性、context needを評価する。選定した`requested` profileとruntimeで実際に成立した`applied` profileを分離し、割当理由、承認状態、fallback、reviewer continuityを証跡として残す。
+単純なfile数ではなく、task kind、判断負荷、不確実性、変更半径、重要度、反復性、分割可能性、context needを評価する。profileは`proposed`、`requested`、role/default-roleを考慮した`planned_runtime_profile`、runtimeで観測できた場合だけ確定する`applied`を分離し、割当理由、承認状態、runtime observability、fallback、reviewer continuityを証跡として残す。
 
 本設計はIssue #13の「sub-agentの使用modelがSkillへ定義されていない」という問題を解消する。
 
@@ -24,7 +24,7 @@ reasoning effortは同じ問題へどれだけ慎重に取り組むかを表す�
 - `medium`: 通常実装またはdeterministic evidence
 - `high`: 複数条件、debug、design、review
 - `xhigh`: boundedかつ網羅性または重要度が高いaudit
-- `max`: 一つの非常に難しく分割不能な問題
+- `max`: 一つの非常に難しく、本質的に分割不能な問題
 
 ### `Sol xhigh` / `Sol max`はapproval-gated
 
@@ -43,6 +43,7 @@ automatic classification
 - repository policy、過去taskの承認、沈黙、推測した嗜好はapprovalにしない
 - current taskでユーザーが明示的にそのprofileを指定した場合はapproval evidenceとして扱える
 - implementation、investigation、review、release auditを含む全taskへ適用する
+- role/default roleがrequestedより高いprofileへ上書きする場合も同じgateを再評価する
 
 ### Ultraはreasoning effortではない
 
@@ -52,41 +53,98 @@ automatic classification
 - 各bounded taskへ`sub-agent-task-manager`が個別profileを選ぶ
 - `reasoning_effort: ultra`は生成しない
 
-ただし、callerがidentity-sensitive lifecycleとして`decomposition_policy: forbidden`を指定したtaskは分割しない。
+ただしcallerがidentity-sensitive lifecycleとして`decomposition_policy: forbidden`を指定したtaskは実行分割しない。
 
-### `proposed` / `requested` / `applied`を時系列で分離する
+### decomposabilityとdecomposition policyを分離する
 
-profile stateは次の3段階を持つ。
+`decomposability`はtaskの構造に関する観測事実、`decomposition_policy`は実行制約である。
+
+```yaml
+decomposability: independent_workstreams
+decomposition_policy: forbidden
+decomposition_disposition: prohibited_by_review_lifecycle
+parallelism_mode: single_agent
+```
+
+上記は矛盾しない。large reviewに独立review areaが複数存在しても、reviewer identity / continuity / one exhaustive passを守るためsingle reviewer executionを要求できる。
+
+禁止事項:
+
+- policyが`forbidden`だから観測signalを`decomposability: single`へ書き換える
+- caller policyで分割禁止になったことを、`max`の「本質的にnon-decomposable」条件の根拠にする
+
+### `proposed` / `requested` / `planned_runtime_profile` / `applied`を分離する
+
+profile stateは次の段階を持つ。
 
 - `proposed_profile`: user approvalなどが未確定の候補
 - `requested`: spawn前に親がruntimeへ要求するprofile
-- `applied`: spawn後にruntime evidenceから確定したprofile
-
-`applied`はspawn前には確定できない。
+- `role_plan`: explicit/default agent roleと、そのroleがmodel/reasoningへ与える影響
+- `planned_runtime_profile`: role/default-role constraintsを加味したspawn前の予測
+- `applied`: parentから最終runtime profileを観測できた場合だけ記録する事実
 
 ```text
 classification
   -> proposed? -> approval
   -> requested
+  -> agent role/default-role planning
+  -> planned_runtime_profile
+  -> floor / expensive-profile approval recheck
   -> spawn / inheritance / fallback attempt
-  -> runtime evidence
-  -> applied + application_status
+  -> parent-visible runtime evidence
+      |-- exact final snapshot -> applied
+      `-- hidden/unobservable   -> applied=null + unverified state
 ```
 
 禁止事項:
 
-- `requested`を無条件に`applied`へcopyする
-- spawn入力として、まだ存在しない`applied`を使う
+- `requested`または`planned_runtime_profile`を無条件に`applied`へcopyする
+- spawn成功だけを根拠にexact model/reasoningが適用されたと断定する
 - runtime rejectionを成功したapplicationとして扱う
+
+## Codex MultiAgent V2のrole適用制約
+
+現行Codex MultiAgent V2では、requested model/reasoning overrideを適用した後にexplicit/default agent roleが適用される。role configはmodel/reasoningを再変更できる。
+
+そのためspawn前に次を記録する。
+
+```yaml
+role_plan:
+  explicit_agent_type: <role or null>
+  effective_role: <role name>
+  role_config_evidence: <source or null>
+  profile_effect: unchanged | changed | locked | unknown
+planned_runtime_profile:
+  model: <known planned model or null>
+  reasoning_effort: <known planned effort or null>
+```
+
+規則:
+
+- roleがprofileを変更/lockする場合、変更後profileでmodel floorとapproval gateを再評価する
+- roleがSol `xhigh/max`を生む場合、requestedが安価でもuser approvalまでspawnしない
+- roleがrequired floorより低いprofileを強制する場合はcapability/policy mismatch
+- applicable role/default-role configの影響を確認できない場合、高コストgateを保証できないためpre-spawn capability gapとして停止する
+- `planned_runtime_profile`は予測であり`applied`ではない
+
+通常spawn outputでfinal model/reasoning snapshotが親に公開されない場合、spawn成功後も:
+
+```yaml
+applied: null
+application_status: spawn_succeeded_profile_unverified
+profile_observability: final_profile_hidden
+```
+
+とする。
 
 ## 責務配置
 
 ### `development-orchestrator`
 
 - routineなimplementation model確認を要求しない
-- userまたはrepositoryが明示したoverrideやbudget制約だけを取得する
-- `Sol xhigh` / `Sol max` proposalではuser confirmation boundaryとしてworkflowを停止する
-- executor、assessment、proposal、approval、requested、appliedをlifecycle evidenceとして保持する
+- user/repositoryが明示したoverrideやbudget制約だけを取得する
+- Sol `xhigh/max` proposalではuser confirmation boundaryとしてworkflowを停止する
+- executor、assessment、proposal、approval、requested、runtime observabilityをlifecycle evidenceとして保持する
 
 ### `codex-delegation-executor`
 
@@ -107,16 +165,16 @@ classification
 
 新規sub-agentについて次を所有する。
 
-- model tier選定
-- reasoning effort選定
-- fork policy選定
+- model tier / reasoning effort / fork policy選定
+- truthful decomposability evidenceとdecomposition policy disposition
 - expensive Sol approval gate
+- explicit/default role planning
+- role-adjusted approval re-evaluation
 - requested profileのspawn call plan
-- post-runtime applied profileとapplication status
+- runtime profile observability
+- exact evidenceがある場合だけapplied profile
 - runtime rejection / inheritance / parent-owned fallback evidence
 - report persistence mode
-
-callerが`decomposition_policy: forbidden`を指定した場合、taskをmulti-agent decompositionへ戻さない。
 
 ### `review-enforcer`
 
@@ -125,7 +183,9 @@ review lifecycleについて次を所有する。
 - reviewer identity
 - normal reviewer continuity
 - independent reviewer independence
-- single-reviewer enforcement
+- `decomposition_policy: forbidden`
+- `parallelism_mode: single_agent`
+- truthful decomposability signal / suppressed-decomposition disposition
 - review mode
 - report persistence mode
 - frozen reviewed implementation HEAD
@@ -136,10 +196,26 @@ new normal / replacement / independent reviewerは`sub-agent-task-manager`経由
 
 ### `report-output-manager`
 
+phaseごとに責務を分ける。
+
+#### normal persistence
+
+- `work-context-manager` + `report-writer`
 - normal reportのpath予約・作成・永続化
-- independent-final-review report pathのmetadata-only予約
-- passing verdict後のreport-attestation persistence
-- attestation diff allowlist検証
+
+#### independent-final reservation
+
+- `work-context-manager`のみ
+- exact pathをmetadata-onlyで予約
+- `report-writer`を呼ばない
+- report body/fileを作らない
+
+#### independent-final attestation persistence
+
+- passing verdict後のみ`work-context-manager` + `report-writer`
+- retained evidenceからreport生成
+- reserved pathへ初回persist
+- report-only attestation commitとallowlist diff検証
 
 ## profile選定入力
 
@@ -157,12 +233,14 @@ constraints:
   user_override: null
   repository_policy: null
   runtime_availability: known | unknown
+  agent_type: null
+  effective_default_role: null
 approval:
   required: false
   status: not_required | pending | approved | rejected
 ```
 
-非自明な分類にはsource evidenceを付ける。不明な場合は低く見積もらず、uncertaintyを上げる。
+非自明な分類にはsource evidenceを付ける。不明な場合は低く見積もらずuncertaintyを上げる。
 
 ## model floor
 
@@ -209,11 +287,13 @@ Sol `xhigh`が適切な場合:
 Sol `max`は次を満たす場合だけproposal可能とする。
 
 - 一つの問題が主要blocker
-- 安全にworkstream分割できない
-- Sol `high`では不足する具体的理由がある
+- `decomposability`が本質的に`single`または分割不能なsequential dependencyである
+- Sol `high` / `xhigh`では不足する具体的理由がある
 - `execution-cost-stabilizer`でscopeとevidence reuseを確認済み
 - userへcost noticeを提示
 - explicit approvalまでdispatchしない
+
+`decomposition_policy: forbidden`はnon-decomposable条件の代替にならない。
 
 ## multi-agent gate
 
@@ -228,15 +308,16 @@ Sol `max`は次を満たす場合だけproposal可能とする。
 - parent synthesisが定義されている
 - parallelismの実益がある
 
-`review-enforcer`が作るreviewer taskは常に:
+reviewer taskの例:
 
 ```yaml
-decomposability: single
+decomposability: independent_workstreams  # observed fact when true
 decomposition_policy: forbidden
+decomposition_disposition: prohibited_by_review_lifecycle
 parallelism_mode: single_agent
 ```
 
-review scopeが大きいことだけを理由に複数reviewerへ分割しない。normal reviewer continuityとindependent final reviewのone exhaustive passは、一つのreviewer identityへ結び付く。
+review scopeが大きいことだけを理由に複数reviewerへ分割しないが、scopeの構造自体は正しく記録する。
 
 ## spawn application
 
@@ -244,41 +325,57 @@ review scopeが大きいことだけを理由に複数reviewerへ分割しない
 
 ```yaml
 dispatch_profile:
-  schema_version: 3
+  schema_version: 4
   requested:
     model: gpt-5.6-sol
     reasoning_effort: high
     fork_turns: none
+  role_plan:
+    explicit_agent_type: null
+    effective_role: default
+    role_config_evidence: <source>
+    profile_effect: unchanged
+  planned_runtime_profile:
+    model: gpt-5.6-sol
+    reasoning_effort: high
   applied: null
   application_status: pending_runtime_result
+  profile_observability: pending
 ```
 
-`requested`をactual spawn argumentsへ使う。
+`requested`をactual spawn argumentsへ使う。explicit roleがある場合は`agent_type`もcall planへ含める。default roleを使う場合もrole effectを事前評価する。
 
-### spawn後
-
-runtime evidenceを確認してから次を記録する。
+### spawn後: exact snapshotが見える場合
 
 ```yaml
 applied:
-  model: <actual model or inherited parent model>
-  reasoning_effort: <actual effort or inherited parent effort>
-  fork_turns: <actual fork policy>
-application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+  model: <observed final model>
+  reasoning_effort: <observed final effort>
+  fork_turns: <established fork policy>
+application_status: applied_verified
+profile_observability: verified_final_snapshot
 ```
 
-full-history forkの場合はoverrideを付けずparent profileを継承し、runtime path確定後に`inherited_parent_profile`を記録する。
+### spawn後: final profileが見えない場合
 
-runtimeがhidden overrideをrejectした場合、rejectされたrequested profileを`applied`にしない。fallbackが許可される場合は親がfallbackを実行し、そのactual profileだけを`applied`へ記録する。
+```yaml
+applied: null
+application_status: spawn_succeeded_profile_unverified
+profile_observability: final_profile_hidden
+```
+
+spawn成功だけを根拠にrequested/plannedをappliedへcopyしない。
+
+full-history、runtime rejection、fallbackも同じ原則で扱い、exact final evidenceがない場合はunknown/unverifiedを保持する。
 
 ## reviewer continuity
 
 既存normal reviewerまたはindependent reviewerをfix verification / finding closureで再利用するときは新規spawnしない。
 
-- original applied model / effort / contextを維持
+- original profile evidence / observability stateを維持
 - task defaultを再適用しない
 - `application_status: reused_existing_agent_profile`
-- reviewer identity、original applied profile evidence、continued modeを記録
+- reviewer identity、original exact/unverified evidence、continued modeを記録
 
 同じreview lifecycle内で既に承認されたSol `xhigh/max` reviewerを再利用する場合、再承認は不要。replacement reviewerまたは新task lifecycleは新規selectionとしてapproval gateを通す。
 
@@ -288,27 +385,29 @@ runtimeがhidden overrideをrejectした場合、rejectされたrequested profil
 
 `report_persistence_mode: normal_persistence`を使う。
 
+- `work-context-manager` + `report-writer`
 - report pathを予約し、dispatch前にstandard templateを作成可能
 - `Dispatch profile` sectionはparent-owned
-- parentがpre-dispatch `requested`等を記録
-- spawn後にparentが`applied` / `application_status`をruntime evidenceから記録
-- childはhidden runtime stateを推測せず、child-owned task/result sectionだけを埋める
+- parentがpre-dispatch requested / role plan / planned runtime profileを記録
+- spawn後にparentがexact appliedまたはunverified stateを記録
+- childはhidden runtime stateを推測せずchild-owned sectionだけを埋める
 
-### independent final review
-
-`report_persistence_mode: deferred_attestation`を使う。
+### independent final review: reservation
 
 freeze前:
 
+- `report-output-manager` reservation-only phaseを使う
+- `work-context-manager`のみ呼ぶ
 - exact report pathをmetadataとして予約
-- repository fileを作成・pre-populate・編集しない
+- `report-writer`を呼ばない
+- repository file/report bodyを作成しない
 - 他の全repository変更をcommitしてHEADをfreeze
 
 review中:
 
 - independent reviewerはreserved report fileを作らない
 - structured findings / coverage / commands / verdict / risks / unexploredをparentへ返す
-- parentはreviewer outputとdispatch-profile evidenceをrepository外のlifecycle evidenceとして保持
+- parentはreviewer outputとdispatch-profile evidenceをrepository外lifecycle evidenceとして保持
 
 reviewがfailした場合:
 
@@ -316,40 +415,46 @@ reviewがfailした場合:
 - implementation -> normal fix verificationへ戻る
 - 同じindependent reviewerでbounded finding/CI-delta closureを行う
 
+### independent final review: attestation persistence
+
 passing verdict後:
 
-- `report-writer`がretained evidenceからreportを生成
-- `report-output-manager`がreserved pathへ初めてpersist
+- `work-context-manager`でauthoritative contextを再確認
+- 初めて`report-writer`を呼ぶ
+- retained evidenceからreportを生成
+- `report-output-manager`がreserved pathへ初回persist
 - reviewed implementation HEADの直後にreport-only attestation commitを1件だけ作成
 - allowlist diffを検証
 
 ## override優先順位
 
 1. current-task user instruction / explicit expensive-profile approval
-2. unapproved Sol `xhigh/max` mandatory approval gate
+2. unapproved initial/role-adjusted Sol `xhigh/max` mandatory approval gate
 3. existing reviewer continuity
-4. caller-owned decomposition prohibition
+4. caller-owned decomposition policy
 5. authoritative repository policy
-6. runtime capability / model availability
+6. runtime role/default-role constraints / model availability
 7. automatic selection
 
 ## fork制約
 
 - fresh specialist + overrideは原則`fork_turns: "none"`
 - bounded historyならexplicit positive partial fork
-- full-historyはparent execution profile継承
+- full-historyはruntime inheritance/role pathに従う
 - specialization優先ならtask-local contextを明示してfresh spawn
 - reviewer continuity reuseは新規forkではない
 
 ## 再分類とescalation
 
-新しいagentをdispatchする場合、新しいevidenceでtask kind / uncertainty / change radius / criticalityが変化したらprofileを再計算する。
+新しいagentをdispatchする場合、新しいevidenceでtask kind / uncertainty / change radius / criticality / role-adjusted planが変化したらprofileを再計算する。
 
 - failed deterministic verification -> investigation
-- local implementationでarchitecture ambiguity判明 -> Sol floorへ
+- local implementationでarchitecture ambiguity判明 -> Sol floor
 - independently separable -> decomposition allowed時だけ`codex-delegation-executor`へ戻る
+- decomposition forbidden時はobserved decomposabilityを保持しsuppressed dispositionを記録
 - 同一problemで慎重さ不足 -> effortを上げる
 - problem nature変化 -> model tierを上げる
+- role/default roleでprofile変化 -> floor/approval再評価
 - Sol `xhigh/max`到達 -> proposal化しuser approval stop
 
 existing reviewerがinitial reviewからfix verificationやbounded closureへ移るだけではprofileを再計算しない。
@@ -366,19 +471,23 @@ Terra `medium`。module間regression reasoningが必要ならTerra `high`。
 
 ### intermittent concurrency failureの原因調査
 
-通常はSol `high`。一つの非分割root causeへ深い証明が必要ならSol `max`をproposalし、承認まで停止する。
+通常はSol `high`。本質的に一つの非分割root causeへ深い証明が必要な場合だけSol `max`をproposalし、承認まで停止する。
+
+### roleがreasoningを上書きする
+
+selectorがSol `high`をrequestedしても、default roleがSol `xhigh`をlockすることが事前に分かった場合、role-adjusted planをSol `xhigh` proposalへ変換しuser approvalまでspawnしない。role configを確認できずxhigh化の可能性を排除できない場合もspawnしない。
 
 ### normal reviewとfix verification
 
-initial reviewerはnew Sol `high`がdefault。同じreviewerをfix verificationへreuseする場合はSol `high`のoriginal applied profileを継続し、Terra `high`へ切り替えない。
+initial reviewerはnew Sol `high`がdefault。同じreviewerをfix verificationへreuseする場合はoriginal profile/observability evidenceを継続し、Terra `high`へ切り替えない。
 
 ### independent final review
 
-single reviewer固定。Sol `xhigh`をproposalし、承認後にfresh reviewerをdispatchする。report pathは予約だけで、passing verdictまでrepository fileを作らない。
+single-agent execution policy。review scopeが独立workstreamを含むならその事実は保持するがdecompositionはsuppressed。Sol `xhigh`をproposalし、approvalとrole-plan safetyを確認後にfresh reviewerをdispatchする。report pathはmetadata予約だけでpassing verdictまでfileを作らない。
 
 ### frontend / backend / migrationが独立している
 
-通常implementationなら3 bounded taskへ分割可能。各taskへ個別profileを選びparentが統合する。review-enforcerのone-reviewer lifecycleにはこの分割規則を適用しない。
+通常implementationなら3 bounded taskへ分割可能。各taskへ個別profileを選びparentが統合する。review-enforcerのone-reviewer lifecycleには実行分割を適用しないが、review scopeのdecomposability signalは保持する。
 
 ## 検証方針
 
@@ -388,16 +497,20 @@ CodexSkill repositoryの方針に従いTDDは適用しない。
 - `python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip`
 - active relative Markdown link検証
 - current PR HEAD SHAと一致するGitHub Actions runの確認
-- requested -> spawn -> appliedの時系列contract review
-- expensive Sol approval gate review
-- reviewer single-agent / continuity contract review
-- independent-final deferred-attestation contract review
+- requested -> role plan -> spawn -> applied/unverifiedの時系列contract review
+- role/default-roleによるexpensive Sol approval再評価
+- hidden final-profile metadata時にexact appliedを断定しないことのreview
+- decomposability signalとdecomposition policy分離のreview
+- reviewer single-agent execution / continuity contract review
+- independent-final reservation phaseでreport-writerを呼ばないことのreview
+- passing-verdict後だけattestation persistenceするcontract review
 - fixed `Dispatch profile` templateのparent/child ownership review
 
 ## 非対象
 
 - Codex runtime本体へのmodel router実装
 - runtime model availability APIの新設
+- parent-visible final agent config snapshot APIの新設
 - model価格だけに基づくoptimization
 - user explicit overrideのsilent変更
 - full-history forkへ異なるmodelを強制
@@ -422,3 +535,4 @@ CodexSkill repositoryの方針に従いTDDは適用しない。
 - [役割分担で回すGPT-5.6 Luna / Terra / Sol](https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb)
 - [OpenAI model catalog](https://developers.openai.com/api/docs/models)
 - [OpenAI latest-model guidance](https://developers.openai.com/api/docs/guides/latest-model)
+- [Codex MultiAgent V2 spawn implementation](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs)

--- a/design/adaptive-agent-assignment-design.md
+++ b/design/adaptive-agent-assignment-design.md
@@ -2,39 +2,23 @@
 
 ## 目的
 
-delegated taskの性質に応じて、sub-agentへ適切なモデル、推論強度、fork方式を割り当てる。
+delegated taskの性質に応じて、sub-agentへ適切なmodel tier、reasoning effort、fork方式を割り当てる。
 
-単純なfile数や一律のreviewer設定ではなく、工程、判断負荷、不確実性、変更半径、重要度、反復性、分割可能性を評価する。選定結果と実際にruntimeへ適用されたprofileを分離し、割当理由、承認状態、fallbackをreportへ残す。
+単純なfile数ではなく、task kind、判断負荷、不確実性、変更半径、重要度、反復性、分割可能性、context needを評価する。選定した`requested` profileとruntimeで実際に成立した`applied` profileを分離し、割当理由、承認状態、fallback、reviewer continuityを証跡として残す。
 
-本設計はIssue #13の「sub-agentの使用モデルがSkillへ定義されていない」という問題を解消する。
-
-## 背景
-
-既存flowには次の要素があった。
-
-- `codex-delegation-executor`によるmain agentとsub-agentのexecutor選択
-- `sub-agent-task-manager`によるbounded taskとreport契約
-- `spawn-agent-model-overrides.md`によるhidden model overrideの適用方法
-- `development-orchestrator`によるworkflow lifecycle管理
-- `review-enforcer`によるnormal reviewer continuityとindependent final reviewer lifecycle
-
-一方、taskの性質からmodelとreasoning effortを選ぶ中央規則がなかった。そのため、callerごとにprofileが固定または手動選択され、機械的作業、通常実装、判断中心作業、難しい単一問題、独立workstream分割を区別できなかった。
-
-また、`Sol xhigh`と`Sol max`は実行コストが高いため、品質要件だけで自動選定すると意図せず高コストなdispatchが発生する。そこで、この2 profileは自動選定の最終結果ではなく、ユーザー承認が必要なproposalとして扱う。
-
-reviewでは別の制約もある。initial reviewとfix verificationで同じreviewerを再利用する場合、fix verificationのtask defaultへmodelを切り替える新規spawnは存在しない。このため、新規reviewerのprofile選定と既存reviewerのcontinuity reuseを明確に分離する。
+本設計はIssue #13の「sub-agentの使用modelがSkillへ定義されていない」という問題を解消する。
 
 ## 設計原則
 
-### モデルと推論強度を別軸にする
+### model tierとreasoning effortを別軸にする
 
-モデルtierはtaskが要求する判断能力を表す。
+model tierはtaskが要求する判断能力を表す。
 
 - Luna: 決定済みの機械的・反復的・高volume作業
 - Terra: 通常のbounded technical work
 - Sol: 不確実、判断中心、高重要度、cross-system、design、難しいdebug、review
 
-推論強度は同じ問題へどれだけ慎重に取り組むかを表す。
+reasoning effortは同じ問題へどれだけ慎重に取り組むかを表す。
 
 - `low`: exactな低risk変換
 - `medium`: 通常実装またはdeterministic evidence
@@ -42,76 +26,71 @@ reviewでは別の制約もある。initial reviewとfix verificationで同じre
 - `xhigh`: boundedかつ網羅性または重要度が高いaudit
 - `max`: 一つの非常に難しく分割不能な問題
 
-モデルtierを上げる条件とreasoning effortを上げる条件を混同しない。
-
 ### `Sol xhigh` / `Sol max`はapproval-gated
 
 `Sol xhigh`と`Sol max`は自動dispatchしない。
-
-selectorがどちらかを必要と判断した場合は、次の状態遷移にする。
 
 ```text
 automatic classification
   -> proposed_profile = Sol xhigh | Sol max
   -> userへ理由とcost noticeを提示
   -> STOP
-      |-- approve -> requestedへ昇格 -> runtime application
+      |-- approve -> requestedへ昇格
       `-- reject  -> xhigh/maxを除外して再計算
 ```
 
-approval前は`requested`と`applied`を空にする。repository policy、過去の別taskでの承認、沈黙、推測したユーザー嗜好はapprovalとして扱わない。
+- approval前は`requested`へ昇格しない
+- repository policy、過去taskの承認、沈黙、推測した嗜好はapprovalにしない
+- current taskでユーザーが明示的にそのprofileを指定した場合はapproval evidenceとして扱える
+- implementation、investigation、review、release auditを含む全taskへ適用する
 
-現在taskでユーザーが明示的に`Sol xhigh`または`Sol max`を指定している場合のみ、その指示自体をapproval evidenceとして扱える。
+### Ultraはreasoning effortではない
 
-このgateはreviewやrelease auditを含む全task kindへ適用し、repository policyとautomatic selectionより優先する。
-
-### Ultraをreasoning effortにしない
-
-参考記事のUltra相当は、単一agentの推論強度ではなく、独立workstreamへ分割し親が統合するmulti-agent戦略として扱う。
+参考記事のUltra相当は、独立workstreamへ分割し親が統合するmulti-agent strategyとして扱う。
 
 - `codex-delegation-executor`が分割可否を判断する
 - 各bounded taskへ`sub-agent-task-manager`が個別profileを選ぶ
 - `reasoning_effort: ultra`は生成しない
 
-### 行数より変更半径を重視する
+ただし、callerがidentity-sensitive lifecycleとして`decomposition_policy: forbidden`を指定したtaskは分割しない。
 
-小さなdiffでもsecurity、authorization、migration、concurrency、compatibility、public API、releaseへ影響する場合は高重要度とする。
+### `proposed` / `requested` / `applied`を時系列で分離する
 
-大きなdiffでも、手順と期待結果が完全に決まりdeterministic validatorがある反復処理ならLuna候補になりうる。
+profile stateは次の3段階を持つ。
 
-### proposed / requested / appliedを分離する
+- `proposed_profile`: user approvalなどが未確定の候補
+- `requested`: spawn前に親がruntimeへ要求するprofile
+- `applied`: spawn後にruntime evidenceから確定したprofile
 
-profile stateは次の3段階を区別する。
+`applied`はspawn前には確定できない。
 
-- `proposed_profile`: cost gateなどによりまだ選択確定していない候補
-- `requested`: 承認済みまたは通常自動選定され、runtimeへ要求するprofile
-- `applied`: runtimeへ実際に適用されたprofile
+```text
+classification
+  -> proposed? -> approval
+  -> requested
+  -> spawn / inheritance / fallback attempt
+  -> runtime evidence
+  -> applied + application_status
+```
 
-full-history fork、hidden override rejection、runtime model unavailableなどにより`requested`と`applied`が異なる場合がある。未承認proposalを`requested`または`applied`として記録してはならない。
+禁止事項:
 
-### reviewer continuityは新規profile選定ではない
-
-既存normal reviewerまたはindependent reviewerをfix verification／finding closureで再利用するときは、新しいagentを作らない。
-
-- original reviewerのapplied model、reasoning effort、fork contextを維持する
-- task default tableを再適用しない
-- `application_status: reused_existing_agent_profile`を記録する
-- reviewer identity、original applied profile evidence、continued review modeをcontinuity evidenceとして残す
-- 同一review lifecycleで既に承認済みの`Sol xhigh` / `Sol max` reviewerを再利用する場合は新しい高コストprofile選定ではないため再承認を要求しない
-- replacement reviewerまたは新しいtask lifecycleは新規dispatchとしてprofile selectionとapproval gateを通す
+- `requested`を無条件に`applied`へcopyする
+- spawn入力として、まだ存在しない`applied`を使う
+- runtime rejectionを成功したapplicationとして扱う
 
 ## 責務配置
 
 ### `development-orchestrator`
 
-- workflow開始時にroutineなimplementation model確認を要求しない
+- routineなimplementation model確認を要求しない
 - userまたはrepositoryが明示したoverrideやbudget制約だけを取得する
-- `Sol xhigh` / `Sol max` proposalが出た場合はuser confirmation boundaryとしてworkflowを停止する
-- executor、assessment、proposal/approval、requested/applied profileをlifecycle evidenceとして保持する
+- `Sol xhigh` / `Sol max` proposalではuser confirmation boundaryとしてworkflowを停止する
+- executor、assessment、proposal、approval、requested、appliedをlifecycle evidenceとして保持する
 
 ### `codex-delegation-executor`
 
-- main agent、single sub-agent、multi-agent decompositionを選ぶ
+- main agent / single sub-agent / multi-agent decompositionを選ぶ
 - taskを次の軸で評価する
   - `task_kind`
   - `work_class`
@@ -121,82 +100,48 @@ full-history fork、hidden override rejection、runtime model unavailableなど�
   - `repetition`
   - `decomposability`
   - `context_need`
-- multi-agent分割のwrite ownership、blocking dependency、synthesisを確認する
-- modelとreasoning effortの中央tableは持たない
+- write ownership、blocking dependency、parent synthesisを確認する
+- model/reasoningの中央defaultは持たない
 
 ### `sub-agent-task-manager`
 
-- 新規bounded taskのmodel tier、reasoning effort、fork policyを選ぶ
-- `Sol xhigh` / `Sol max`ではproposalを生成し、approvalがない限りdispatchしない
-- explicit overrideの優先順位を適用する
-- approved requested profileをruntimeへ適用する
-- applied profileとfallbackをreportへ記録する
-- taskが独立分割可能になった場合はdispatch前に`codex-delegation-executor`へ戻す
-- fixed report templateの`Dispatch profile` sectionへselection／approval／requested／applied／application statusを記録させる
+新規sub-agentについて次を所有する。
+
+- model tier選定
+- reasoning effort選定
+- fork policy選定
+- expensive Sol approval gate
+- requested profileのspawn call plan
+- post-runtime applied profileとapplication status
+- runtime rejection / inheritance / parent-owned fallback evidence
+- report persistence mode
+
+callerが`decomposition_policy: forbidden`を指定した場合、taskをmulti-agent decompositionへ戻さない。
 
 ### `review-enforcer`
 
-- reviewer identity、normal reviewer continuity、independent reviewer independenceを所有する
-- 新しく作るnormal reviewer、replacement reviewer、independent reviewerは必ず`sub-agent-task-manager`経由でdispatchする
-- `Sol xhigh` / `Sol max` proposalが返った場合はreviewer spawn前にparentへstopを返す
-- fix verification／finding closureで既存reviewerを再利用するときはoriginal applied profileを維持する
-- reuse時は`reused_existing_agent_profile`として証跡化し、新しいprofileを適用したと主張しない
+review lifecycleについて次を所有する。
 
-### `execution-cost-stabilizer`
+- reviewer identity
+- normal reviewer continuity
+- independent reviewer independence
+- single-reviewer enforcement
+- review mode
+- report persistence mode
+- frozen reviewed implementation HEAD
+- retained independent-review evidence
+- report-attestation lifecycle
 
-- `max` proposalまたはmulti-agentを使う前に、再実行、過剰parallelism、evidence再利用を確認する
-- `Sol xhigh` / `Sol max` proposalのcost rationaleを支援する
-- costだけを理由に必要なmodel floorを下げない
+new normal / replacement / independent reviewerは`sub-agent-task-manager`経由でdispatchする。
 
-## 処理flow
+### `report-output-manager`
 
-```text
-development-orchestrator
-  |
-  | explicit override / repository policy / task context
-  v
-codex-delegation-executor
-  |-- executor decision
-  |-- delegation assessment
-  |-- single vs multi-agent decision
-  |
-  +--> main agent
-  |
-  +--> bounded sub-agent task(s)
-          |
-          v
-      sub-agent-task-manager
-          |-- model tier selection
-          |-- reasoning effort selection
-          |-- fork policy selection
-          |
-          |-- Sol xhigh/max ?
-          |       |-- yes -> proposal + cost notice -> USER APPROVAL STOP
-          |       `-- no  -> requested
-          |
-          |-- approved proposal -> requested
-          |-- requested -> applied resolution
-          |-- report pre-creation
-          v
-      collaboration.spawn_agent
-```
+- normal reportのpath予約・作成・永続化
+- independent-final-review report pathのmetadata-only予約
+- passing verdict後のreport-attestation persistence
+- attestation diff allowlist検証
 
-reviewer作成も同じselectorを通す。
-
-```text
-review-enforcer
-  |-- new normal / replacement / independent reviewer
-  |       v
-  |   sub-agent-task-manager
-  |       |-- expensive proposal -> USER APPROVAL STOP before spawn
-  |       `-- approved/ordinary -> spawn reviewer
-  |
-  `-- existing reviewer continuity
-          `-- no spawn / no reselection
-              application_status = reused_existing_agent_profile
-```
-
-## 選定入力
+## profile選定入力
 
 ```yaml
 task_kind: implementation | design | investigation | review | verification | environment_verification | intake_verification | standards | other
@@ -206,6 +151,7 @@ change_radius: local | cross_module | cross_system
 criticality: ordinary | high
 repetition: single | high_volume
 decomposability: single | sequential_dependencies | independent_workstreams
+decomposition_policy: allowed | forbidden
 context_need: fresh | bounded_history | full_history
 constraints:
   user_override: null
@@ -214,16 +160,11 @@ constraints:
 approval:
   required: false
   status: not_required | pending | approved | rejected
-continuity:
-  existing_agent: null
-  original_applied_profile: null
 ```
 
 非自明な分類にはsource evidenceを付ける。不明な場合は低く見積もらず、uncertaintyを上げる。
 
-## profile選定
-
-### model floor
+## model floor
 
 | 条件 | 最低tier |
 | --- | --- |
@@ -233,9 +174,9 @@ continuity:
 
 複数条件が該当する場合は最も高いfloorを採用する。
 
-### task default
+## task default
 
-新規agentを作るときだけ次のdefaultを使う。既存reviewer reuseではoriginal applied profileを維持する。
+新規agentを作る場合だけ適用する。
 
 | task | default |
 | --- | --- |
@@ -247,208 +188,197 @@ continuity:
 | design / requirement interpretation | Sol `high` |
 | open-ended or cross-layer investigation | Sol `high` |
 | initial normal review | Sol `high` |
-| focused fix verification, new reviewer only | Terra `high` |
-| independent final review / release audit | propose Sol `xhigh`, then stop for approval |
+| focused fix verification, replacement reviewerのみ | Terra `high` |
+| independent final review / release audit | propose Sol `xhigh`; approval待ちで停止 |
 
 失敗したdeterministic verificationは同じLuna taskとして再実行せず、investigationへ再分類する。
 
-### `xhigh` gate
+## reasoning effort gate
 
-Sol `xhigh`が適切と判断された場合、selectorは次を実行する。
+### `xhigh`
 
-- `proposed_profile`へSol `xhigh`を設定
-- Sol `high`では不足する理由を記録
-- higher effortによるexecution cost増加をユーザーへ伝える
-- explicit approvalがなければdispatchを停止
+Sol `xhigh`が適切な場合:
 
-承認後のみ`requested`へ昇格する。
+- `proposed_profile`へ設定
+- Sol `high`で不足する理由を記録
+- cost増加をユーザーへ通知
+- explicit approvalまでdispatchしない
 
-### `max` gate
+### `max`
 
-Sol `max`は次を全て満たす場合だけproposal可能とする。
+Sol `max`は次を満たす場合だけproposal可能とする。
 
-- 一つの問題が主要blockerである
-- workstreamへ安全に分割できない
+- 一つの問題が主要blocker
+- 安全にworkstream分割できない
 - Sol `high`では不足する具体的理由がある
-- `execution-cost-stabilizer`でscopeとevidence再利用を確認した
-- ユーザーへcost notice付きで提案する
-- explicit approvalを得るまでdispatchしない
+- `execution-cost-stabilizer`でscopeとevidence reuseを確認済み
+- userへcost noticeを提示
+- explicit approvalまでdispatchしない
 
-`xhigh`を先に実行する必要はない。task evidenceから直接`max`候補になりうるが、いずれの場合もapproval gateは必須である。
+## multi-agent gate
 
-### multi-agent gate
+`decomposition_policy: allowed`のtaskだけ分割候補にできる。
 
-複数agentへ分割するには次を全て満たす。
+必要条件:
 
-- 独立workstreamが2件以上ある
-- scope、non-goals、evidence、report ownerを各taskへ定義できる
-- write ownershipが重複しない、またはread-onlyである
+- 独立workstreamが2件以上
+- 各taskへscope / non-goals / evidence / report ownerを定義できる
+- write ownershipが重複しない、またはread-only
 - blocking investigation dependencyがない
 - parent synthesisが定義されている
 - parallelismの実益がある
 
-各taskは別々にprofile選定する。分割後の個別taskがSol `xhigh`またはSol `max`候補なら、そのtaskごとにapproval gateを通す。
+`review-enforcer`が作るreviewer taskは常に:
+
+```yaml
+decomposability: single
+decomposition_policy: forbidden
+parallelism_mode: single_agent
+```
+
+review scopeが大きいことだけを理由に複数reviewerへ分割しない。normal reviewer continuityとindependent final reviewのone exhaustive passは、一つのreviewer identityへ結び付く。
+
+## spawn application
+
+### spawn前
+
+```yaml
+dispatch_profile:
+  schema_version: 3
+  requested:
+    model: gpt-5.6-sol
+    reasoning_effort: high
+    fork_turns: none
+  applied: null
+  application_status: pending_runtime_result
+```
+
+`requested`をactual spawn argumentsへ使う。
+
+### spawn後
+
+runtime evidenceを確認してから次を記録する。
+
+```yaml
+applied:
+  model: <actual model or inherited parent model>
+  reasoning_effort: <actual effort or inherited parent effort>
+  fork_turns: <actual fork policy>
+application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+```
+
+full-history forkの場合はoverrideを付けずparent profileを継承し、runtime path確定後に`inherited_parent_profile`を記録する。
+
+runtimeがhidden overrideをrejectした場合、rejectされたrequested profileを`applied`にしない。fallbackが許可される場合は親がfallbackを実行し、そのactual profileだけを`applied`へ記録する。
+
+## reviewer continuity
+
+既存normal reviewerまたはindependent reviewerをfix verification / finding closureで再利用するときは新規spawnしない。
+
+- original applied model / effort / contextを維持
+- task defaultを再適用しない
+- `application_status: reused_existing_agent_profile`
+- reviewer identity、original applied profile evidence、continued modeを記録
+
+同じreview lifecycle内で既に承認されたSol `xhigh/max` reviewerを再利用する場合、再承認は不要。replacement reviewerまたは新task lifecycleは新規selectionとしてapproval gateを通す。
+
+## report persistence
+
+### normal sub-agent / normal review
+
+`report_persistence_mode: normal_persistence`を使う。
+
+- report pathを予約し、dispatch前にstandard templateを作成可能
+- `Dispatch profile` sectionはparent-owned
+- parentがpre-dispatch `requested`等を記録
+- spawn後にparentが`applied` / `application_status`をruntime evidenceから記録
+- childはhidden runtime stateを推測せず、child-owned task/result sectionだけを埋める
+
+### independent final review
+
+`report_persistence_mode: deferred_attestation`を使う。
+
+freeze前:
+
+- exact report pathをmetadataとして予約
+- repository fileを作成・pre-populate・編集しない
+- 他の全repository変更をcommitしてHEADをfreeze
+
+review中:
+
+- independent reviewerはreserved report fileを作らない
+- structured findings / coverage / commands / verdict / risks / unexploredをparentへ返す
+- parentはreviewer outputとdispatch-profile evidenceをrepository外のlifecycle evidenceとして保持
+
+reviewがfailした場合:
+
+- reserved report pathをpersistしない
+- implementation -> normal fix verificationへ戻る
+- 同じindependent reviewerでbounded finding/CI-delta closureを行う
+
+passing verdict後:
+
+- `report-writer`がretained evidenceからreportを生成
+- `report-output-manager`がreserved pathへ初めてpersist
+- reviewed implementation HEADの直後にreport-only attestation commitを1件だけ作成
+- allowlist diffを検証
 
 ## override優先順位
 
-1. 明示的なcurrent-task user instruction
-2. 未承認Sol `xhigh` / `Sol max`に対するmandatory user-approval gate
-3. existing reviewer continuity reuse
-4. authoritative repository policy
-5. runtime capabilityとmodel availability
-6. automatic selection
-
-explicit overrideがautomatic floorを下回る場合も、silentに置換しない。mismatchを記録し、governing authorityに従う。
-
-repository policyがSol `xhigh`またはSol `max`を要求していても、それはproposalの根拠にはなるがuser approvalの代替にはならない。
-
-## dispatch profile schema
-
-通常profile:
-
-```yaml
-dispatch_profile:
-  schema_version: 2
-  selection_source: automatic | user_override | repository_policy
-  task_kind: review
-  requested:
-    model_tier: sol
-    model: gpt-5.6-sol
-    reasoning_effort: high
-    fork_turns: none
-  applied:
-    model: gpt-5.6-sol
-    reasoning_effort: high
-    fork_turns: none
-  application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
-  approval:
-    required: false
-    status: not_required
-```
-
-approval待ちprofile:
-
-```yaml
-dispatch_profile:
-  schema_version: 2
-  selection_source: automatic | repository_policy
-  proposed_profile:
-    model_tier: sol
-    model: gpt-5.6-sol
-    reasoning_effort: xhigh | max
-    fork_turns: none
-  requested: null
-  applied: null
-  application_status: awaiting_user_approval
-  approval:
-    required: true
-    status: pending
-    approved_by: null
-    approval_evidence: null
-  reasons:
-    - why Sol high is insufficient
-  cost_notice:
-    - higher reasoning effort increases execution cost
-```
-
-reviewer continuity:
-
-```yaml
-dispatch_profile:
-  schema_version: 2
-  selection_source: continuity_reuse
-  task_kind: review
-  requested: null
-  applied:
-    model: <original applied model>
-    reasoning_effort: <original applied effort>
-    fork_turns: <original fork policy>
-  application_status: reused_existing_agent_profile
-  continuity:
-    reviewer_identity: <existing reviewer>
-    continued_mode: fix_verification | finding_ci_delta_closure
-    original_profile_evidence: <report or spawn evidence>
-```
-
-承認後はapproval evidenceを保存し、approved proposalを`requested`へ昇格してからruntime applicationへ進む。
-
-## report schema
-
-全てのdispatched sub-agent reportは固定の`## Dispatch profile` sectionを持つ。
-
-最低限、次のplaceholderをtemplateで事前作成する。
-
-- selection inputs
-- selection source
-- proposed profile
-- approval status / evidence
-- requested profile
-- applied profile
-- application status
-- reviewer continuity
-- fork policy
-- reasons / constraints
-
-childはreport構造を変更せず、これらのblank fieldだけを埋める。これによりfixed-format制約とdispatch-profile evidence必須制約を両立する。
+1. current-task user instruction / explicit expensive-profile approval
+2. unapproved Sol `xhigh/max` mandatory approval gate
+3. existing reviewer continuity
+4. caller-owned decomposition prohibition
+5. authoritative repository policy
+6. runtime capability / model availability
+7. automatic selection
 
 ## fork制約
 
-- fresh specialistとoverrideを組み合わせる場合は`fork_turns: "none"`
-- bounded historyだけ必要なら明示的なpositive partial fork
-- full-history forkはparent profileを継承し、`inherited_parent_profile`として記録
-- model specializationを優先する場合は、必要contextをtask-local promptへ明示してfresh spawnする
-- approvalはfork制約を上書きしない
+- fresh specialist + overrideは原則`fork_turns: "none"`
+- bounded historyならexplicit positive partial fork
+- full-historyはparent execution profile継承
+- specialization優先ならtask-local contextを明示してfresh spawn
 - reviewer continuity reuseは新規forkではない
 
 ## 再分類とescalation
 
-新しいevidenceがtask kind、不確実性、変更半径、重要度を変え、新しいagentを作る場合はprofileを再計算する。
+新しいagentをdispatchする場合、新しいevidenceでtask kind / uncertainty / change radius / criticalityが変化したらprofileを再計算する。
 
-- 問題自体は同じだが慎重さが不足する場合: reasoning effortを上げる
-- 問題の性質または必要判断能力が変わる場合: model tierを上げる
-- 独立workstreamが判明した場合: multi-agent分割判断へ戻る
-- escalation結果がSol `xhigh`またはSol `max`ならproposalへ変換し、user approval stopへ入る
-- runtime rejectionの場合: spawn適用contractに従いrequested/appliedを分離する
-- existing reviewerがinitial reviewからfix verificationへ移るだけではprofileを再計算しない
+- failed deterministic verification -> investigation
+- local implementationでarchitecture ambiguity判明 -> Sol floorへ
+- independently separable -> decomposition allowed時だけ`codex-delegation-executor`へ戻る
+- 同一problemで慎重さ不足 -> effortを上げる
+- problem nature変化 -> model tierを上げる
+- Sol `xhigh/max`到達 -> proposal化しuser approval stop
 
-理由のないretry escalationは禁止する。
+existing reviewerがinitial reviewからfix verificationやbounded closureへ移るだけではprofileを再計算しない。
 
 ## 代表例
 
 ### formatting対象が多数ある
 
-選定: Luna `low`。validator解釈が必要ならLuna `medium`。
+Luna `low`。validator解釈が必要ならLuna `medium`。
 
 ### accepted designに基づく通常実装
 
-選定: Terra `medium`。module間regression reasoningが必要ならTerra `high`。
+Terra `medium`。module間regression reasoningが必要ならTerra `high`。
 
 ### intermittent concurrency failureの原因調査
 
-通常はSol `high`。一つの非分割root causeへ深い証明が必要でSol `high`では不足すると判断した場合はSol `max`を提案し、ユーザー承認まで停止する。
+通常はSol `high`。一つの非分割root causeへ深い証明が必要ならSol `max`をproposalし、承認まで停止する。
 
 ### normal reviewとfix verification
 
-initial normal reviewerは新規dispatchとして通常Sol `high`を選ぶ。finding修正後に同じreviewerを再利用する場合、focused fix verificationのTerra `high` defaultへ切り替えず、元のSol `high`を維持して`reused_existing_agent_profile`を記録する。
+initial reviewerはnew Sol `high`がdefault。同じreviewerをfix verificationへreuseする場合はSol `high`のoriginal applied profileを継続し、Terra `high`へ切り替えない。
 
 ### independent final review
 
-release-criticalな独立final reviewではSol `xhigh`を候補として提案する。Sol `high`との差とcost noticeを提示し、ユーザー承認前にはreviewerをdispatchしない。承認後に作ったindependent reviewerをfinding closureで再利用する場合は、そのoriginal applied profileを継続する。
+single reviewer固定。Sol `xhigh`をproposalし、承認後にfresh reviewerをdispatchする。report pathは予約だけで、passing verdictまでrepository fileを作らない。
 
-### frontend、backend、migrationが独立している
+### frontend / backend / migrationが独立している
 
-単一のSol `max`へまとめない。write ownershipとdependencyを確認し、3 bounded taskへ分割する。各taskは個別にLuna、Terra、Solを選定し、parentが統合する。
-
-## 既存設計との関係
-
-Skill hierarchyのtopologyは変更しない。
-
-- `codex-delegation-executor`から`sub-agent-task-manager`へ委譲する既存関係を維持する
-- `review-enforcer`配下のnew reviewer dispatchは既存hierarchyどおり`sub-agent-task-manager`を通す
-- model overrideの実applicationは既存referenceを拡張する
-- 新規runtime wrapperまたはcore Skillは追加しない
-
-このため`design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`の同期対象内容は変更しない。
+通常implementationなら3 bounded taskへ分割可能。各taskへ個別profileを選びparentが統合する。review-enforcerのone-reviewer lifecycleにはこの分割規則を適用しない。
 
 ## 検証方針
 
@@ -458,19 +388,21 @@ CodexSkill repositoryの方針に従いTDDは適用しない。
 - `python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip`
 - active relative Markdown link検証
 - current PR HEAD SHAと一致するGitHub Actions runの確認
-- proposed/requested/applied profile、approval gate、Ultraとreasoning effort、full-history forkのcontract review
-- review-enforcerからnew reviewerが`sub-agent-task-manager`を通ることのcontract review
-- reviewer continuityがoriginal applied profileを保持することのcontract review
-- fixed `Dispatch profile` report templateとSkill section orderingの整合確認
+- requested -> spawn -> appliedの時系列contract review
+- expensive Sol approval gate review
+- reviewer single-agent / continuity contract review
+- independent-final deferred-attestation contract review
+- fixed `Dispatch profile` templateのparent/child ownership review
 
 ## 非対象
 
 - Codex runtime本体へのmodel router実装
 - runtime model availability APIの新設
-- model価格に基づく自動optimization
-- userのexplicit overrideをsilentに変更すること
-- full-history forkへ異なるmodelを強制すること
-- `reasoning_effort: ultra`の追加
+- model価格だけに基づくoptimization
+- user explicit overrideのsilent変更
+- full-history forkへ異なるmodelを強制
+- `reasoning_effort: ultra`
+- multi-agent review lifecycleの新設
 - automatic merge
 
 ## 関連file
@@ -481,6 +413,7 @@ CodexSkill repositoryの方針に従いTDDは適用しない。
 - [Spawn-agent model overrides](../skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md)
 - [Development Orchestrator](../skills/development-orchestrator/SKILL.md)
 - [Review Enforcer](../skills/review-enforcer/SKILL.md)
+- [Report Output Manager](../skills/report-output-manager/SKILL.md)
 - [Sub-agent report template](../skills/report-output-manager/references/sub-agent-report-template.md)
 - [Execution Cost Stabilizer](../skills/execution-cost-stabilizer/SKILL.md)
 

--- a/design/adaptive-agent-assignment-design.md
+++ b/design/adaptive-agent-assignment-design.md
@@ -4,7 +4,7 @@
 
 delegated taskの性質に応じて、sub-agentへ適切なモデル、推論強度、fork方式を割り当てる。
 
-単純なfile数や一律のreviewer設定ではなく、工程、判断負荷、不確実性、変更半径、重要度、反復性、分割可能性を評価する。選定結果と実際にruntimeへ適用されたprofileを分離し、割当理由とfallbackをreportへ残す。
+単純なfile数や一律のreviewer設定ではなく、工程、判断負荷、不確実性、変更半径、重要度、反復性、分割可能性を評価する。選定結果と実際にruntimeへ適用されたprofileを分離し、割当理由、承認状態、fallbackをreportへ残す。
 
 本設計はIssue #13の「sub-agentの使用モデルがSkillへ定義されていない」という問題を解消する。
 
@@ -15,15 +15,11 @@ delegated taskの性質に応じて、sub-agentへ適切なモデル、推論強
 - `codex-delegation-executor`によるmain agentとsub-agentのexecutor選択
 - `sub-agent-task-manager`によるbounded taskとreport契約
 - `spawn-agent-model-overrides.md`によるhidden model overrideの適用方法
-- `development-orchestrator`によるimplementation modelの事前ユーザー確認
+- `development-orchestrator`によるworkflow lifecycle管理
 
-一方、taskの性質からmodelとreasoning effortを選ぶ中央規則がなかった。そのため、callerごとにprofileが固定または手動選択され、次を区別できなかった。
+一方、taskの性質からmodelとreasoning effortを選ぶ中央規則がなかった。そのため、callerごとにprofileが固定または手動選択され、機械的作業、通常実装、判断中心作業、難しい単一問題、独立workstream分割を区別できなかった。
 
-- 既に手順が決まった反復作業
-- 通常のbounded implementation
-- 要件、設計、難しいdebug、reviewのような判断中心作業
-- 一つの難問へ深く取り組む場合
-- 複数の独立workstreamへ分割する場合
+また、`Sol xhigh`と`Sol max`は実行コストが高いため、品質要件だけで自動選定すると意図せず高コストなdispatchが発生する。そこで、この2 profileは自動選定の最終結果ではなく、ユーザー承認が必要なproposalとして扱う。
 
 ## 設計原則
 
@@ -45,6 +41,27 @@ delegated taskの性質に応じて、sub-agentへ適切なモデル、推論強
 
 モデルtierを上げる条件とreasoning effortを上げる条件を混同しない。
 
+### `Sol xhigh` / `Sol max`はapproval-gated
+
+`Sol xhigh`と`Sol max`は自動dispatchしない。
+
+selectorがどちらかを必要と判断した場合は、次の状態遷移にする。
+
+```text
+automatic classification
+  -> proposed_profile = Sol xhigh | Sol max
+  -> userへ理由とcost noticeを提示
+  -> STOP
+      |-- approve -> requestedへ昇格 -> runtime application
+      `-- reject  -> xhigh/maxを除外して再計算
+```
+
+approval前は`requested`と`applied`を空にする。repository policy、過去の別taskでの承認、沈黙、推測したユーザー嗜好はapprovalとして扱わない。
+
+現在taskでユーザーが明示的に`Sol xhigh`または`Sol max`を指定している場合のみ、その指示自体をapproval evidenceとして扱える。
+
+このgateはreviewやrelease auditを含む全task kindへ適用し、repository policyとautomatic selectionより優先する。
+
 ### Ultraをreasoning effortにしない
 
 参考記事のUltra相当は、単一agentの推論強度ではなく、独立workstreamへ分割し親が統合するmulti-agent戦略として扱う。
@@ -59,15 +76,15 @@ delegated taskの性質に応じて、sub-agentへ適切なモデル、推論強
 
 大きなdiffでも、手順と期待結果が完全に決まりdeterministic validatorがある反復処理ならLuna候補になりうる。
 
-### requestedとappliedを分離する
+### proposed / requested / appliedを分離する
 
-runtime制約により、選択したprofileがそのまま適用されない場合がある。
+profile stateは次の3段階を区別する。
 
-- full-history forkはparent profileを継承する
-- hidden overrideがbackendでrejectされる可能性がある
-- runtimeでmodelが利用不能な場合がある
+- `proposed_profile`: cost gateなどによりまだ選択確定していない候補
+- `requested`: 承認済みまたは通常自動選定され、runtimeへ要求するprofile
+- `applied`: runtimeへ実際に適用されたprofile
 
-reportでは`requested`と`applied`、`application_status`を別に記録し、未適用profileを適用済みとしない。
+full-history fork、hidden override rejection、runtime model unavailableなどにより`requested`と`applied`が異なる場合がある。未承認proposalを`requested`または`applied`として記録してはならない。
 
 ## 責務配置
 
@@ -75,7 +92,8 @@ reportでは`requested`と`applied`、`application_status`を別に記録し、�
 
 - workflow開始時にroutineなimplementation model確認を要求しない
 - userまたはrepositoryが明示したoverrideやbudget制約だけを取得する
-- executor、assessment、requested/applied profileをlifecycle evidenceとして保持する
+- `Sol xhigh` / `Sol max` proposalが出た場合はuser confirmation boundaryとしてworkflowを停止する
+- executor、assessment、proposal/approval、requested/applied profileをlifecycle evidenceとして保持する
 
 ### `codex-delegation-executor`
 
@@ -95,14 +113,16 @@ reportでは`requested`と`applied`、`application_status`を別に記録し、�
 ### `sub-agent-task-manager`
 
 - 各bounded taskのmodel tier、reasoning effort、fork policyを選ぶ
+- `Sol xhigh` / `Sol max`ではproposalを生成し、approvalがない限りdispatchしない
 - explicit overrideの優先順位を適用する
-- requested profileをruntimeへ適用する
+- approved requested profileをruntimeへ適用する
 - applied profileとfallbackをreportへ記録する
 - taskが独立分割可能になった場合はdispatch前に`codex-delegation-executor`へ戻す
 
 ### `execution-cost-stabilizer`
 
-- `max`またはmulti-agentを使う前に、再実行、過剰parallelism、evidence再利用を確認する
+- `max` proposalまたはmulti-agentを使う前に、再実行、過剰parallelism、evidence再利用を確認する
+- `Sol xhigh` / `Sol max` proposalのcost rationaleを支援する
 - costだけを理由に必要なmodel floorを下げない
 
 ## 処理flow
@@ -126,6 +146,12 @@ codex-delegation-executor
           |-- model tier selection
           |-- reasoning effort selection
           |-- fork policy selection
+          |
+          |-- Sol xhigh/max ?
+          |       |-- yes -> proposal + cost notice -> USER APPROVAL STOP
+          |       `-- no  -> requested
+          |
+          |-- approved proposal -> requested
           |-- requested -> applied resolution
           |-- report pre-creation
           v
@@ -147,6 +173,9 @@ constraints:
   user_override: null
   repository_policy: null
   runtime_availability: known | unknown
+approval:
+  required: false
+  status: not_required | pending | approved | rejected
 ```
 
 非自明な分類にはsource evidenceを付ける。不明な場合は低く見積もらず、uncertaintyを上げる。
@@ -176,18 +205,33 @@ constraints:
 | open-ended or cross-layer investigation | Sol `high` |
 | initial normal review | Sol `high` |
 | focused fix verification | Terra `high` |
-| independent final review / release audit | Sol `xhigh` |
+| independent final review / release audit | propose Sol `xhigh`, then stop for approval |
 
 失敗したdeterministic verificationは同じLuna taskとして再実行せず、investigationへ再分類する。
 
+### `xhigh` gate
+
+Sol `xhigh`が適切と判断された場合、selectorは次を実行する。
+
+- `proposed_profile`へSol `xhigh`を設定
+- Sol `high`では不足する理由を記録
+- higher effortによるexecution cost増加をユーザーへ伝える
+- explicit approvalがなければdispatchを停止
+
+承認後のみ`requested`へ昇格する。
+
 ### `max` gate
 
-`max`は次を全て満たす場合だけ使用する。
+Sol `max`は次を全て満たす場合だけproposal可能とする。
 
 - 一つの問題が主要blockerである
 - workstreamへ安全に分割できない
-- `high`または`xhigh`で不足する具体的理由がある
+- Sol `high`では不足する具体的理由がある
 - `execution-cost-stabilizer`でscopeとevidence再利用を確認した
+- ユーザーへcost notice付きで提案する
+- explicit approvalを得るまでdispatchしない
+
+`xhigh`を先に実行する必要はない。task evidenceから直接`max`候補になりうるが、いずれの場合もapproval gateは必須である。
 
 ### multi-agent gate
 
@@ -200,49 +244,70 @@ constraints:
 - parent synthesisが定義されている
 - parallelismの実益がある
 
-各taskは別々にprofile選定する。
+各taskは別々にprofile選定する。分割後の個別taskがSol `xhigh`またはSol `max`候補なら、そのtaskごとにapproval gateを通す。
 
 ## override優先順位
 
-1. 明示的なuser instruction
-2. authoritative repository policy
-3. runtime capabilityとmodel availability
-4. automatic selection
+1. 明示的なcurrent-task user instruction
+2. 未承認Sol `xhigh` / `Sol max`に対するmandatory user-approval gate
+3. authoritative repository policy
+4. runtime capabilityとmodel availability
+5. automatic selection
 
 explicit overrideがautomatic floorを下回る場合も、silentに置換しない。mismatchを記録し、governing authorityに従う。
 
-model tierだけが指定された場合はreasoning effortを自動選定できる。reasoning effortだけが指定された場合はmodel tierを自動選定できる。
+repository policyがSol `xhigh`またはSol `max`を要求していても、それはproposalの根拠にはなるがuser approvalの代替にはならない。
 
 ## dispatch profile schema
 
+通常profile:
+
 ```yaml
 dispatch_profile:
-  schema_version: 1
+  schema_version: 2
   selection_source: automatic | user_override | repository_policy
   task_kind: review
-  signals:
-    work_class: judgment_heavy
-    uncertainty: high
-    change_radius: cross_module
-    criticality: high
-    repetition: single
-    decomposability: single
-    context_need: fresh
   requested:
     model_tier: sol
     model: gpt-5.6-sol
-    reasoning_effort: xhigh
+    reasoning_effort: high
     fork_turns: none
-    parallelism_mode: single_agent
   applied:
     model: gpt-5.6-sol
-    reasoning_effort: xhigh
+    reasoning_effort: high
     fork_turns: none
   application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
-  reasons: []
-  constraints: []
-  escalation_triggers: []
+  approval:
+    required: false
+    status: not_required
 ```
+
+approval待ちprofile:
+
+```yaml
+dispatch_profile:
+  schema_version: 2
+  selection_source: automatic | repository_policy
+  proposed_profile:
+    model_tier: sol
+    model: gpt-5.6-sol
+    reasoning_effort: xhigh | max
+    fork_turns: none
+  requested: null
+  applied: null
+  application_status: awaiting_user_approval
+  approval:
+    required: true
+    status: pending
+    approved_by: null
+    approval_evidence: null
+  reasons:
+    - why Sol high is insufficient
+  cost_notice:
+    - higher reasoning effort increases execution cost
+```
+
+承認後はapproval evidenceを保存し、approved proposalを`requested`へ昇格してからruntime applicationへ進む。
 
 ## fork制約
 
@@ -250,6 +315,7 @@ dispatch_profile:
 - bounded historyだけ必要なら明示的なpositive partial fork
 - full-history forkはparent profileを継承し、`inherited_parent_profile`として記録
 - model specializationを優先する場合は、必要contextをtask-local promptへ明示してfresh spawnする
+- approvalはfork制約を上書きしない
 
 ## 再分類とescalation
 
@@ -258,6 +324,7 @@ dispatch_profile:
 - 問題自体は同じだが慎重さが不足する場合: reasoning effortを上げる
 - 問題の性質または必要判断能力が変わる場合: model tierを上げる
 - 独立workstreamが判明した場合: multi-agent分割判断へ戻る
+- escalation結果がSol `xhigh`またはSol `max`ならproposalへ変換し、user approval stopへ入る
 - runtime rejectionの場合: spawn適用contractに従いrequested/appliedを分離する
 
 理由のないretry escalationは禁止する。
@@ -266,44 +333,23 @@ dispatch_profile:
 
 ### formatting対象が多数ある
 
-- mechanical
-- low uncertainty
-- local
-- ordinary
-- high volume
-
 選定: Luna `low`。validator解釈が必要ならLuna `medium`。
 
 ### accepted designに基づく通常実装
-
-- bounded technical
-- lowからmedium uncertainty
-- localまたはcross-module
-- ordinary
 
 選定: Terra `medium`。module間regression reasoningが必要ならTerra `high`。
 
 ### intermittent concurrency failureの原因調査
 
-- judgment heavy
-- high uncertainty
-- cross-moduleまたはcross-system
-- high criticality
-
-選定: Sol `high`。一つの非分割root causeへ深い証明が必要な場合だけSol `max`。
+通常はSol `high`。一つの非分割root causeへ深い証明が必要でSol `high`では不足すると判断した場合はSol `max`を提案し、ユーザー承認まで停止する。
 
 ### independent final review
 
-- judgment heavy
-- high uncertainty
-- scopeに応じたchange radius
-- release criticality
-
-選定: Sol `xhigh`。過去review conclusionを引き継がないfresh spawnを使う。
+release-criticalな独立final reviewではSol `xhigh`を候補として提案する。Sol `high`との差とcost noticeを提示し、ユーザー承認前にはreviewerをdispatchしない。
 
 ### frontend、backend、migrationが独立している
 
-単一のSol `max`へまとめない。write ownershipとdependencyを確認し、3 bounded taskへ分割する。各taskは個別にTerraまたはSolを選定し、parentが統合する。
+単一のSol `max`へまとめない。write ownershipとdependencyを確認し、3 bounded taskへ分割する。各taskは個別にLuna、Terra、Solを選定し、parentが統合する。
 
 ## 既存設計との関係
 
@@ -323,7 +369,7 @@ CodexSkill repositoryの方針に従いTDDは適用しない。
 - `python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip`
 - active relative Markdown link検証
 - current PR HEAD SHAと一致するGitHub Actions runの確認
-- selected/applied profile、Ultraとreasoning effort、full-history forkのcontract review
+- proposed/requested/applied profile、approval gate、Ultraとreasoning effort、full-history forkのcontract review
 
 ## 非対象
 

--- a/design/skill-hierarchy-design.md
+++ b/design/skill-hierarchy-design.md
@@ -56,7 +56,7 @@ runtime wrapper
 
 ### Runtime wrapper
 
-Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、一度だけのfresh independent reviewerと同reviewerによるbounded closure、report path、persistence、completion gateを所有する。
+Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、一度だけのfresh independent reviewerと同reviewerによるbounded closure、report path reservation identity、phase-specific report persistence、completion gateを所有する。
 
 ChatGPT wrapperはcurrent-chat permission、connector、repository／PR persistence、chat continuity、cross-chat handoffを所有する。
 
@@ -105,17 +105,23 @@ development-orchestrator [親]
 │  │  └─ implementation-worker
 │  ├─ design-executor
 │  ├─ sub-agent-task-manager [verification]
-│  └─ report-output-manager [wrapper]
+│  └─ report-output-manager [normal persistence]
 │     ├─ work-context-manager
 │     └─ report-writer
 ├─ review-enforcer [wrapper]
 │  ├─ work-context-manager
 │  ├─ markdown-word-checker
-│  ├─ sub-agent-task-manager [normal reviewer]
+│  ├─ sub-agent-task-manager [normal reviewer / normal_persistence]
 │  │  └─ review-worker
-│  ├─ sub-agent-task-manager [fresh independent final reviewer]
+│  ├─ report-output-manager [normal-review persistence]
+│  │  ├─ work-context-manager
+│  │  └─ report-writer
+│  ├─ report-output-manager [independent reservation-only]
+│  │  └─ work-context-manager
+│  ├─ sub-agent-task-manager [fresh independent final reviewer / deferred_attestation / reuse reservation]
 │  │  └─ review-worker
-│  └─ report-output-manager
+│  └─ report-output-manager [passing attestation persistence]
+│     ├─ work-context-manager
 │     └─ report-writer
 ├─ progress-sync-manager
 ├─ git-workflow-manager
@@ -178,7 +184,9 @@ normal review cycleが収束した後、independent final reviewのtargetをfree
 
 ### 独立最終レビュー
 
-pre-freeze gateを通過し、全ての非final変更がcommitされた後に、independent-final-review report pathを予約する。`local_execution_available`ではvalidated local committed HEADをpushせずに、`remote_ci_only`ではauthorized pre-review pushとmatching current-HEAD CIをformal evidenceとして、そのHEADを`reviewed implementation HEAD`に固定する。
+pre-freeze gateを通過し、全ての非final変更がcommitされた後に、`review-enforcer`が`report-output-manager`のreservation-only phaseを一度だけ実行する。exact independent-final-review report pathをmetadataとして予約し、`reservation_owner: review-enforcer`、stable `reservation_identity`、reserved path、reservation evidence、`reservation_state: metadata_only`を記録する。ここでは`report-writer`を呼ばず、repository report fileを作成・編集しない。
+
+その後、`local_execution_available`ではvalidated local committed HEADをpushせずに、`remote_ci_only`ではauthorized pre-review pushとmatching current-HEAD CIをformal evidenceとして、そのHEADを`reviewed implementation HEAD`に固定する。
 
 fresh reviewerは次を満たす。
 
@@ -187,13 +195,17 @@ fresh reviewerは次を満たす。
 - review fixを実装していないこと
 - 原則`fork_turns: "none"`で起動すること
 - frozen reviewed implementation HEADを対象とすること
-- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
+- 要件、設計、final diff、全変更file、直接依存、tracking、normal report、current HEAD固有validation evidenceを読むこと
 - reviewer identityとindependence evidenceを記録すること
 - `review-worker`のindependent final reviewを実行すること
 - 過去review結論を読む前に独立passを行うこと
-- normal review reportとは別にindependent final review reportを作ること
+- `review-enforcer`が予約した`pre_reserved_report_path`と`reservation_identity`を`sub-agent-task-manager`からmetadataとして受け取ること
+- そのreservationを再作成せず、reserved repository report fileを作成・編集しないこと
+- findings、coverage、commands/evidence、verdict、risks、unexploredをstructured evidenceとしてparentへ返すこと
 
-独立最終レビューはtask lifecycleで一度だけの全coverage passである。required findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationとnormal reviewerのfix verificationへ戻る。HEAD更新後は最初の独立reviewerが、completeness matrixを満たしたfinding／CI-deltaだけをbounded closureとして確認し、新しい観点や再度の全coverage passを行わない。
+`sub-agent-task-manager`はindependent-final dispatch時に予約を作成しない。`review-enforcer`から渡されたpre-freeze reservation identityを検証・継承し、欠落・曖昧・post-freeze reservationであればdispatchをblockする。
+
+独立最終レビューはtask lifecycleで一度だけの全coverage passである。required findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationとnormal reviewerのfix verificationへ戻る。HEAD更新後は最初の独立reviewerが、同じreservation identityを保持したまま、completeness matrixを満たしたfinding／CI-deltaだけをbounded closureとして確認し、新しい観点や再度の全coverage passを行わない。passing verdict前にreserved report fileを作らない。
 
 normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
 
@@ -201,12 +213,14 @@ normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身の
 
 独立最終レビューのtechnical verdictは`reviewed implementation HEAD`へ結び付ける。
 
-詳細reportをrepositoryへ保存する必要がある場合、次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
+passing verdict後に詳細reportをrepositoryへ保存する場合だけ、`report-output-manager`のattestation-persistence phaseで`report-writer`を呼び、review開始前に予約した同じpathへreportを初めてmaterializeする。次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
 
-- independent-final-review report pathはreview開始前に予約済みである
+- independent-final-review report pathはreview開始前に`review-enforcer`が一度だけmetadata予約している
+- stable `reservation_identity`がreview dispatch、bounded closure、attestation persistenceで同一である
+- passing verdict前にreserved report fileを作成・編集していない
 - report-attestation commitのfirst parentはreviewed implementation HEADである
 - reviewed implementation HEADの後に存在するcommitはこの1件だけである
-- diffは予約済みindependent-final-review report pathだけを変更する
+- diffはreservation identityに結び付くindependent-final-review report pathだけを変更する
 - reportはreviewed implementation HEADとadministrative attestationであることを明記する
 - executable、Skill、design、workflow、configuration、tracking、feedback、handoff、product fileを変更しない
 - report-attestation commit以後にrepository commitを作らない
@@ -427,17 +441,17 @@ Release時の共通file複製とrepository相対link書換は行わない。
 14. normal cycle収束後、end-of-Issue Skill-gap decisionを行う。
 15. current scopeで必要な`skill-authoring-wrapper`処理を実行し、feedback classification、feedback ledger、normal handoffを保存する。
 16. steps 14から15でrepositoryが変わった場合、validation、report、tracking、commit、verification routeに従うpush、normal fix verificationを再実施する。
-17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、independent-final-review report pathを予約する。
+17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、`review-enforcer`が`report-output-manager` reservation-only phaseを一度だけ実行してindependent-final-review report pathとstable reservation identityをmetadata予約する。report fileは作らない。
 18. current HEADをreviewed implementation HEADとしてfreezeする。
-19. 別fresh reviewerによる独立最終reviewを実施する。
-20. repository changeが必要になった場合はterminal stateを無効化し、normal cycleと同一independent reviewerのbounded finding／CI-delta closureへ戻る。
-21. passing reportを保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
+19. `sub-agent-task-manager`へpre-reserved path／reservation identityを渡し、再予約せず、別fresh reviewerによる独立最終reviewを`deferred_attestation`で実施する。reviewerはrepository report fileを編集せずstructured evidenceをparentへ返す。
+20. repository changeが必要になった場合はterminal stateを無効化し、normal cycleと同一independent reviewerのbounded finding／CI-delta closureへ戻る。同じreservation identityを保持し、passing verdict前にreportをpersistしない。
+21. passing reportを保存する場合だけ、`report-output-manager` attestation-persistence phaseで`report-writer`を呼び、予約済みreport pathへ初めてmaterializeする。予約pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
 22. report-attestation commitをfinal pushする。
 23. authorized PRを作成または更新する。
 24. publication後にexact-head `pull_request` required CIをmerge gateとして一度待つ。`remote_ci_only`ではroute内のmatching current-HEAD CIも正式verification evidenceとして扱う。
-25. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、validation evidenceを記録する。
-24. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
-25. mergeは利用者が行う。
+25. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、reservation identity、validation evidenceを記録する。
+26. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
+27. mergeは利用者が行う。
 
 ## Skill一覧
 
@@ -446,8 +460,8 @@ Release時の共通file複製とrepository相対link書換は行わない。
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
 | `development-orchestrator` | task選定から設計、実装、検証、レビュー、Git提出、pre-freeze gate、final attestation boundaryまでを統括する | 親が実行 |
-| `codex-delegation-executor` | 実作業の委譲先と実行profileを決める | 親が実行 |
-| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、report契約を固定する | 親が実行 |
+| `codex-delegation-executor` | 実作業の委譲先、executor、decomposition policy／dispositionを決め、sub-agent evidenceを統合する | 親が実行 |
+| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、role plan、runtime observability、report persistence契約を固定する | 親が実行 |
 | `execution-cost-stabilizer` | retry、parallelism、実行コストを安定化する | 親が実行 |
 | `feedback-autonomy-boundary-manager` | 自律継続と利用者確認の境界を決める | 親が実行 |
 | `skill-authoring-wrapper` | core Skill／runtime wrapperをrepository標準へ揃える | 親が実行 |
@@ -484,7 +498,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze gate、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
+| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze reservation、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
 | `markdown-word-checker` | Markdown lintと表記ルールを検証する | 親が実行 |
 | `feedback-coding-standards-enforcer` | coding standardを検証する | 親が実行 |
 | `feedback-issue-intake-fallback-manager` | Issue取得失敗時に要件を確保する | 親が実行 |
@@ -498,7 +512,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 | `git-commit-manager` | scoped commitを作成する | 親が実行 |
 | `git-pr-submitter` | PRを作成または更新する | 親が実行 |
 | `git-review-followup-manager` | review findingをimplementation flowへ戻す | 親が実行 |
-| `report-output-manager` | report path／persistence／report-attestationを管理し、`report-writer`を呼び出すCodex wrapper | 親が実行 |
+| `report-output-manager` | normal persistence、independent reservation-only、passing attestation persistenceをphase別に管理するCodex wrapper | 親が実行 |
 
 ### ChatGPT runtime wrapper
 
@@ -517,7 +531,9 @@ Release時の共通file複製とrepository相対link書換は行わない。
 - implementationは自分の変更へreview verdictを出さない。
 - reviewerはfindingを実装しない。
 - finding identityとsource severityを維持し、severity変更はsource／new severity、理由、承認主体を明示する。
-- reviewは詳細reportへ記録する。
+- reviewは詳細reportへ記録する。ただしindependent-final `deferred_attestation`ではpassing verdict前にrepository reportを作成せず、structured evidenceをparentが保持し、passing後に同一reservation identityのpathへattestationとしてpersistする。
+- sub-agentのexact final model／reasoningがparent-visibleでないruntimeでは、successful spawnだけを根拠に`applied`を断定しない。`requested`、role plan、planned runtime profile、profile observabilityとexplicit unverified stateを保持する。
+- independent-final report reservationは`review-enforcer`がfreeze前に一度だけ所有し、`sub-agent-task-manager`はそのreservation identityを検証・継承して再予約しない。
 - CIは対象current HEAD SHAに紐づくrunだけを使用する。
 - 別SHAのrunを代用しない。
 - report、tracking、handoffは自己を含む将来のcommit SHAを要求しない。`commit_pending`、technical HEAD、administrative parentを区別する。

--- a/reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
+++ b/reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
@@ -1,0 +1,785 @@
+schema_version: 3
+producer:
+  skill: chat-implementation-worker
+  mode: initial implementation
+  generated_at: 2026-08-26T13:21:38+09:00
+
+repository: ssaattww/CodexSkill
+issue_or_pr: "Issue #13 / PR #65"
+task_id: "Issue #13"
+branch: feat/adaptive-agent-assignment
+base_ref: main
+target:
+  current_head: 8731e75427aacada40db2fe1a2ceb8376d797266
+  reviewed_head: null
+  commit_range: 2ea9522d494b2b37c1d8aabb340a3113cfd18240...8731e75427aacada40db2fe1a2ceb8376d797266
+
+authoritative_requirements:
+  - source: user_instruction
+    reference: "https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb"
+    summary: 参考記事を基に適切なagentを割り当てる仕組みを実装し、PR作成まで行う。
+  - source: repository_instruction
+    reference: AGENTS.md
+    summary: CodexSkill repositoryの保守へTDDを適用せず、既存validatorとdistribution buildで検証する。
+  - source: issue
+    reference: "https://github.com/ssaattww/CodexSkill/issues/13"
+    summary: sub-agentの使用modelをtask種別に応じて定義する。
+  - source: repository_instruction
+    reference: Project Instruction
+    summary: repository操作、Issue、PR、PR commentにはGitHub connectorを使用し、詳細reportと簡易PR commentを残し、mergeしない。
+  - source: repository_instruction
+    reference: Project Instruction CI rule
+    summary: PR current HEAD SHAとworkflow runのhead_shaが一致するrunだけをCI evidenceとして使用する。
+
+development_policy:
+  method: non-TDD repository maintenance
+  testing_order: implementation後にrepository Skill validator、active-link validation、ChatGPT worker ZIP buildを実行する。
+  governing_source: AGENTS.md
+validation_plan:
+  commands:
+    - python3 scripts/verify_skill_repository.py
+    - python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip
+    - python3 -m zipfile -l chatgpt-worker-skills.zip
+  required_failure_diagnostics:
+    - test result
+    - standard output
+    - standard error
+    - failure investigation logs and artifacts when validation fails
+blocked: []
+
+authorized_actions:
+  - read_repository
+  - edit_documentation
+  - edit_configuration
+  - write_handoff
+  - write_report
+  - create_branch
+  - commit
+  - push
+  - create_pr
+  - update_pr
+  - comment_pr
+write_boundary:
+  allowed:
+    - path_or_operation: skills/sub-agent-task-manager/**
+      reason: per-task profile selectionとspawn application contractの更新対象。
+    - path_or_operation: skills/codex-delegation-executor/SKILL.md
+      reason: executor selectionとmulti-agent decompositionの責務owner。
+    - path_or_operation: skills/development-orchestrator/SKILL.md
+      reason: routine model confirmationをautomatic profile selectionへ接続する。
+    - path_or_operation: design/adaptive-agent-assignment-design.md
+      reason: agent assignment architectureと選定規則の設計正本。
+    - path_or_operation: reports/issue-13-adaptive-agent-assignment-*
+      reason: implementation reportとlossless handoffの保存先。
+    - path_or_operation: PR #65 metadata and comments
+      reason: PR作成、検証結果、handoffを利用者へ提示する。
+  forbidden:
+    - path_or_operation: main branch direct update
+      reason: 変更はfeature branchとPR経由で提出する。
+    - path_or_operation: tasks/tasks-status.md manual edit
+      reason: repository contract上、指定されたtask tracking Skillだけが更新する。
+    - path_or_operation: unrelated repository files
+      reason: Issue #13 scope外の変更を避ける。
+    - path_or_operation: merge PR #65
+      reason: mergeは利用者が実施する。
+
+scope:
+  - bounded taskの性質からLuna、Terra、Solのmodel tierを選ぶ中央contractを追加する。
+  - model tierとreasoning effortを独立に選択する。
+  - uncertainty、change radius、criticality、repetition、decomposability、context needをassessmentする。
+  - requested profileとruntimeへ実際に適用されたprofileを分離する。
+  - full-history fork、runtime rejection、fallback、capability gapをreport evidenceへ残す。
+  - Ultra相当をreasoning effortではなくmulti-agent decompositionとして扱う。
+  - existing delegation architectureへ接続し、新規Skillを増やさない。
+non_goals:
+  - Codex runtime本体へのmodel router実装。
+  - runtime model availability APIの新設。
+  - model価格だけに基づくrouting。
+  - explicit userまたはrepository overrideのsilent変更。
+  - full-history forkへ異なるmodelを強制すること。
+  - reasoning_effortとしてultraを追加すること。
+  - task tracking fileの手動更新。
+  - merge。
+
+files:
+  changed:
+    - path: skills/sub-agent-task-manager/references/agent-profile-selection.md
+      purpose: model tier、reasoning effort、task default、override、fork、escalation、evidence schemaの中央reference。
+    - path: skills/sub-agent-task-manager/SKILL.md
+      purpose: per-task profile selectionとactual runtime applicationをrequired flowへ追加。
+    - path: skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
+      purpose: selectionとapplicationを分離し、requested/applied、full-history、fallbackを定義。
+    - path: skills/codex-delegation-executor/SKILL.md
+      purpose: delegation assessmentとmulti-agent decomposition gateを追加。
+    - path: skills/development-orchestrator/SKILL.md
+      purpose: routine implementation model confirmationをautomatic selectionへ置換。
+    - path: design/adaptive-agent-assignment-design.md
+      purpose: architecture、input schema、selection matrix、flow、examples、validation方針を記録。
+    - path: reports/issue-13-adaptive-agent-assignment-implementation-20260826.md
+      purpose: implementation、validation、CI、riskの詳細report。
+  inspected:
+    - path: AGENTS.md
+      purpose: CodexSkillのnon-TDD方針とSkill-first instructionを確認。
+    - path: tasks/tasks-status.md
+      purpose: manual task tracking update禁止とcurrent stateを確認。
+    - path: .github/workflows/release-chatgpt-worker-skills.yml
+      purpose: repository validator、ZIP build、artifact uploadが既に存在することを確認。
+    - path: scripts/verify_skill_repository.py
+      purpose: repository Skill architecture、active relative link、design synchronizationのvalidation内容を確認。
+    - path: skills/review-enforcer/SKILL.md
+      purpose: reviewer lifecycleと今回のprofile selection責務の境界を確認。
+    - path: skills/execution-cost-stabilizer/SKILL.md
+      purpose: max、parallelism、rerun costのgate ownerを確認。
+    - path: skills/skill-authoring-wrapper/references/responsibility-placement-policy.md
+      purpose: model selection責務を直接利用されうるsub-agent-task-managerへ置く判断根拠を確認。
+    - path: "https://github.com/ssaattww/CodexSkill/issues/13"
+      purpose: model assignment不足のoriginal requirementを確認。
+    - path: "https://github.com/ssaattww/CodexSkill/issues/46"
+      purpose: full-history forkとmodel override制約のrelated issueを確認。
+    - path: "https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb"
+      purpose: Luna、Terra、Sol、Max、Ultraのtask allocation方針を確認。
+    - path: "https://developers.openai.com/api/docs/models"
+      purpose: current model IDsとsupported reasoning effortを確認。
+    - path: "https://developers.openai.com/api/docs/guides/latest-model"
+      purpose: multi-agent decomposition guidanceを確認。
+  intentionally_untouched:
+    - path_or_area: tasks/tasks-status.md
+      reason: repository contract上、指定されたtask tracking Skillだけが更新する。
+    - path_or_area: design/skill-hierarchy-design.md
+      reason: Skill topologyとdependency edgeを変更していない。
+    - path_or_area: skills/design/skill-hierarchy-design.md
+      reason: hierarchy mirrorの同期対象となるtopology変更がない。
+    - path_or_area: .github/workflows/release-chatgpt-worker-skills.yml
+      reason: CodexSkill向けvalidator、ZIP build、artifact uploadが既に存在し、RevMem専用診断artifact追加規則は適用外。
+    - path_or_area: skills/review-enforcer/SKILL.md
+      reason: reviewer lifecycleは変更せず、review modeをselector inputとして使用する。
+
+commands:
+  - command: python3 scripts/verify_skill_repository.py
+    purpose: Skill names、declared dependencies、active relative links、forbidden runtime paths、hierarchy design synchronizationを検証する。
+    exit_code: 0
+    result: passed
+    head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+    evidence: GitHub Actions run 32929830171 / build job 98059811771 / step Validate repository Skill architecture and active links。
+  - command: python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip
+    purpose: ChatGPT wrapperとcore Skill distribution ZIPを生成する。
+    exit_code: 0
+    result: passed
+    head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+    evidence: GitHub Actions run 32929830171 / build job 98059811771 / step Build and verify ChatGPT wrapper and core Skill ZIP。
+  - command: python3 -m zipfile -l chatgpt-worker-skills.zip
+    purpose: generated ZIPの内容を読み取り可能であることを検証する。
+    exit_code: 0
+    result: passed
+    head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+    evidence: GitHub Actions run 32929830171 / build job 98059811771 / step Build and verify ChatGPT wrapper and core Skill ZIP。
+
+tests:
+  - name: CodexSkill TDD red-green cycle
+    phase: not_applicable
+    result: not_run
+    head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+    evidence: AGENTS.mdによりCodexSkill repository maintenanceはnon-TDD。
+  - name: repository Skill architecture and active-link validation
+    phase: verification
+    result: passed
+    head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+    evidence: workflow run 32929830171、build job 98059811771。
+  - name: ChatGPT worker Skill ZIP build and listing
+    phase: verification
+    result: passed
+    head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+    evidence: workflow run 32929830171、build job 98059811771。
+
+ci:
+  required: true
+  workflow: Validate and release ChatGPT worker skills
+  run_id: 32929830171
+  head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+  conclusion: success
+  artifacts:
+    - id: 9592803602
+      name: chatgpt-worker-skills-32929830171
+      purpose: validator通過後に生成されたChatGPT worker Skill ZIP。digest sha256:e5a835c0af6afcd6b9573d563e66ea36ce8ca037e451731eab04318f05145448。
+
+implementation:
+  outcome: completed
+  final_head: 8731e75427aacada40db2fe1a2ceb8376d797266
+  commits:
+    - sha: 716594ca5a19e5ad5fe3e718cd445ab4559811f8
+      purpose: adaptive profile selection referenceを追加。
+    - sha: 52a9b63dd4a119aa9410133ec4e0e7e07d3f1183
+      purpose: sub-agent-task-managerへautomatic profile selectionを追加。
+    - sha: 76b49304cdb9d3a54f3d202a6b072584431612e2
+      purpose: spawn application contractをrequested/appliedへ分離。
+    - sha: df3d44be01c9b7022909bd7a2ce614733c820f07
+      purpose: delegation assessmentとmulti-agent decomposition gateを追加。
+    - sha: abf889a0e4955069a3901c99973ee401d1226ce2
+      purpose: orchestratorのroutine model confirmationをautomatic selectionへ置換。
+    - sha: 18694e6bdfd15301afbaf57b2e6596fe52d239e7
+      purpose: 適応型agent割当設計を追加。
+    - sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+      purpose: detailed implementation reportを追加。
+  addressed_findings: []
+  failure_diagnostics:
+    - type: test_result
+      location: GitHub Actions run 32929830171
+      summary: repository validatorとZIP buildは成功し、test failureはない。
+    - type: standard_output
+      location: GitHub Actions build job 98059811771
+      summary: 全verification stepがsuccessで完了した。failure stdoutはない。
+    - type: standard_error
+      location: GitHub Actions build job 98059811771
+      summary: failure stderrはない。
+    - type: artifact
+      location: GitHub Actions artifact 9592803602
+      summary: validation済みChatGPT worker Skill ZIPがuploadされた。
+  blocked_items: []
+  summary:
+    - task特性をmodel tier、reasoning effort、fork policyへ写像する中央contractを追加した。
+    - executor decisionとper-task profile selectionを別責務にした。
+    - Ultra相当をmulti-agent strategyとして定義し、reasoning_effortから除外した。
+    - explicit override、full-history inheritance、runtime rejection、fallbackをlossless evidenceとして残す。
+    - Issue #13をcloseするDraft PR #65を作成した。mergeは行っていない。
+
+review:
+  mode: not_applicable
+  reviewed_head: unknown
+  reviewer:
+    identity: unknown
+    role: not_applicable
+    continuity:
+      previous_reviewer_identity: null
+      changed: false
+      reason: null
+    independence:
+      implemented_change: unknown
+      implemented_review_fix: unknown
+      served_as_normal_reviewer: unknown
+      inherited_conversation: unknown
+      evidence:
+        - chat-implementation-workerはindependent review verdictを生成しない。
+  verdict: not_applicable
+  required_coverage:
+    - criterion: independent implementation review
+      disposition: not_applicable
+      evidence: このhandoffはimplementation workerの成果であり、次actionをexternal reviewとする。
+  validation_assessment:
+    - item: exact-head CI for packet target
+      result: supported
+      evidence: workflow run 32929830171のhead_shaがpacket target 8731e75427aacada40db2fe1a2ceb8376d797266と一致し、conclusion success。
+  reserved_report_paths: []
+  report_attestation:
+    allowed: not_applicable
+    reviewed_implementation_head: null
+    allowed_paths: []
+    required_first_parent: null
+    maximum_commits_after_reviewed_head: null
+    forbidden_path_classes: []
+    no_later_commits_required: not_applicable
+    validation_status: not_applicable
+    validation_evidence:
+      - independent final reviewとreport-attestationは実施していない。
+  summary:
+    - implementation evidenceは作成済み。
+    - independent review verdictは未生成であり、PR reviewが次action。
+
+report:
+  report_type: implementation_report
+  outcome: created
+  persistence_mode: repository_file
+  paths:
+    - reports/issue-13-adaptive-agent-assignment-implementation-20260826.md
+  reviewed_head: null
+  attestation_head: null
+  pr_comments: []
+  summary:
+    - requirements、scope、design、changed files、commits、exact-head CI、risks、next actionを日本語で記録した。
+    - report blob SHAは98c3ed9ad669ecf787611e4345605416d81e13aa。
+
+findings: []
+held: []
+unexplored:
+  - area: hidden collaboration.spawn_agent model/reasoning overrideのlive integration
+    blocker: CodexSkillはSkill contract repositoryであり、CIにspawn fixtureが存在しない。
+    remaining_risk: runtimeがhidden overrideをrejectする可能性がある。
+    verdict_impact: requested/applied分離、parent-owned fallback、capability_gap記録で安全に扱う。implementation completionは妨げない。
+unknown:
+  - field_or_fact: 各accountまたはruntimeで実際に利用可能なmodel一覧
+    reason: runtime availability APIは本repositoryに存在しない。availability failureはapplication_statusへ記録する契約とした。
+not_applicable:
+  - field_or_area: TDD red-green evidence
+    reason: AGENTS.mdによりCodexSkill repository maintenanceはnon-TDD。
+  - field_or_area: independent review verdict
+    reason: chat-implementation-workerはreview verdictを生成しない。
+  - field_or_area: report-attestation commit
+    reason: independent final reviewは実施していない。
+  - field_or_area: merge
+    reason: mergeは利用者が行う。
+remaining_risks:
+  - GPT model familyまたはsupported reasoning effortが将来変更された場合、current mappingの更新が必要になる。
+  - hidden spawn overrideがruntimeでrejectされる可能性があり、その場合はrequested/applied分離とfallback evidenceが必要になる。
+  - automatic classificationはSkill instructionに基づくjudgmentであり、runtime classifier codeではない。
+  - このpacketを保存するtransport commit後はPR HEADが変わるため、final exact-head CIを別途確認し、PR commentへ記録する必要がある。
+
+source_payloads:
+  - source_skill: work-context-manager
+    output_contract_version: unknown
+    content_type: application/yaml
+    payload:
+      repository: ssaattww/CodexSkill
+      task:
+        issue: 13
+        pr: 65
+        mode: initial implementation
+      target:
+        branch: feat/adaptive-agent-assignment
+        base_ref: main
+        base_head: 2ea9522d494b2b37c1d8aabb340a3113cfd18240
+        current_head: 8731e75427aacada40db2fe1a2ceb8376d797266
+        commit_range: 2ea9522d494b2b37c1d8aabb340a3113cfd18240...8731e75427aacada40db2fe1a2ceb8376d797266
+      authority:
+        - user request
+        - root AGENTS.md
+        - Issue #13
+        - Project Instruction
+        - uploaded ChatGPT worker Skills
+      development_policy:
+        method: non-TDD repository maintenance
+        testing_order: implementation then repository validator and distribution build
+        governing_source: AGENTS.md
+      verification_capability: remote_ci_only
+      validation_targets:
+        - repository Skill architecture and active links
+        - ChatGPT worker ZIP build and listing
+        - exact-head pull_request workflow run
+      write_boundary:
+        allowed:
+          - relevant Skill files
+          - adaptive assignment design
+          - implementation report
+          - handoff transport
+          - PR #65 metadata and comment
+        forbidden:
+          - direct main update
+          - unrelated files
+          - manual tasks/tasks-status.md edit
+          - merge
+      blocked: []
+      unknown:
+        - runtime model availability per account
+  - source_skill: implementation-worker
+    output_contract_version: unknown
+    content_type: application/yaml
+    payload:
+      mode: initial implementation
+      scope:
+        - adaptive per-task agent profile selection
+        - delegation assessment
+        - multi-agent decomposition gate
+        - requested/applied runtime evidence
+        - design and report persistence
+      non_goals:
+        - runtime router implementation
+        - model availability API
+        - price-only optimization
+        - task status manual update
+        - merge
+      authoritative_requirements:
+        - user-requested article-based agent assignment
+        - Issue #13 model policy gap
+        - CodexSkill non-TDD policy
+        - exact-head CI rule
+      changes:
+        - path: skills/sub-agent-task-manager/references/agent-profile-selection.md
+          outcome: added
+        - path: skills/sub-agent-task-manager/SKILL.md
+          outcome: updated
+        - path: skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
+          outcome: updated
+        - path: skills/codex-delegation-executor/SKILL.md
+          outcome: updated
+        - path: skills/development-orchestrator/SKILL.md
+          outcome: updated
+        - path: design/adaptive-agent-assignment-design.md
+          outcome: added
+        - path: reports/issue-13-adaptive-agent-assignment-implementation-20260826.md
+          outcome: added
+      intentionally_untouched:
+        - tasks/tasks-status.md
+        - design/skill-hierarchy-design.md
+        - skills/design/skill-hierarchy-design.md
+        - .github/workflows/release-chatgpt-worker-skills.yml
+        - skills/review-enforcer/SKILL.md
+      model_selection_contract:
+        luna: low-uncertainty local ordinary deterministic mechanical or high-volume work
+        terra: ordinary bounded technical work
+        sol: requirement design open investigation cross-system high-criticality and review work
+        reasoning_effort:
+          low: exact low-risk transformation
+          medium: ordinary bounded implementation or deterministic evidence
+          high: multi-factor debugging design or review
+          xhigh: bounded exhaustive high-stakes review or audit
+          max: one exceptionally difficult non-decomposable problem
+        ultra: multi-agent decomposition strategy; never a reasoning_effort value
+      validation:
+        head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+        workflow_run: 32929830171
+        conclusion: success
+        commands:
+          - python3 scripts/verify_skill_repository.py
+          - python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip
+          - python3 -m zipfile -l chatgpt-worker-skills.zip
+        artifact:
+          id: 9592803602
+          name: chatgpt-worker-skills-32929830171
+      commits:
+        - 716594ca5a19e5ad5fe3e718cd445ab4559811f8
+        - 52a9b63dd4a119aa9410133ec4e0e7e07d3f1183
+        - 76b49304cdb9d3a54f3d202a6b072584431612e2
+        - df3d44be01c9b7022909bd7a2ce614733c820f07
+        - abf889a0e4955069a3901c99973ee401d1226ce2
+        - 18694e6bdfd15301afbaf57b2e6596fe52d239e7
+        - 8731e75427aacada40db2fe1a2ceb8376d797266
+      failure_diagnostics:
+        test_result: no failure
+        standard_output: no failure output
+        standard_error: no failure output
+        artifact: validation ZIP uploaded
+      blocked: []
+      unknown:
+        - live hidden spawn override integration
+        - per-runtime model availability
+      risks:
+        - model catalog drift
+        - hidden override rejection
+        - judgment-based classification
+      outcome: completed
+      next_action: persist handoff, verify its exact final HEAD CI, update PR body/comment, mark ready for review
+  - source_skill: report-writer
+    output_contract_version: unknown
+    content_type: text/markdown
+    payload: |
+      # Issue #13 適応型agent割当 実装レポート
+
+      ## メタデータ
+
+      - repository: `ssaattww/CodexSkill`
+      - Issue: `#13 sub-agentの使用モデル`
+      - PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+      - branch: `feat/adaptive-agent-assignment`
+      - base: `main`
+      - base HEAD: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+      - implementation HEAD: `18694e6bdfd15301afbaf57b2e6596fe52d239e7`
+      - report persistence: repository file
+      - report commit SHA: commit後にのみ確定するため本文には記載しない。final PR HEADとexact-head CIはPR commentへ記録する。
+
+      ## 目的
+
+      参考記事のLuna、Terra、Solの役割分担をCodexSkillの既存delegation flowへ取り込み、bounded taskの性質に応じて次を自動選定する。
+
+      - model tier
+      - reasoning effort
+      - fork policy
+      - single-agent executionとmulti-agent decompositionの区別
+
+      modelをpromptへ書くだけでなく、requested profileとruntimeへ実際に適用されたprofileを分離し、選定理由、制約、fallbackをreport evidenceとして残す。
+
+      ## authoritative requirements
+
+      - user instruction: 参考記事を基に適切なagentを割り当てる仕組みを実装し、PR作成まで行う。
+      - repository instruction: root `AGENTS.md`に従いCodexSkill保守へTDDを適用しない。
+      - Issue #13: 機械的実装、設計・調査、reviewで使用modelを分けるSkill契約が不足している。
+      - project instruction: GitHub connectorでrepository、Issue、PRを操作し、詳細reportをrepositoryへ保存し、簡易reportをPR commentへ投稿する。mergeは行わない。
+      - CI instruction: PR current HEAD SHAとworkflow runの`head_sha`が一致するrunだけを使用する。
+
+      ## 参考資料
+
+      - https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb
+      - https://developers.openai.com/api/docs/models
+      - https://developers.openai.com/api/docs/guides/latest-model
+
+      OpenAI公式model catalogに基づき、current model IDを`gpt-5.6-luna`、`gpt-5.6-terra`、`gpt-5.6-sol`として定義した。reasoning effortは`none`、`low`、`medium`、`high`、`xhigh`、`max`をnormalization対象とした。
+
+      参考記事のUltra相当はreasoning effortではなく、独立workstreamを複数agentへ分割するexecution strategyとして扱った。
+
+      ## scope
+
+      - `sub-agent-task-manager`へper-task profile selection責務を追加
+      - model tierとreasoning effortを別軸で選ぶ中央matrixを追加
+      - Luna、Terra、Solのtask floorとtask defaultを追加
+      - uncertainty、change radius、criticality、repetition、decomposability、context needのassessmentを追加
+      - `codex-delegation-executor`へsingle-agentとmulti-agent decompositionのgateを追加
+      - `development-orchestrator`のroutineなimplementation model確認を廃止
+      - explicit userまたはrepository overrideの優先順位を追加
+      - requested profileとapplied profileを分離
+      - full-history fork、runtime rejection、fallback、capability gapの記録契約を追加
+      - 適応型agent割当の設計書を追加
+
+      ## non-goals
+
+      - Codex runtime本体へのmodel router実装
+      - runtime model availability APIの追加
+      - model価格だけに基づくrouting
+      - explicit overrideのsilent変更
+      - full-history forkへ異なるmodelを強制すること
+      - `reasoning_effort: ultra`の追加
+      - task tracking fileの手動更新
+      - merge
+
+      ## 責務配置
+
+      ### `codex-delegation-executor`
+
+      次を所有する。
+
+      - main agent、single sub-agent、multi-agentのexecutor decision
+      - task assessment
+      - independent workstreamの分割gate
+      - parent synthesis
+
+      modelとreasoning effortの中央defaultは持たない。
+
+      ### `sub-agent-task-manager`
+
+      次を所有する。
+
+      - bounded taskごとのmodel tier選定
+      - reasoning effort選定
+      - fork policy選定
+      - requested profileのspawn適用
+      - applied profileとfallbackのreport evidence
+
+      この配置により、`sub-agent-task-manager`が直接使われる経路でもmodel selectionが欠落しない。
+
+      ### `development-orchestrator`
+
+      routineなmodel確認を要求せず、明示overrideまたはbudget constraintだけをworkflow inputとして保持する。
+
+      ## 選定規則
+
+      ### model tier
+
+      - Luna: low uncertainty、local、ordinary criticality、deterministic、mechanicalまたはhigh-volume
+      - Terra: ordinary bounded implementation、focused verification、具体的仮説があるlocalized investigation、focused fix verification
+      - Sol: requirement、design、open-ended investigation、cross-system、高criticality、initial review、independent final review、release audit
+
+      複数条件が該当する場合は最も高いfloorを使う。diff行数よりchange radiusとimpactを優先する。
+
+      ### reasoning effort
+
+      - `low`: exactかつ低riskの変換
+      - `medium`: ordinary bounded implementationまたはdeterministic evidence
+      - `high`: 複数条件、debug、design、review
+      - `xhigh`: boundedで網羅性または重要度が高いreview・audit
+      - `max`: 一つの非常に難しく分割不能な問題
+
+      `max`はgeneric quality settingとして使わず、`execution-cost-stabilizer`を通す。
+
+      ### multi-agent
+
+      次を全て満たす場合だけ分割する。
+
+      - independent workstreamが2件以上
+      - 各taskへscope、non-goals、evidence、report ownerを定義できる
+      - write ownershipが重複しない、またはread-only
+      - blocking dependencyがない
+      - parent synthesisが定義されている
+      - parallelismの実益がある
+
+      各taskは別々にprofileを選ぶ。
+
+      ## changed files
+
+      - `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+        - model tier、reasoning effort、task default、override、fork、escalation、evidence schemaを追加
+      - `skills/sub-agent-task-manager/SKILL.md`
+        - per-task profile selectionとactual runtime applicationをrequired flowへ追加
+      - `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+        - selectionとapplicationを分離し、requested/applied、full-history、fallbackを追加
+      - `skills/codex-delegation-executor/SKILL.md`
+        - delegation assessmentとmulti-agent decomposition gateを追加
+      - `skills/development-orchestrator/SKILL.md`
+        - routineなimplementation model確認をautomatic selectionへ置換
+      - `design/adaptive-agent-assignment-design.md`
+        - architecture、input schema、selection matrix、flow、examples、validation方針を追加
+
+      ## intentionally untouched
+
+      - `tasks/tasks-status.md`
+        - repository契約上、指定されたtask管理Skillだけが更新するため手動変更しない。
+      - `design/skill-hierarchy-design.md`
+      - `skills/design/skill-hierarchy-design.md`
+        - Skill hierarchy topologyとdependency edgeは変更していない。新規Skillも追加していないため同期pairは変更しない。
+      - `.github/workflows/release-chatgpt-worker-skills.yml`
+        - CodexSkillには既にrepository validator、ZIP build、artifact uploadを行うPR workflowが存在する。RevMem向け診断artifact追加規則は本repositoryへ適用しない。
+      - `skills/review-enforcer/SKILL.md`
+        - reviewer lifecycleは変更せず、review modeをbounded task inputとしてselectorが使用する。
+
+      ## commits
+
+      - `716594ca5a19e5ad5fe3e718cd445ab4559811f8`: adaptive profile selection reference追加
+      - `52a9b63dd4a119aa9410133ec4e0e7e07d3f1183`: `sub-agent-task-manager`へautomatic selection追加
+      - `76b49304cdb9d3a54f3d202a6b072584431612e2`: spawn application contract更新
+      - `df3d44be01c9b7022909bd7a2ce614733c820f07`: delegation assessmentとmulti-agent gate追加
+      - `abf889a0e4955069a3901c99973ee401d1226ce2`: orchestratorのroutine model confirmation置換
+      - `18694e6bdfd15301afbaf57b2e6596fe52d239e7`: 適応型agent割当設計追加
+
+      ## development policy
+
+      - method: non-TDD repository maintenance
+      - testing order: implementation後にrepository validatorとdistribution buildを実行
+      - governing source: root `AGENTS.md`
+      - TDD: not applicable
+      - Red/Green evidence: 作成していない
+
+      ## validation route
+
+      - verification capability: `remote_ci_only`
+      - 理由: repository参照・更新はGitHub connectorを使用し、local checkoutを作らずGitHub Actionsをformal validation evidenceとして使用した。
+
+      ## validation evidence for implementation HEAD
+
+      対象HEAD: `18694e6bdfd15301afbaf57b2e6596fe52d239e7`
+
+      - workflow: `Validate and release ChatGPT worker skills`
+      - run ID: `32929673352`
+      - run number: `159`
+      - event route: pull request
+      - run head SHA: `18694e6bdfd15301afbaf57b2e6596fe52d239e7`
+      - conclusion: `success`
+      - build job ID: `98059362580`
+
+      成功step:
+
+      - Checkout target HEAD without write credentials
+      - Validate repository Skill architecture and active links
+      - Build and verify ChatGPT wrapper and core Skill ZIP
+      - Upload validation artifact
+
+      このrunはimplementation HEADと一致する。reportとhandoff追加後はPR HEADが変わるため、このrunをfinal HEADの代用にはしない。final exact-head runはPR commentへ記録する。
+
+      ## failure diagnostics
+
+      - test failure: なし
+      - standard output failure: なし
+      - standard error failure: なし
+      - failure artifact inspection: not applicable
+      - workflow artifact: validation成功時にChatGPT worker ZIPがuploadされた。failure investigationは不要だった。
+
+      ## contract review
+
+      次を差分で確認した。
+
+      - model tierとreasoning effortが別のdecisionとして記述されている
+      - `reasoning_effort: ultra`を生成しない
+      - multi-agent decompositionは`codex-delegation-executor`が所有する
+      - per-task profileは`sub-agent-task-manager`が所有する
+      - user/repository overrideをsilentに変更しない
+      - requested profileをapplied profileとして無条件copyしない
+      - full-history forkはparent profile継承として記録する
+      - runtime rejectionはfallbackまたはcapability gapとして記録する
+      - failed deterministic verificationをinvestigationへ再分類する
+      - existing report、review、nested Codex禁止契約を維持する
+
+      ## blocked / unknown / unexplored
+
+      - blocked: なし
+      - unknown: 実行時に各accountまたはruntimeで利用可能なmodel一覧を取得するAPIは本repositoryに存在しない。
+      - unexplored: hidden `collaboration.spawn_agent` overrideのlive integration test。CodexSkillはSkill contract repositoryであり、CIにspawn fixtureは存在しない。
+
+      ## remaining risks
+
+      - GPT model familyまたはsupported reasoning effortが将来変更された場合、current model mappingの更新が必要になる。
+      - hidden spawn overrideがruntimeでrejectされる可能性は残る。その場合はrequested/appliedを分離し、parent-owned fallbackまたはcapability gapを記録する。
+      - automatic classificationはSkill instructionに基づくjudgmentであり、runtime classifier codeではない。non-obvious classificationにはevidence記録を必須化した。
+      - final report/handoff commitについては、新しいPR HEADに紐づくworkflow runを別途確認する必要がある。
+
+      ## outcome
+
+      Issue #13のmodel assignment不足に対し、既存delegation architectureを維持したまま、task特性からLuna、Terra、Solとreasoning effortを選ぶ中央contractを実装した。
+
+      PR #65を作成済み。mergeは行わない。
+
+      ## next action
+
+      - reportとhandoffをrepositoryへpersistする。
+      - final PR HEADと一致するworkflow runだけを確認する。
+      - PR bodyをfinal stateへ更新し、変更内容と検証結果の簡易reportをPR commentへ投稿する。
+      - PRをready for reviewへ変更する。
+  - source_skill: chat-implementation-worker
+    output_contract_version: unknown
+    content_type: application/yaml
+    payload:
+      wrapper_mode: initial implementation
+      repository_operations:
+        connector: GitHub
+        branch_created: feat/adaptive-agent-assignment
+        pull_request_created: 65
+        report_persisted: reports/issue-13-adaptive-agent-assignment-implementation-20260826.md
+        handoff_path: reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
+        merge_performed: false
+      current_source_head: 8731e75427aacada40db2fe1a2ceb8376d797266
+      exact_head_ci:
+        run_id: 32929830171
+        head_sha: 8731e75427aacada40db2fe1a2ceb8376d797266
+        conclusion: success
+      pending_wrapper_actions:
+        - verify exact-head CI after handoff transport commit
+        - update PR body with final evidence
+        - post concise PR comment
+        - mark PR ready for review
+      blocked: []
+
+extensions:
+  - namespace: openai.agent_assignment.sources
+    payload:
+      article: https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb
+      model_catalog: https://developers.openai.com/api/docs/models
+      latest_model_guidance: https://developers.openai.com/api/docs/guides/latest-model
+      normalized_models:
+        luna: gpt-5.6-luna
+        terra: gpt-5.6-terra
+        sol: gpt-5.6-sol
+      normalized_reasoning_effort:
+        - none
+        - low
+        - medium
+        - high
+        - xhigh
+        - max
+      ultra_interpretation: multi-agent decomposition strategy
+  - namespace: github.persistence
+    payload:
+      pull_request: https://github.com/ssaattww/CodexSkill/pull/65
+      source_head: 8731e75427aacada40db2fe1a2ceb8376d797266
+      source_head_ci_run: 32929830171
+      source_head_ci_artifact: 9592803602
+      report_blob_sha: 98c3ed9ad669ecf787611e4345605416d81e13aa
+      transport_commit_head: unknown until this packet is committed
+      final_exact_head_ci: must be recorded in PR comment after transport commit
+
+next_action:
+  type: external_owner
+  target_skill: none
+  mode: review_and_merge_decision
+  summary: PR #65のfinal exact-head CIと差分をreviewし、利用者がmerge可否を判断する。
+  instructions:
+    - PR bodyと簡易PR commentに記録されるfinal HEAD SHAを基準にする。
+    - workflow runのhead_shaがPR current HEADと一致することを確認する。
+    - detailed implementation reportとこのhandoffを参照する。
+    - implementation workerはindependent review verdictを生成していないため、必要なreviewを別途実施する。
+    - mergeは利用者が行う。
+  required_attachments_or_references:
+    - https://github.com/ssaattww/CodexSkill/pull/65
+    - reports/issue-13-adaptive-agent-assignment-implementation-20260826.md
+    - reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
+  requested_authorized_actions:
+    - read_repository
+    - comment_pr
+
+transport:
+  method: repository_file
+  packet_path: reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
+  packet_url: https://github.com/ssaattww/CodexSkill/blob/feat/adaptive-agent-assignment/reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
+  transport_note: Packet targetとCI evidenceはtransport commit直前のsource HEAD 8731e75427aacada40db2fe1a2ceb8376d797266へ結び付く。このpacket自体を追加したfinal PR HEADとそのexact-head CIはGitHub PR commentへ記録する。current permissionsは次chatへ自動移送されない。

--- a/reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
+++ b/reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml
@@ -71,7 +71,7 @@ write_boundary:
       reason: agent assignment architectureと選定規則の設計正本。
     - path_or_operation: reports/issue-13-adaptive-agent-assignment-*
       reason: implementation reportとlossless handoffの保存先。
-    - path_or_operation: PR #65 metadata and comments
+    - path_or_operation: "PR #65 metadata and comments"
       reason: PR作成、検証結果、handoffを利用者へ提示する。
   forbidden:
     - path_or_operation: main branch direct update
@@ -79,8 +79,8 @@ write_boundary:
     - path_or_operation: tasks/tasks-status.md manual edit
       reason: repository contract上、指定されたtask tracking Skillだけが更新する。
     - path_or_operation: unrelated repository files
-      reason: Issue #13 scope外の変更を避ける。
-    - path_or_operation: merge PR #65
+      reason: "Issue #13 scope外の変更を避ける。"
+    - path_or_operation: "merge PR #65"
       reason: mergeは利用者が実施する。
 
 scope:
@@ -240,7 +240,7 @@ implementation:
     - executor decisionとper-task profile selectionを別責務にした。
     - Ultra相当をmulti-agent strategyとして定義し、reasoning_effortから除外した。
     - explicit override、full-history inheritance、runtime rejection、fallbackをlossless evidenceとして残す。
-    - Issue #13をcloseするDraft PR #65を作成した。mergeは行っていない。
+    - "Issue #13をcloseするDraft PR #65を作成した。mergeは行っていない。"
 
 review:
   mode: not_applicable
@@ -341,7 +341,7 @@ source_payloads:
       authority:
         - user request
         - root AGENTS.md
-        - Issue #13
+        - "Issue #13"
         - Project Instruction
         - uploaded ChatGPT worker Skills
       development_policy:
@@ -359,7 +359,7 @@ source_payloads:
           - adaptive assignment design
           - implementation report
           - handoff transport
-          - PR #65 metadata and comment
+          - "PR #65 metadata and comment"
         forbidden:
           - direct main update
           - unrelated files
@@ -387,7 +387,7 @@ source_payloads:
         - merge
       authoritative_requirements:
         - user-requested article-based agent assignment
-        - Issue #13 model policy gap
+        - "Issue #13 model policy gap"
         - CodexSkill non-TDD policy
         - exact-head CI rule
       changes:
@@ -763,7 +763,7 @@ next_action:
   type: external_owner
   target_skill: none
   mode: review_and_merge_decision
-  summary: PR #65のfinal exact-head CIと差分をreviewし、利用者がmerge可否を判断する。
+  summary: "PR #65のfinal exact-head CIと差分をreviewし、利用者がmerge可否を判断する。"
   instructions:
     - PR bodyと簡易PR commentに記録されるfinal HEAD SHAを基準にする。
     - workflow runのhead_shaがPR current HEADと一致することを確認する。

--- a/reports/issue-13-adaptive-agent-assignment-implementation-20260826.md
+++ b/reports/issue-13-adaptive-agent-assignment-implementation-20260826.md
@@ -1,0 +1,247 @@
+# Issue #13 適応型agent割当 実装レポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- Issue: `#13 sub-agentの使用モデル`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- branch: `feat/adaptive-agent-assignment`
+- base: `main`
+- base HEAD: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+- implementation HEAD: `18694e6bdfd15301afbaf57b2e6596fe52d239e7`
+- report persistence: repository file
+- report commit SHA: commit後にのみ確定するため本文には記載しない。final PR HEADとexact-head CIはPR commentへ記録する。
+
+## 目的
+
+参考記事のLuna、Terra、Solの役割分担をCodexSkillの既存delegation flowへ取り込み、bounded taskの性質に応じて次を自動選定する。
+
+- model tier
+- reasoning effort
+- fork policy
+- single-agent executionとmulti-agent decompositionの区別
+
+modelをpromptへ書くだけでなく、requested profileとruntimeへ実際に適用されたprofileを分離し、選定理由、制約、fallbackをreport evidenceとして残す。
+
+## authoritative requirements
+
+- user instruction: 参考記事を基に適切なagentを割り当てる仕組みを実装し、PR作成まで行う。
+- repository instruction: root `AGENTS.md`に従いCodexSkill保守へTDDを適用しない。
+- Issue #13: 機械的実装、設計・調査、reviewで使用modelを分けるSkill契約が不足している。
+- project instruction: GitHub connectorでrepository、Issue、PRを操作し、詳細reportをrepositoryへ保存し、簡易reportをPR commentへ投稿する。mergeは行わない。
+- CI instruction: PR current HEAD SHAとworkflow runの`head_sha`が一致するrunだけを使用する。
+
+## 参考資料
+
+- https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb
+- https://developers.openai.com/api/docs/models
+- https://developers.openai.com/api/docs/guides/latest-model
+
+OpenAI公式model catalogに基づき、current model IDを`gpt-5.6-luna`、`gpt-5.6-terra`、`gpt-5.6-sol`として定義した。reasoning effortは`none`、`low`、`medium`、`high`、`xhigh`、`max`をnormalization対象とした。
+
+参考記事のUltra相当はreasoning effortではなく、独立workstreamを複数agentへ分割するexecution strategyとして扱った。
+
+## scope
+
+- `sub-agent-task-manager`へper-task profile selection責務を追加
+- model tierとreasoning effortを別軸で選ぶ中央matrixを追加
+- Luna、Terra、Solのtask floorとtask defaultを追加
+- uncertainty、change radius、criticality、repetition、decomposability、context needのassessmentを追加
+- `codex-delegation-executor`へsingle-agentとmulti-agent decompositionのgateを追加
+- `development-orchestrator`のroutineなimplementation model確認を廃止
+- explicit userまたはrepository overrideの優先順位を追加
+- requested profileとapplied profileを分離
+- full-history fork、runtime rejection、fallback、capability gapの記録契約を追加
+- 適応型agent割当の設計書を追加
+
+## non-goals
+
+- Codex runtime本体へのmodel router実装
+- runtime model availability APIの追加
+- model価格だけに基づくrouting
+- explicit overrideのsilent変更
+- full-history forkへ異なるmodelを強制すること
+- `reasoning_effort: ultra`の追加
+- task tracking fileの手動更新
+- merge
+
+## 責務配置
+
+### `codex-delegation-executor`
+
+次を所有する。
+
+- main agent、single sub-agent、multi-agentのexecutor decision
+- task assessment
+- independent workstreamの分割gate
+- parent synthesis
+
+modelとreasoning effortの中央defaultは持たない。
+
+### `sub-agent-task-manager`
+
+次を所有する。
+
+- bounded taskごとのmodel tier選定
+- reasoning effort選定
+- fork policy選定
+- requested profileのspawn適用
+- applied profileとfallbackのreport evidence
+
+この配置により、`sub-agent-task-manager`が直接使われる経路でもmodel selectionが欠落しない。
+
+### `development-orchestrator`
+
+routineなmodel確認を要求せず、明示overrideまたはbudget constraintだけをworkflow inputとして保持する。
+
+## 選定規則
+
+### model tier
+
+- Luna: low uncertainty、local、ordinary criticality、deterministic、mechanicalまたはhigh-volume
+- Terra: ordinary bounded implementation、focused verification、具体的仮説があるlocalized investigation、focused fix verification
+- Sol: requirement、design、open-ended investigation、cross-system、高criticality、initial review、independent final review、release audit
+
+複数条件が該当する場合は最も高いfloorを使う。diff行数よりchange radiusとimpactを優先する。
+
+### reasoning effort
+
+- `low`: exactかつ低riskの変換
+- `medium`: ordinary bounded implementationまたはdeterministic evidence
+- `high`: 複数条件、debug、design、review
+- `xhigh`: boundedで網羅性または重要度が高いreview・audit
+- `max`: 一つの非常に難しく分割不能な問題
+
+`max`はgeneric quality settingとして使わず、`execution-cost-stabilizer`を通す。
+
+### multi-agent
+
+次を全て満たす場合だけ分割する。
+
+- independent workstreamが2件以上
+- 各taskへscope、non-goals、evidence、report ownerを定義できる
+- write ownershipが重複しない、またはread-only
+- blocking dependencyがない
+- parent synthesisが定義されている
+- parallelismの実益がある
+
+各taskは別々にprofileを選ぶ。
+
+## changed files
+
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+  - model tier、reasoning effort、task default、override、fork、escalation、evidence schemaを追加
+- `skills/sub-agent-task-manager/SKILL.md`
+  - per-task profile selectionとactual runtime applicationをrequired flowへ追加
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+  - selectionとapplicationを分離し、requested/applied、full-history、fallbackを追加
+- `skills/codex-delegation-executor/SKILL.md`
+  - delegation assessmentとmulti-agent decomposition gateを追加
+- `skills/development-orchestrator/SKILL.md`
+  - routineなimplementation model確認をautomatic selectionへ置換
+- `design/adaptive-agent-assignment-design.md`
+  - architecture、input schema、selection matrix、flow、examples、validation方針を追加
+
+## intentionally untouched
+
+- `tasks/tasks-status.md`
+  - repository契約上、指定されたtask管理Skillだけが更新するため手動変更しない。
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+  - Skill hierarchy topologyとdependency edgeは変更していない。新規Skillも追加していないため同期pairは変更しない。
+- `.github/workflows/release-chatgpt-worker-skills.yml`
+  - CodexSkillには既にrepository validator、ZIP build、artifact uploadを行うPR workflowが存在する。RevMem向け診断artifact追加規則は本repositoryへ適用しない。
+- `skills/review-enforcer/SKILL.md`
+  - reviewer lifecycleは変更せず、review modeをbounded task inputとしてselectorが使用する。
+
+## commits
+
+- `716594ca5a19e5ad5fe3e718cd445ab4559811f8`: adaptive profile selection reference追加
+- `52a9b63dd4a119aa9410133ec4e0e7e07d3f1183`: `sub-agent-task-manager`へautomatic selection追加
+- `76b49304cdb9d3a54f3d202a6b072584431612e2`: spawn application contract更新
+- `df3d44be01c9b7022909bd7a2ce614733c820f07`: delegation assessmentとmulti-agent gate追加
+- `abf889a0e4955069a3901c99973ee401d1226ce2`: orchestratorのroutine model confirmation置換
+- `18694e6bdfd15301afbaf57b2e6596fe52d239e7`: 適応型agent割当設計追加
+
+## development policy
+
+- method: non-TDD repository maintenance
+- testing order: implementation後にrepository validatorとdistribution buildを実行
+- governing source: root `AGENTS.md`
+- TDD: not applicable
+- Red/Green evidence: 作成していない
+
+## validation route
+
+- verification capability: `remote_ci_only`
+- 理由: repository参照・更新はGitHub connectorを使用し、local checkoutを作らずGitHub Actionsをformal validation evidenceとして使用した。
+
+## validation evidence for implementation HEAD
+
+対象HEAD: `18694e6bdfd15301afbaf57b2e6596fe52d239e7`
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `32929673352`
+- run number: `159`
+- event route: pull request
+- run head SHA: `18694e6bdfd15301afbaf57b2e6596fe52d239e7`
+- conclusion: `success`
+- build job ID: `98059362580`
+
+成功step:
+
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
+
+このrunはimplementation HEADと一致する。reportとhandoff追加後はPR HEADが変わるため、このrunをfinal HEADの代用にはしない。final exact-head runはPR commentへ記録する。
+
+## failure diagnostics
+
+- test failure: なし
+- standard output failure: なし
+- standard error failure: なし
+- failure artifact inspection: not applicable
+- workflow artifact: validation成功時にChatGPT worker ZIPがuploadされた。failure investigationは不要だった。
+
+## contract review
+
+次を差分で確認した。
+
+- model tierとreasoning effortが別のdecisionとして記述されている
+- `reasoning_effort: ultra`を生成しない
+- multi-agent decompositionは`codex-delegation-executor`が所有する
+- per-task profileは`sub-agent-task-manager`が所有する
+- user/repository overrideをsilentに変更しない
+- requested profileをapplied profileとして無条件copyしない
+- full-history forkはparent profile継承として記録する
+- runtime rejectionはfallbackまたはcapability gapとして記録する
+- failed deterministic verificationをinvestigationへ再分類する
+- existing report、review、nested Codex禁止契約を維持する
+
+## blocked / unknown / unexplored
+
+- blocked: なし
+- unknown: 実行時に各accountまたはruntimeで利用可能なmodel一覧を取得するAPIは本repositoryに存在しない。
+- unexplored: hidden `collaboration.spawn_agent` overrideのlive integration test。CodexSkillはSkill contract repositoryであり、CIにspawn fixtureは存在しない。
+
+## remaining risks
+
+- GPT model familyまたはsupported reasoning effortが将来変更された場合、current model mappingの更新が必要になる。
+- hidden spawn overrideがruntimeでrejectされる可能性は残る。その場合はrequested/appliedを分離し、parent-owned fallbackまたはcapability gapを記録する。
+- automatic classificationはSkill instructionに基づくjudgmentであり、runtime classifier codeではない。non-obvious classificationにはevidence記録を必須化した。
+- final report/handoff commitについては、新しいPR HEADに紐づくworkflow runを別途確認する必要がある。
+
+## outcome
+
+Issue #13のmodel assignment不足に対し、既存delegation architectureを維持したまま、task特性からLuna、Terra、Solとreasoning effortを選ぶ中央contractを実装した。
+
+PR #65を作成済み。mergeは行わない。
+
+## next action
+
+- reportとhandoffをrepositoryへpersistする。
+- final PR HEADと一致するworkflow runだけを確認する。
+- PR bodyをfinal stateへ更新し、変更内容と検証結果の簡易reportをPR commentへ投稿する。
+- PRをready for reviewへ変更する。

--- a/reports/issue-13-pr65-normal-review-20260827.md
+++ b/reports/issue-13-pr65-normal-review-20260827.md
@@ -1,0 +1,211 @@
+# PR #65 通常レビュー報告
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- Issue: `#13 sub-agentの使用モデル`
+- review mode: `initial_review`
+- reviewed implementation HEAD: `46776a85f09b101018338309ccd3221cc10592ad`
+- base: `main`
+- base HEAD: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+- commit range: `2ea9522d494b2b37c1d8aabb340a3113cfd18240...46776a85f09b101018338309ccd3221cc10592ad`
+- reviewer role: normal reviewer
+- reviewer independence: このreview chatではPR #65の実装・修正を行っていない
+- development policy: CodexSkill repository maintenanceはnon-TDD
+- verdict: `fail`
+
+## 要求と設計の確認
+
+対象要求は次のとおり。
+
+- Issue #13: sub-agentの使用modelをtask種別に応じて定義する。
+- PR #65: bounded taskごとにLuna / Terra / Sol、reasoning effort、fork policyを選定する。
+- 追加要求: `Sol xhigh` / `Sol max`は自動dispatchせず、current-taskの明示的なユーザー承認後のみdispatchする。
+- review / independent final review / release auditにも同じapproval gateを適用する。
+- `codex-delegation-executor`はexecutorとmulti-agent decomposition、`sub-agent-task-manager`はper-task profileを所有する。
+
+GPT-5.6のSol / Terra / Lunaと、`max`・`ultra`の公開上の位置づけはOpenAIの現行資料とも照合した。`ultra`を単一agentの深いreasoningではなくmulti-agent戦略として扱う設計方針自体には指摘なし。
+
+参考:
+
+- https://openai.com/index/gpt-5-6/
+- https://openai.com/index/builders-guide-to-gpt-5-6/
+
+## 変更範囲
+
+変更9ファイルを全件確認した。
+
+- `design/adaptive-agent-assignment-design.md`
+- `reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml`
+- `reports/issue-13-adaptive-agent-assignment-implementation-20260826.md`
+- `reports/issue-13-sol-expensive-profile-approval-followup-20260827.md`
+- `skills/codex-delegation-executor/SKILL.md`
+- `skills/development-orchestrator/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+
+直接依存として少なくとも次を横断確認した。
+
+- `skills/review-enforcer/SKILL.md`
+- `skills/report-output-manager/SKILL.md`
+- `skills/report-output-manager/references/sub-agent-report-template.md`
+- `skills/execution-cost-stabilizer/SKILL.md`
+- `design/skill-hierarchy-design.md`
+- root `AGENTS.md`
+- `tasks/tasks-status.md`
+
+## Findings
+
+### F65-001 — HIGH — review dispatchがprofile selectorを通らず、review向けapproval gateを迂回できる
+
+- origin: `coverage_miss`
+- location:
+  - `skills/development-orchestrator/SKILL.md:68,74`
+  - `skills/review-enforcer/SKILL.md` のnormal reviewer / independent final reviewer dispatch
+  - `design/skill-hierarchy-design.md` のreview-enforcer配下
+
+#### 説明
+
+PRでは`development-orchestrator`がnormal reviewとindependent final reviewを`review-enforcer`へ委譲し、review profileが`Sol xhigh` / `Sol max`になった場合はdispatch前にapproval stopすると定義している。
+
+しかしcurrent HEADの`review-enforcer`はRequired Skillsに`sub-agent-task-manager`を含まず、required flowでもnormal reviewerとindependent final reviewerを直接dispatchしている。したがって、標準review lifecycle上で`agent-profile-selection.md`のclassification、requested/applied profile、`Sol xhigh` approval gateが実行される保証がない。
+
+一方、既存の`design/skill-hierarchy-design.md`は`review-enforcer -> sub-agent-task-manager -> review-worker`を正規経路として記載しているため、Skill実装とhierarchy設計も一致していない。
+
+#### 影響
+
+- initial normal reviewをSol `high`へ割り当てる新規規則が実行されない可能性がある。
+- independent final reviewでSol `xhigh` proposalを生成せず、ユーザー承認を取らないままreviewerをdispatchできる。
+- PRが追加した高コストprofileのapproval safeguardをreview経路だけ迂回できる。
+- PR本文の「review / independent final reviewにもgateを適用」という要求を満たさない。
+
+#### required action
+
+`review-enforcer`の新規reviewer dispatchを必ず`sub-agent-task-manager`経由へ変更する。normal review / independent final reviewのmode・criticalityをselectorへ渡し、`proposed_profile`が返った場合はspawn前にparentへapproval stopを返すこと。既存`design/skill-hierarchy-design.md`の経路とSkill実装を一致させること。
+
+### F65-002 — MEDIUM — fix verificationのTerra defaultと同一reviewer継続契約が両立しない
+
+- origin: `introduced_by_change`
+- location:
+  - `skills/sub-agent-task-manager/references/agent-profile-selection.md:118-120`
+  - `skills/sub-agent-task-manager/SKILL.md` のreview default
+  - `skills/review-enforcer/SKILL.md` のnormal reviewer continuity / step 6
+
+#### 説明
+
+新しいprofile tableはinitial normal reviewをSol `high`、focused fix verificationをTerra `high`としている。一方、`review-enforcer`はinitial reviewとfix verificationで同一のnormal reviewer sub-agentを可能な限り再利用することを必須にしている。
+
+model / reasoning overrideはspawn時のprofileであり、既に起動済みのreviewerをfix verification時にSolからTerraへ変更するruntime application pathは定義されていない。
+
+そのためfix verification時には次のどちらかになる。
+
+- 同一reviewerを再利用する: 実際はinitial reviewのSol `high`のままで、Terra `high` defaultを適用できない。
+- Terra `high`で新規spawnする: reviewer continuity契約を破る。
+
+また、`dispatch_profile.application_status`にも「既存reviewer継続のため元profileを継承した」状態がない。
+
+#### 影響
+
+- fix verificationのrequested/applied profile証跡が実態と一致しなくなる。
+- cost最適化としてTerraを選んだという記録だけが残り、実際にはSolを継続利用する可能性がある。
+- selector規則を守ろうとするとreviewer continuityを壊すため、callerごとに挙動が分岐する。
+
+#### required action
+
+reviewer continuityとprofile selectionの優先関係を明示する。推奨は、既存normal reviewerを再利用できるfix verificationではinitial spawn時のapplied profileを継続し、その事実を専用のapplication statusまたはconstraintとして記録すること。Terra `high` defaultはreplacement reviewerなど新規spawnが必要な場合に限定するなど、selector table・`sub-agent-task-manager`・`review-enforcer`の契約を一貫させること。
+
+### F65-003 — MEDIUM — 必須dispatch-profile証跡を標準sub-agent report templateへ保存できない
+
+- origin: `coverage_miss`
+- location:
+  - `skills/sub-agent-task-manager/SKILL.md` required flow 9-13 / Report rules / Standard report sections
+  - `skills/report-output-manager/references/sub-agent-report-template.md`
+
+#### 説明
+
+`sub-agent-task-manager`は、全dispatchについてselection inputs、proposal / approval evidence、requested / applied profile、selection source、reasons、constraints、fork policy、application status、escalation / fallbackをreportへ保存することをcompletion条件に追加した。
+
+同時に、sub-agentにはpre-created standard reportのheading順・format・既存textを維持し、「blank section / placeholderだけを埋める」よう要求している。
+
+しかし参照される`sub-agent-report-template.md`は従来の10 sectionのままで、dispatch profile、approval evidence、requested/applied、application status等のplaceholderが存在しない。`sub-agent-task-manager`自身の`Standard report sections`一覧も同じ旧構造のままである。
+
+#### 影響
+
+- 新しい必須profile evidenceをどこへ記録するかcallerごとに異なる。
+- fixed templateを守ると必要証跡を構造化して残せず、証跡を追加すると「report formatを変更しない」というprompt契約と衝突する。
+- `Sol xhigh` / `Sol max`のapproval evidenceを含むcost-control監査情報が欠落・散在し得る。
+- completion gateをreport内容から一貫して確認できない。
+
+#### required action
+
+`sub-agent-report-template.md`と`sub-agent-task-manager`のStandard report sectionsを更新し、dispatch-profile専用sectionまたは固定YAML blockを追加する。少なくともselection inputs、proposal/approval、requested、applied、fork policy、application status、fallback/escalationを明示的なplaceholderとして持たせ、parent/childのどちらがどのfieldを埋めるかも定義すること。
+
+## Required coverage
+
+| criterion | disposition | evidence |
+| --- | --- | --- |
+| requirement and design conformance | `checked_finding` | F65-001, F65-002, F65-003 |
+| correctness and edge cases | `checked_finding` | review dispatch bypassとreviewer reuse/profile変更不能を確認 |
+| scope discipline and unrelated changes | `checked_no_finding` | 変更9ファイルはIssue #13、approval follow-up、report/handoffに限定 |
+| changed files and direct dependency impact | `checked_finding` | `review-enforcer`、report templateまで横断しF65-001/F65-003を検出 |
+| API / data / configuration / workflow / compatibility | `checked_finding` | spawn override、fork、review lifecycleを確認。F65-001/F65-002あり |
+| error handling and failure diagnostics | `checked_no_finding` | runtime rejectionをfallback/capability_gapとして区別するcontractは存在 |
+| security and secret handling | `not_applicable` | secret/auth処理の変更なし |
+| tests and validation adequacy | `checked_finding` | static validator/buildは成功するが、review call pathとreport schemaのsemantic整合は検証対象外 |
+| current-HEAD CI evidence | `checked_no_finding` | run `33019645686`の`head_sha`がreviewed HEADと完全一致しbuild成功 |
+| report / tracking / documentation accuracy | `checked_finding` | implementation reportが`review-enforcer`をintentionally untouchedとしているがF65-001のintegration gapが残る |
+| regression and maintainability risk | `checked_finding` | profile evidenceとreviewer continuityの契約不整合あり |
+
+## CI / validation assessment
+
+reviewed implementation HEAD `46776a85f09b101018338309ccd3221cc10592ad`と一致するrunだけを確認した。
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33019645686`
+- run number: `165`
+- event: `pull_request`
+- run head SHA: `46776a85f09b101018338309ccd3221cc10592ad`
+- conclusion: `success`
+- build job ID: `98346565507`
+- build job conclusion: `success`
+- validation step: `Validate repository Skill architecture and active links` -> success
+- ZIP build step: `Build and verify ChatGPT wrapper and core Skill ZIP` -> success
+- artifact upload step: success
+- artifact ID: `9625970350`
+- artifact name: `chatgpt-worker-skills-33019645686`
+- artifact digest: `sha256:45e2e8d58f4941260788e33d48a98b51ef48c9235600dcd109df732e5e73a091`
+
+CI成功はstatic architecture/link/build validationの成功を示すが、F65-001からF65-003のsemantic contractまでは検査していないため、findingsを解消しない。
+
+## Held / unexplored
+
+### runtime model availability
+
+- disposition: `held`
+- reason: account/runtimeごとのsub-agent model availabilityをrepositoryから決定できない。
+- current contract: unavailable時はsame/higher tier resolution、fallback、または`capability_gap`を記録する。
+- verdict impact: 今回のfail理由ではない。
+
+### live `collaboration.spawn_agent` integration
+
+- disposition: `held`
+- reason: repository CIにlive spawn fixtureがない。
+- current Codex実装ではmodel override exposure/availabilityがruntime設定・catalogに依存するため、requested/applied分離とcapability stateを残す方針は妥当。
+- verdict impact: 今回のfail理由ではない。
+
+## Verdict
+
+`fail`
+
+required finding 3件があるため、このHEADをacceptしない。
+
+## Next action
+
+1. F65-001からF65-003を実装側でまとめて修正する。
+2. 関連Skill、設計、report templateを同期する。
+3. CodexSkill方針に従いrepository validator / ZIP buildを実行する。
+4. push後、新しいPR current HEADと`head_sha`が一致するworkflow runだけをCI evidenceにする。
+5. 同じnormal review chatでfinding-by-finding fix verificationを行う。
+6. mergeは利用者が行う。

--- a/reports/issue-13-pr65-r2-findings-followup-20260829.md
+++ b/reports/issue-13-pr65-r2-findings-followup-20260829.md
@@ -1,0 +1,204 @@
+# PR #65 R2指摘対応レポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- branch: `feat/adaptive-agent-assignment`
+- 対応対象review: R2
+- 対応前HEAD: `3ae8a067b648ffbbc956fdc651f3bdfa7b1316d2`
+- 技術修正HEAD: `fedaeaa93f1425ada5a3cd3f8f64a604d5203c1f`
+- development policy: CodexSkill repository maintenanceはnon-TDD
+
+## 対応した指摘
+
+### F65-R2-001 / HIGH
+
+指摘:
+
+`requested`と`applied`の時系列が逆転しており、spawn前に`applied`を確定した上でその値をspawn引数へ使用する契約になっていた。
+
+対応:
+
+- `requested`をpre-spawn instructionとして固定
+- spawn前は`applied: null`、`application_status: pending_runtime_result`とする
+- actual spawn argumentsには`requested` model / reasoning effortを使用
+- full-historyの場合はincompatible overrideを付けず、runtime path成立後にparent inheritanceを`applied`として記録
+- spawn result / rejection / fallback evidenceを得た後だけ`applied`と`application_status`を記録
+- rejected requested profileを`applied`へcopyしない
+- hidden runtime stateはchildではなくparentが記録する
+
+変更:
+
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+- `skills/report-output-manager/references/sub-agent-report-template.md`
+- `design/adaptive-agent-assignment-design.md`
+
+### F65-R2-002 / HIGH
+
+指摘:
+
+new independent-final reviewerを`sub-agent-task-manager`経由にした結果、通常sub-agentと同じ「report fileをdispatch前に作成しchildが編集する」契約が、independent-final-reviewのreport-attestation lifecycleと衝突した。
+
+対応:
+
+report persistenceを2modeへ分離した。
+
+`normal_persistence`:
+
+- implementation / verification / normal review / fix verificationで使用
+- dispatch前にstandard reportを作成可能
+- freeze前にpersist / commitする
+
+`deferred_attestation`:
+
+- independent final review / bounded independent closureで使用
+- freeze前はexact report pathをmetadataとして予約するだけ
+- repository report fileを作成・pre-populate・編集しない
+- reviewerはstructured review evidenceをparentへ返す
+- parentがreviewer outputとdispatch profile evidenceをrepository外のlifecycle evidenceとして保持
+- fail時はreportをpersistせずimplementationとnormal fix verificationへ戻る
+- same independent reviewer closureでもreport pathは未作成を維持
+- passing verdict後のみ`report-writer`と`report-output-manager`がreserved pathへ初回persistし、1件だけのreport-attestation commitを作る
+
+変更:
+
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/review-enforcer/SKILL.md`
+- `skills/report-output-manager/SKILL.md`
+- `design/adaptive-agent-assignment-design.md`
+
+### F65-R2-003 / HIGH
+
+指摘:
+
+review taskが`sub-agent-task-manager`で`independent_workstreams`へ再分類されると、review-enforcerの1 normal reviewer / 1 fresh exhaustive independent reviewerというidentity保証が崩れる。
+
+対応:
+
+`review-enforcer`が作る全new reviewer taskへ次を固定した。
+
+```yaml
+decomposability: single
+decomposition_policy: forbidden
+parallelism_mode: single_agent
+```
+
+- normal reviewer
+- replacement reviewer
+- independent final reviewer
+
+すべて1 reviewer固定とする。
+
+`sub-agent-task-manager`とprofile selectorはcaller-owned `decomposition_policy: forbidden`を優先し、このtaskを`codex-delegation-executor`へmulti-agent decompositionとして戻さない。
+
+review scopeが大きいこと自体はdecomposition理由にしない。multi-agent review lifecycleを正式設計していないため、現行review identity / continuity / one exhaustive passを維持する。
+
+変更:
+
+- `skills/review-enforcer/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- `design/adaptive-agent-assignment-design.md`
+
+## 追加整合化
+
+### Dispatch profile section ownership
+
+standard sub-agent report templateの`Dispatch profile` sectionをparent-ownedとして明記した。
+
+parent pre-dispatch:
+
+- selection inputs
+- selection source
+- proposed / approval
+- requested
+- fork / constraints
+
+parent post-runtime:
+
+- applied
+- application status
+- fallback / inheritance evidence
+
+childはhidden spawn argumentsまたはruntime applicationを推測しない。
+
+### 設計書
+
+`design/adaptive-agent-assignment-design.md`を現行契約へ整理した。
+
+- requested -> spawn -> appliedの時系列
+- caller-owned decomposition prohibition
+- single reviewer lifecycle
+- normal persistence / deferred attestation
+- independent final reportのmetadata-only reservation
+- passing verdict後だけのreport attestation
+
+## commit
+
+R2対応の主なcommit:
+
+- `0a967fcac5eadbeb989f10cbe9a6f639cab765f1`: dispatch timingとfinal-review report boundaryを修正
+- `2d1500982d3bae78f3dccc646256b81debbbb29c`: single reviewer / deferred-attestation review lifecycleを修正
+- `35e4cd2ce10ce04901f08e06773e662dd192fedd`: independent-final report pathをmetadata-only reservationへ変更
+- `4820b49867ba40fbd0e961ff918430f95390b2e8`: profile schemaとdecomposition lockを修正
+- `34c7aedcbc4a5ad742cb38876d6ad15fb183c50f`: standard reportのdispatch evidence ownershipを明記
+- `b7d34ed8807d35a348038bdb4c66883f259646bb`: spawn application時系列を中央referenceへ明記
+- `fedaeaa93f1425ada5a3cd3f8f64a604d5203c1f`: 設計書を現行contractへ同期
+
+## 検証
+
+技術修正HEAD:
+
+`fedaeaa93f1425ada5a3cd3f8f64a604d5203c1f`
+
+GitHub Actions:
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33246215564`
+- run number: `181`
+- run head SHA: `fedaeaa93f1425ada5a3cd3f8f64a604d5203c1f`
+- build job: `99084021821`
+- conclusion: `success`
+
+成功step:
+
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
+
+artifact:
+
+- name: `chatgpt-worker-skills-33246215564`
+- ID: `9712913941`
+- digest: `sha256:e96d321210333ae6b47aa7f0c55ac55fefba45580f4da1ea61ce2b83b5506728`
+- artifact head SHA: `fedaeaa93f1425ada5a3cd3f8f64a604d5203c1f`
+
+別SHAのrunはこの技術修正HEADの検証には使用していない。
+
+このreport追加後はPR HEADが変わるため、final exact-head CIは新しいHEADとrun head SHAの一致を別途確認する。
+
+## failure diagnostics
+
+- test / validator failure: なし
+- failure stdout: なし
+- failure stderr: なし
+- failure investigation artifact: 不要
+- validation artifact: 正常生成済み
+
+## 残存リスク
+
+- hidden `collaboration.spawn_agent` override自体のlive integration fixtureはrepositoryに存在しない
+- runtime model availability APIはrepositoryに存在しない
+- multi-agent review lifecycleは今回のscope外。現行reviewはsingle reviewer固定
+
+これらは今回のR2 findingのclosureを妨げる未解決required actionではない。
+
+## 結果
+
+F65-R2-001、F65-R2-002、F65-R2-003の3件に対し、spawn時系列、independent-final report attestation、reviewer identity/decompositionの各contractを修正した。
+
+mergeは行っていない。

--- a/reports/issue-13-pr65-r3-findings-followup-20260829.md
+++ b/reports/issue-13-pr65-r3-findings-followup-20260829.md
@@ -1,0 +1,170 @@
+# PR #65 R3 指摘対応レポート
+
+## 対象
+
+- repository: `ssaattww/CodexSkill`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- 対応対象review: R3
+- 実装修正HEAD: `2cf3451747c03a045c9cd275c58238db04a4f151`
+- target repository policy: CodexSkill maintenanceはnon-TDD
+
+## 指摘
+
+### F65-R3-001 / HIGH
+
+`spawn_agent`成功後も、requested overrideが最終model/reasoningとして適用されたとは断定できない問題。
+
+確認した現行Codex MultiAgent V2 implementationでは、requested model/reasoning override適用後に`apply_spawn_agent_role`が実行される。explicit/default agent roleはmodel/reasoningを再変更できる。また内部ではagent config snapshotが取得されるが、通常のparent-visible spawn outputは設定によりmetadataを隠し、`task_name`のみを返す。
+
+このため、spawn成功だけを根拠に`applied=requested`とする証跡は不正確であり、roleがSol `xhigh` / `max`へ変更した場合にはuser approval gateを迂回する可能性がある。
+
+### F65-R3-002 / HIGH
+
+`report-output-manager`のRequired Skillsで`report-writer`を無条件invokeすると、independent-final-review前のmetadata-only report path reservationと矛盾する問題。
+
+reservation時点ではcoverage/findings/verdictがまだ存在せず、report生成はできない。
+
+### F65-R3-003 / MEDIUM
+
+`decomposition_policy: forbidden`を理由に観測された`decomposability`を`single`へ書き換えていた問題。
+
+実際にはreview scopeに独立workstreamが複数存在しても、reviewer identity / continuityを守るためexecution decompositionだけ禁止するケースがある。観測signalの改変はprofile理由を歪め、特にSol `max`のintrinsic non-decomposability条件を人工的に満たす可能性がある。
+
+## 対応内容
+
+### agent role / default roleを含むprofile planning
+
+`skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`とselector contractを更新した。
+
+spawn前に次を分離して記録する。
+
+- `requested`: selector/user policyが要求するprofile
+- `role_plan`: explicit `agent_type`またはeffective default roleと、そのconfig evidence
+- `planned_runtime_profile`: known role constraints適用後の予測profile
+- `applied`: parent-visibleなexact final runtime evidenceが存在する場合だけ記録
+
+role/default roleがmodel tierまたはreasoning effortを変更・lockする場合、role-adjusted planでmodel floorとSol `xhigh` / `max` approval gateを再評価する。
+
+role/default-role configの影響をspawn前に十分確認できず、高コストprofileへ変更されないことを保証できない場合は、silent dispatchせずpre-spawn capability gapとして停止する。
+
+### runtime observability
+
+spawn成功だけではexact `applied`を確定しない。
+
+parent-visible final snapshotがある場合のみ:
+
+```yaml
+application_status: applied_verified
+profile_observability: verified_final_snapshot
+```
+
+final model/reasoning metadataがparentから見えない場合:
+
+```yaml
+applied: null
+application_status: spawn_succeeded_profile_unverified
+profile_observability: final_profile_hidden
+```
+
+とし、requested/planned profileをappliedへcopyしない。
+
+standard sub-agent report templateにもrole plan、planned runtime profile、runtime observabilityをparent-owned欄として追加した。
+
+### report-output-managerのphase分離
+
+`report-output-manager`をphase-specific contractへ変更した。
+
+- normal persistence: `work-context-manager` + `report-writer`
+- independent-final reservation: `work-context-manager`のみ。`report-writer`はinvokeしない
+- independent-final attestation persistence: passing verdict後に`work-context-manager` + `report-writer`
+
+reservation phaseではreport body/fileを作らず、exact path metadataだけを確定する。
+
+### decomposabilityとdecomposition policyの分離
+
+selectorとreview lifecycleを次のように変更した。
+
+```yaml
+decomposability: independent_workstreams
+decomposition_policy: forbidden
+decomposition_disposition: prohibited_by_review_lifecycle
+parallelism_mode: single_agent
+```
+
+- `decomposability`: work structureの観測事実
+- `decomposition_policy`: execution constraint
+- `decomposition_disposition`: observed decompositionを実行しなかった理由
+
+reviewerはsingle-agent executionを維持するが、review scopeの構造は偽装しない。
+
+Sol `max`のnon-decomposable条件はintrinsicなtask propertyとして判定し、`decomposition_policy: forbidden`を根拠にしない。
+
+## 主な変更ファイル
+
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/report-output-manager/SKILL.md`
+- `skills/report-output-manager/references/sub-agent-report-template.md`
+- `skills/review-enforcer/SKILL.md`
+- `skills/development-orchestrator/SKILL.md`
+- `design/adaptive-agent-assignment-design.md`
+
+## 現行Codex挙動の確認
+
+確認対象:
+
+- repository: `openai/codex`
+- commit: `6478a751fde8884b2fdc76486fe23175a8e795d4`
+- `codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs`
+- `codex-rs/core/src/tools/handlers/multi_agents_common.rs`
+
+確認事項:
+
+- requested model/reasoning overrideの後に`apply_spawn_agent_role`が呼ばれる
+- role applicationは`config.model` / `config.model_reasoning_effort`を変更できる
+- runtime-only overrideはapproval/cwd/permission等であり、今回確認した範囲ではmodel/reasoningを変更していない
+- child spawn後、runtime内部ではconfig snapshotを取得してtelemetryへ利用している
+- parent-visible spawn resultはmetadata非表示時`task_name`のみとなり、final model/reasoningをparentが観測できないケースがある
+
+したがって「runtime内部にsnapshotが存在すること」と「parentがexact final profileを証跡として取得できること」は区別した。
+
+## 検証
+
+CodexSkill repository policyに従いTDDは適用していない。
+
+実装修正HEAD `2cf3451747c03a045c9cd275c58238db04a4f151` に対して、同一SHAのpull-request workflow runだけを検証対象とした。
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33248500555`
+- run number: `191`
+- run head SHA: `2cf3451747c03a045c9cd275c58238db04a4f151`
+- build job: `99089994435`
+- conclusion: `success`
+
+成功step:
+
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
+
+artifact:
+
+- name: `chatgpt-worker-skills-33248500555`
+- ID: `9713604462`
+- workflow run head SHA: `2cf3451747c03a045c9cd275c58238db04a4f151`
+- digest: `sha256:16a39097e7851ce11aae09f8981f517ad9c224f5741a201cd209cc1cbbef91ed`
+
+このreport commit後はPR HEADが変わるため、上記runをfinal PR HEAD CIとしては代用しない。final exact-head CIはreport commit後の新しいHEADに対して別途確認する。
+
+## 残存制約
+
+- 本repositoryはCodex runtime本体を変更しないため、parent-visible final agent config snapshot APIは追加していない。
+- runtimeがfinal model/reasoningをparentへ公開しない場合、exact `applied`は不明のまま保持する。
+- role/default-role configをspawn前に確認できないruntimeでは、高コストapproval gateを保証するためdispatchをcapability gapとして停止する。
+- multi-agent review lifecycle自体は今回のscope外であり、review executionはsingle reviewer policyを維持する。
+
+## Merge
+
+mergeは行わない。

--- a/reports/issue-13-pr65-r3-rereview-20260829.md
+++ b/reports/issue-13-pr65-r3-rereview-20260829.md
@@ -1,0 +1,382 @@
+# PR #65 R3 再reviewレポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- Issue: `#13 sub-agentの使用モデル`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- review mode: `fix verification + full changed-area regression review`
+- branch: `feat/adaptive-agent-assignment`
+- base: `main`
+- reviewed implementation HEAD: `bfac39347647e66dfce7c8af925f2deab2300d92`
+- previous review report: `reports/issue-13-pr65-rereview-20260829.md`
+- previous findings: `F65-R2-001`〜`F65-R2-003`
+- date: `2026-08-29`
+- reviewer: current ChatGPT review chat
+- verdict: `fail`
+- merge: not performed
+
+## authoritative requirements
+
+- user instruction: PR #65を再reviewし、指摘点を一度で網羅する。
+- uploaded review Skills:
+  - `chat-review-worker`
+  - `review-worker`
+  - `work-context-manager`
+  - `report-writer`
+- repository instruction: root `AGENTS.md`に従いCodexSkill repository maintenanceへTDDを適用しない。
+- project instruction: repository/PR操作にはGitHub connectorを使用し、current PR HEADとworkflow run `head_sha`が一致するrunだけをCI evidenceとして扱い、詳細reportをrepositoryへ保存し、mergeしない。
+
+## scope
+
+- 前回R2 findingのclosure確認
+- R2後の8 commitの差分確認
+- PR全変更fileとprofile selection / spawn application / review lifecycle / report lifecycleの直接依存確認
+- 現行OpenAI GPT-5.6 model guidanceとの整合確認
+- 現行`openai/codex`のspawn-agent runtime実装との整合確認
+- exact-head CI確認
+
+## non-goals
+
+- findingの実装修正
+- PR merge
+- Codex runtime本体の変更
+- multi-agent review lifecycleの新設
+
+## target identity
+
+- reviewed implementation HEAD: `bfac39347647e66dfce7c8af925f2deab2300d92`
+- base HEAD: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+- R2 review-report HEAD: `5302de3d4bc4c7c29e53943bba30a7307df16cee`
+- R2後のcommit数: 8
+
+R2後に変更されたfile:
+
+- `design/adaptive-agent-assignment-design.md`
+- `reports/issue-13-pr65-r2-findings-followup-20260829.md`
+- `skills/report-output-manager/SKILL.md`
+- `skills/report-output-manager/references/sub-agent-report-template.md`
+- `skills/review-enforcer/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+
+PR全体のchanged fileは17件。
+
+## R2 finding closure
+
+### F65-R2-001 / HIGH
+
+Status: `resolved`
+
+確認内容:
+
+- `requested`はpre-spawn instructionとして記録される。
+- spawn前は`applied: null` / `application_status: pending_runtime_result`。
+- actual spawn argsには`requested`を使用する。
+- spawn / inheritance / rejection / fallback後にのみ`applied`を記録する。
+- rejected requestを`applied`へcopyしない。
+
+時系列の逆転は解消されている。
+
+### F65-R2-002 / HIGH
+
+Status: `resolved for the original finding`
+
+確認内容:
+
+- independent final reviewは`report_persistence_mode: deferred_attestation`。
+- freeze前はreport pathをmetadata予約するだけでrepository fileを作成しない。
+- independent reviewerはreserved report fileを編集せず、structured evidenceをparentへ返す。
+- passing verdict後だけreserved pathへ初回persistして1 report-attestation commitを作る。
+
+元findingの「freeze後にchild report fileを作る」問題は解消された。
+
+ただし、この修正によって`report-output-manager`のRequired Skills contractとの新しい矛盾が顕在化した。詳細は`F65-R3-002`。
+
+### F65-R2-003 / HIGH
+
+Status: `resolved for the original finding`
+
+確認内容:
+
+- `review-enforcer`のnew normal / replacement / independent reviewerはsingle reviewer固定。
+- `decomposition_policy: forbidden`。
+- `parallelism_mode: single_agent`。
+- task managerはreviewer taskをmulti-agent decompositionへ戻さない。
+
+one-reviewer identity lifecycleは維持される。
+
+ただし、policyとtask propertyを同じ値へ潰しているためselection evidence上の新規問題がある。詳細は`F65-R3-003`。
+
+## 新規 findings
+
+### F65-R3-001 / HIGH
+
+#### location
+
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+- 関連: `skills/sub-agent-task-manager/SKILL.md`
+- 関連: `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+
+#### description
+
+PRはspawn後のruntime evidenceからexact `applied.model` / `applied.reasoning_effort`を記録する契約にしているが、現行Codex V2ではsuccessful `spawn_agent` resultだけでは最終profileを観測できない。
+
+現行`openai/codex`実装では、`multi_agents_v2/spawn.rs`で次の順に処理される。
+
+1. `apply_requested_spawn_agent_model_overrides`
+2. `apply_spawn_agent_role`
+3. spawn
+
+`apply_spawn_agent_role`は`agent_type`省略時にも`default` roleを適用する。さらに`agent/role.rs`ではuser-defined roleがbuilt-inより優先され、role configは`model`と`model_reasoning_effort`を上書き可能。
+
+一方、`spawn_agent` outputは`hide_agent_metadata`時に`task_name`しか返さず、model / reasoning effortをparentへ返さない。内部の`ThreadConfigSnapshot`はanalyticsには使われるがtool outputへ含まれない。
+
+#### impact
+
+- successful callを根拠に`applied=requested`とすると誤証跡になりうる。
+- explicit user profile overrideがroleで上書きされても検出できない。
+- user-defined `default` roleがSol `xhigh` / `max`へ上げる場合、PRのmandatory approval gateを通らず高コストprofileが実際に適用されうる。
+- requested/applied分離の主要目的であるruntime fidelityが成立しない。
+
+#### evidence
+
+現行OpenAI Codex source:
+
+- `https://github.com/openai/codex/blob/main/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs`
+- `https://github.com/openai/codex/blob/main/codex-rs/core/src/agent/role.rs`
+- `https://github.com/openai/codex/blob/main/codex-rs/core/src/tools/handlers/multi_agents_spec.rs`
+
+確認事項:
+
+- requested override後にroleを適用する。
+- role configはmodel / reasoning effortをoverride可能。
+- hidden-metadata outputはtask nameのみ。
+
+#### required action
+
+- spawn call planningへeffective agent role / default roleを含める。
+- roleでmodel / reasoningが固定または変更される場合、そのeffective profileをapproval gateにも反映する。
+- Sol `xhigh` / `max`へroleが上げる場合もdispatch前approvalを必須にする。
+- actual snapshotをcallerが観測できないruntimeではexact `applied`を断定せず、`unknown` / `unverified_applied_profile`等のcapability stateを定義する。
+- exact applied profileを記録するのはruntime metadataまたは決定的なrole/profile evidenceが得られる場合だけにする。
+
+### F65-R3-002 / HIGH
+
+#### location
+
+- `skills/report-output-manager/SKILL.md`
+- 関連: `skills/sub-agent-task-manager/SKILL.md`
+- 関連: `skills/review-enforcer/SKILL.md`
+
+#### description
+
+`report-output-manager`冒頭のRequired Skillsは`work-context-manager`と`report-writer`を無条件に`Invoke`すると定義している。
+
+一方、R2修正で追加されたindependent-final-reviewのbefore-review phaseは「reservation only」であり、review開始前にreportを生成せずexact path metadataだけを予約する契約になった。
+
+uploaded `report-writer` contractではindependent-final-review report生成に次が必要:
+
+- immutable reviewed implementation HEAD
+- reviewer identity / independence
+- complete coverage / findings / held / unexplored
+- validation assessment
+- verdict
+- pre-reserved path
+
+review前のreservation phaseにはこれらreview resultが存在しない。
+
+#### impact
+
+- `sub-agent-task-manager`がindependent reviewer dispatch前に`report-output-manager`を呼ぶと、同SkillのRequired Skillsを満たすためには`report-writer`を早過ぎる段階で呼ぶ必要がある。
+- `report-writer`を呼べばdeferred-attestationの「review前はreportを生成しない」contractを破る。
+- 呼ばなければ`report-output-manager`自身のRequired Skills contractを破る。
+- independent final reviewのreservation phaseが自己矛盾している。
+
+#### required action
+
+`report-output-manager`をphase別contractへ分離する。
+
+例:
+
+- `reservation_only`: `work-context-manager`のみ必須。report path metadataを返し、`report-writer`を呼ばない。
+- `normal_persistence`: `report-writer`を使用。
+- `report_attestation_commit`: passing independent evidenceが揃った後に`report-writer`を必須化。
+
+`Required Skills`もunconditional listではなくmode別に定義する。
+
+### F65-R3-003 / MEDIUM
+
+#### location
+
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- 関連: `skills/review-enforcer/SKILL.md`
+- 関連: `design/adaptive-agent-assignment-design.md`
+
+#### description
+
+`decomposability`はtask自身の性質、`decomposition_policy`はcallerが実行分割を許可するかというpolicyであり、別軸である。
+
+現行contractは`decomposition_policy: forbidden`の場合、scopeに複数の独立review areaが存在しても`decomposability: single`へ上書きすると明記している。
+
+これはobserved task signalをpolicyで書き換えている。
+
+#### impact
+
+- reportされるselection inputが実際のtask propertyと異なる。
+- 将来のclassification / audit / tuningで「分割可能だったがidentity policyで禁止した」ケースと「本当に非分割だった」ケースを区別できない。
+- `max` effortは「exceptionally difficult, non-decomposable problem」が条件なので、policyにより人工的に`single`化したsignalがmax判定を歪めうる。
+- R2-003で必要だったsingle-reviewer保証自体には`decomposition_policy: forbidden`だけで足りる。
+
+#### required action
+
+- `decomposability`には観測されたtask propertyを保持する。
+- review scopeが独立workstreamを含むなら`independent_workstreams`等をそのまま記録する。
+- `decomposition_policy: forbidden`で実行上の分割だけ禁止する。
+- profile selection / max判定では「inherent decomposability」と「policy-forbidden execution」を区別する。
+
+## coverage
+
+### requirement and design conformance
+
+Disposition: `checked_finding`
+
+- adaptive Luna / Terra / Sol selection: 概ね整合。
+- Sol xhigh/max approval gate: Skill上は整合するがruntime role overrideで迂回可能 (`F65-R3-001`)。
+- Ultraをmulti-agent strategyとして扱う方針: OpenAI current model guidanceと整合。
+
+### correctness and edge cases
+
+Disposition: `checked_finding`
+
+- requested -> spawn -> applied時系列: R2問題はresolved。
+- role post-override / hidden metadata edge: findingあり (`F65-R3-001`)。
+- full-history inheritance: contract上整理済み。
+
+### scope discipline
+
+Disposition: `checked_no_finding`
+
+R2対応は前回finding closureと関連contract同期に限定されている。
+
+### changed files and direct dependency impact
+
+Disposition: `checked_finding`
+
+- task manager / profile selector / spawn reference / review enforcer / report manager / designを横断確認。
+- report managerのmode dependency contradictionあり (`F65-R3-002`)。
+
+### API / runtime compatibility
+
+Disposition: `checked_finding`
+
+OpenAI current sourceと比較し、role application orderとmetadata visibilityにcompatibility findingあり (`F65-R3-001`)。
+
+### error handling and fallback
+
+Disposition: `checked_no_finding` with finding overlap
+
+- runtime rejectionをcapability gap / parent-owned fallbackとして扱う設計は存在する。
+- exact applied observability不足は`F65-R3-001`で扱う。
+
+### security / secret handling
+
+Disposition: `not_applicable`
+
+新規secret handlingなし。
+
+### tests and validation adequacy
+
+Disposition: `checked_no_finding`
+
+CodexSkill repository policyによりTDDはnot applicable。repository validator / ZIP build / exact-head GitHub Actionsを使用。
+
+### current-HEAD CI evidence
+
+Disposition: `checked_no_finding`
+
+reviewed HEAD `bfac39347647e66dfce7c8af925f2deab2300d92`:
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33246248774`
+- run number: `182`
+- run head SHA: `bfac39347647e66dfce7c8af925f2deab2300d92`
+- conclusion: `success`
+- artifact: `chatgpt-worker-skills-33246248774`
+- artifact ID: `9712923664`
+- digest: `sha256:72362ef0717170a990ca6067d6027e07f16610b1a8eb6c62e363feebda2d4927`
+
+別SHAのrunは使用していない。
+
+### report / documentation accuracy
+
+Disposition: `checked_finding`
+
+R2 follow-up reportはR2 findingへの対応内容を正しく記録している。
+ただし新しいruntime compatibility issueとreport dependency issueは未記録であり、本reportでfinding化した。
+
+### regression / maintainability
+
+Disposition: `checked_finding`
+
+- decomposability signalをpolicyで潰す設計は将来のclassification evidenceを損なう (`F65-R3-003`)。
+
+## external/current verification
+
+OpenAI current documentationを確認した。
+
+- GPT-5.6 current IDs:
+  - `gpt-5.6-sol`
+  - `gpt-5.6-terra`
+  - `gpt-5.6-luna`
+- GPT-5.6 reasoning effort:
+  - `none`
+  - `low`
+  - `medium`
+  - `high`
+  - `xhigh`
+  - `max`
+- model guidanceはMulti-agentをCodex ultra modeと類似するstrategyとして説明している。
+
+Sources:
+
+- `https://developers.openai.com/api/docs/models`
+- `https://developers.openai.com/api/docs/guides/latest-model`
+
+この部分にはfindingなし。
+
+## held
+
+なし。
+
+## unexplored
+
+- live account上の実`collaboration.spawn_agent` override integration test。repositoryにfixtureなし。
+- 実user環境のcustom agent role設定。runtime source上、custom/default roleがmodel/reasoningを上書き可能であることまでは確認済み。
+
+`F65-R3-001`はこのlive fixture不在を理由にheldへ落とさない。runtime sourceだけでcontract gapを確認できる。
+
+## remaining risks
+
+- model catalogやCodex role/spawn contractが将来変更された場合はcentral mappingとapplication contract更新が必要。
+- current validatorはSkill dependency/link構造を検証するが、mode別semantic contradictionやruntime application observabilityまでは検証しない。
+
+## verdict
+
+`fail`
+
+Required findings:
+
+- `F65-R3-001 / HIGH`
+- `F65-R3-002 / HIGH`
+- `F65-R3-003 / MEDIUM`
+
+R2 findingsはresolvedだが、上記3件が未解決のためacceptance不可。
+
+## next action
+
+- 3 findingを修正する。
+- R3 fix後はsame normal review chatでfinding-by-finding fix verificationを行う。
+- 修正HEADと一致するworkflow runだけをCI evidenceとして使用する。
+- mergeは利用者が行う。

--- a/reports/issue-13-pr65-r4-findings-followup-20260829.md
+++ b/reports/issue-13-pr65-r4-findings-followup-20260829.md
@@ -1,0 +1,169 @@
+# PR #65 R4 指摘対応レポート
+
+## 対象
+
+- Repository: `ssaattww/CodexSkill`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- 対応開始時HEAD: `d56be39ce7e69a6fd051dea684f9b0be6958fec0`
+- R4技術修正HEAD: `7db502a389fba91a079719fbfab1c60b4a06a6c8`
+- 対象finding:
+  - `F65-R4-001 / HIGH`
+  - `F65-R4-002 / HIGH`
+  - `F65-R4-003 / MEDIUM`
+
+CodexSkill repository自身の保守であるため、repository policyに従いTDDは適用していない。
+
+## F65-R4-001
+
+### 指摘
+
+R3で`sub-agent-task-manager`がmetadata-hidden runtimeの正常系を次の状態として許容した一方、上流`codex-delegation-executor`が依然としてexact `applied` profileを必須としていた。
+
+```yaml
+applied: null
+application_status: spawn_succeeded_profile_unverified
+```
+
+このためtask managerが正しく完了してもdelegatorのcompletion contractを満たせない矛盾があった。
+
+### 対応
+
+`skills/codex-delegation-executor/SKILL.md`をR3 runtime-observability contractへ同期した。
+
+sub-agent evidenceとして次を必須系列に変更した。
+
+- `requested`
+- `role_plan`
+- `planned_runtime_profile`
+- `profile_observability`
+- exact `applied`はparent-visibleなfinal profile evidenceがある場合のみ
+- exact profileが見えない場合は`spawn_succeeded_profile_unverified`等のexplicit state
+- inherited / fallback / capability-gap state
+
+Outputs / Evidence rules / Completion conditionの全てで、exact `applied`を無条件必須にしない。
+
+また、ordinary `normal_persistence`とindependent-final `deferred_attestation`を分離し、後者ではpre-created reportの直接編集を要求しないよう修正した。
+
+主commit:
+
+- `350ae95ade140a9237f7f68f4eb4cb54b6a8cd31` `fix: sync delegation evidence with runtime observability`
+
+## F65-R4-002
+
+### 指摘
+
+independent-final report path reservationのownerが二重化していた。
+
+- `review-enforcer`がfreeze前にreservation-only phaseでpath予約
+- その後`sub-agent-task-manager`も`deferred_attestation`でreservation phaseを再実行
+
+2回目が別pathを返した場合、freeze前reservation identityが失われる可能性があった。
+
+### 対応
+
+reservation ownershipを`review-enforcer`へ一本化した。
+
+`review-enforcer`がpre-freezeで一度だけ次を確定する。
+
+```yaml
+reservation_owner: review-enforcer
+reservation_identity: <stable identity>
+pre_reserved_report_path: <exact path>
+reservation_state: metadata_only
+```
+
+`sub-agent-task-manager`は`deferred_attestation`時に次を行う。
+
+- callerから上記reservation evidenceを必須inputとして受け取る
+- reservation ownerが`review-enforcer`であることを確認
+- pre-freeze metadata-only reservationであることを確認
+- repository fileがまだ作成・変更されていないことを確認
+- **reservation-only phaseを再実行しない**
+- missing / ambiguous / post-freeze / materialized reservationはblockerとして扱う
+- bounded independent closureでも同じreservation identityを維持する
+
+主commit:
+
+- `169711aacb6a9d69ab6f39793c9a9a0d2c6f732e` `fix: reuse independent review report reservation`
+- `e5ecf0b5f90667427c98452a64d418d007e9ebe2` `fix: make review enforcer reservation owner`
+
+## F65-R4-003
+
+### 指摘
+
+`adaptive-agent-assignment-design.md`のdeferred-attestation意味論がSkill hierarchy正本／mirrorへ同期されておらず、正本にはindependent reviewer自身がreportを作るように読める契約が残っていた。
+
+また`codex-delegation-executor`にも全reviewerへpre-created report直接編集を要求する記述が残っていた。
+
+### 対応
+
+`design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同一blobでatomicに更新した。
+
+正本へ次を明示した。
+
+1. normal reviewerは`normal_persistence`
+2. independent-final review前に`review-enforcer`がreservation-only phaseを一度だけ実行
+3. reservation phaseでは`work-context-manager`のみを使用し、`report-writer`を呼ばない
+4. `sub-agent-task-manager`はpre-reserved identityをreuseして`deferred_attestation`でfresh reviewerをdispatch
+5. independent reviewerはrepository report fileを作成・編集せずstructured evidenceをparentへ返す
+6. findingが出てもsame reservation identityを保持し、passing前にreportをpersistしない
+7. passing verdict後だけattestation-persistence phaseで`report-writer`を呼び、reserved pathへ初回materialize
+8. hierarchy共通規則でもruntime profile unverified stateとdeferred reservation例外を明記
+
+hierarchy正本とmirrorは同一blob SHA `984c549dd78c0f4f7f91e3e73768925219c3996e`を参照するtreeとして1commitで更新した。
+
+主commit:
+
+- `7db502a389fba91a079719fbfab1c60b4a06a6c8` `docs: sync deferred review hierarchy contract`
+
+## 変更ファイル
+
+R4対応で変更したfile:
+
+- `skills/codex-delegation-executor/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/review-enforcer/SKILL.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+
+同時期にreviewer側から`reports/issue-13-pr65-r4-rereview-20260829.md`がbranchへ追加されている。これはR4 review evidenceとして保持し、本対応では削除・書換えしていない。
+
+## 検証
+
+### R4技術修正HEAD
+
+- HEAD: `7db502a389fba91a079719fbfab1c60b4a06a6c8`
+- Workflow: `Validate and release ChatGPT worker skills`
+- Run ID: `33251174658`
+- Run number: `197`
+- Conclusion: `success`
+- Build job: `99096989068`
+
+成功step:
+
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
+
+Artifact:
+
+- name: `chatgpt-worker-skills-33251174658`
+- ID: `9714403697`
+- workflow run head SHA: `7db502a389fba91a079719fbfab1c60b4a06a6c8`
+- digest: `sha256:0dff6fa5ab8d0e95074b9cbca087953bb16f19143a78dae2b34feee29ac600fa`
+
+別SHAのworkflow runはR4技術修正のCI evidenceとして使用していない。
+
+## 最終HEADの扱い
+
+本reportをrepositoryへ保存するcommitによりPR HEADはR4技術修正HEADから進む。
+
+最終CIは、このreport commitを含むPR current HEADとworkflow run `head_sha`が完全一致するrunだけを確認する。別SHAの成功runは代用しない。
+
+## 残存事項
+
+- parent-visible final runtime profile snapshotが存在しないruntimeではexact `applied`を断定しない設計を維持する
+- independent-final report reservationはcurrent lifecycleでは`review-enforcer`単独ownerとする
+- multi-agent review lifecycle自体は本PRのscope外
+- mergeは行わない

--- a/reports/issue-13-pr65-r4-rereview-20260829.md
+++ b/reports/issue-13-pr65-r4-rereview-20260829.md
@@ -1,0 +1,303 @@
+# PR #65 R4 再reviewレポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- Issue: `#13 sub-agentの使用モデル`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- review mode: `fix verification`
+- branch: `feat/adaptive-agent-assignment`
+- base: `main`
+- base HEAD: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+- previous review report HEAD: `3252f67802faea920adff9f917d1e36b2c11ae93`
+- reviewed implementation HEAD: `d56be39ce7e69a6fd051dea684f9b0be6958fec0`
+- reviewed fix range: `3252f67802faea920adff9f917d1e36b2c11ae93...d56be39ce7e69a6fd051dea684f9b0be6958fec0`
+- reviewer: current ChatGPT normal-review chat
+- reviewer continuity: R3 reviewと同一chat
+- implementation performed by reviewer: なし
+- merge: 実施しない
+
+## 目的
+
+R3で指摘した次の3 findingの修正確認を行い、同時にR3修正で追加・変更された領域と直接依存を再reviewする。
+
+- `F65-R3-001 / HIGH`: role/default-role適用後のfinal profile observabilityとapproval gate
+- `F65-R3-002 / HIGH`: independent-final reservation phaseで`report-writer`を呼ばないphase contract
+- `F65-R3-003 / MEDIUM`: observed decomposabilityとexecution decomposition policyの分離
+
+fix verificationではsource findingのseverityを維持し、修正差分により新たに生じた領域と同一欠陥classも確認した。
+
+## authoritative requirements
+
+- user instruction: PR #65を再reviewし、一度で指摘点を網羅する。
+- Issue #13: sub-agentのtask種別に応じた使用model定義不足を解消する。
+- repository policy: CodexSkill repository maintenanceはnon-TDD。
+- project CI rule: PR current HEAD SHAとworkflow runの`head_sha`が一致するrunのみCI evidenceに使用する。
+- uploaded review Skills: `chat-review-worker`、`review-worker`、`work-context-manager`、`report-writer`の契約に従う。
+
+## R3 finding closure
+
+### F65-R3-001 / HIGH — resolved
+
+R3では、requested overrideの後にagent role/default roleがmodel/reasoningを再変更でき、通常のparent-visible `spawn_agent` outputではfinal profileを観測できない問題を指摘した。
+
+current implementationでは次を確認した。
+
+- `requested`と`planned_runtime_profile`をpre-spawn evidenceとして分離
+- explicit/default roleを`role_plan`へ含める
+- role configがmodel/reasoningを変更・lockする場合、role-adjusted profileでfloorとSol `xhigh/max` approvalを再評価
+- role影響を安全に確認できない場合はpre-spawn capability gapとして停止
+- spawn成功だけでは`applied`を確定しない
+- final profileがparent-visibleでない場合は`applied: null`
+- `application_status: spawn_succeeded_profile_unverified`
+- `profile_observability: final_profile_hidden`
+
+current OpenAI model catalogでも`gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna`および`none`〜`max`のreasoning effortが現行仕様であることを確認した。
+
+R3 required actionを満たしているためresolved。
+
+### F65-R3-002 / HIGH — resolved
+
+`report-output-manager`はphase-specific required Skillsへ変更された。
+
+- normal persistence: `work-context-manager` + `report-writer`
+- independent-final reservation: `work-context-manager`のみ
+- reservation phaseでは`report-writer`をinvokeしない
+- passing verdict後のattestation persistenceでのみ`report-writer`をinvokeする
+
+`review-enforcer`と`development-orchestrator`もreservation-only / attestation-persistenceのphase境界へ同期されている。
+
+R3 required actionを満たしているためresolved。
+
+### F65-R3-003 / MEDIUM — resolved
+
+current selectorは次を明確に分離している。
+
+- `decomposability`: observed work structure
+- `decomposition_policy`: execution constraint
+- `decomposition_disposition`: decompositionを実行しなかった理由
+
+review scopeが`independent_workstreams`でも、review lifecycleにより`decomposition_policy: forbidden` / `parallelism_mode: single_agent`を適用できる。policy禁止をSol `max`のintrinsic non-decomposability根拠にしないことも明記された。
+
+R3 required actionを満たしているためresolved。
+
+## R4 findings
+
+### F65-R4-001 / HIGH
+
+- origin: `coverage_miss`
+- location: `skills/codex-delegation-executor/SKILL.md` Outputs / Evidence rules / Completion condition
+
+#### description
+
+R3で`sub-agent-task-manager`は、final runtime profileがparent-visibleでない正常系を次のように扱えるようになった。
+
+```yaml
+applied: null
+application_status: spawn_succeeded_profile_unverified
+profile_observability: final_profile_hidden
+```
+
+しかし上流の`codex-delegation-executor`は依然として次を必須としている。
+
+- `selected and applied dispatch-profile evidence for every sub-agent task`
+- `requested and applied dispatch profile for every sub-agent`
+- completion: `selected and applied profiles are recorded for sub-agent work`
+
+#### impact
+
+current Codex MultiAgent V2でfinal profile metadataがparent-visibleでない場合、`sub-agent-task-manager`は新contract上正しく完了しても、`codex-delegation-executor`のcompletion conditionを満たせない。
+
+これはreview以外のimplementation / verification / investigation等、delegatorを通る通常sub-agent taskを終了不能にする契約矛盾である。
+
+#### evidence
+
+- `skills/sub-agent-task-manager/SKILL.md`: exact `applied`またはexplicit unverified stateを許容
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`: `spawn_succeeded_profile_unverified` schema
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`: spawn successだけでexact appliedを断定しない
+- `skills/codex-delegation-executor/SKILL.md`: exact appliedをoutput/evidence/completionに要求したまま
+
+#### required action
+
+`codex-delegation-executor`のOutputs / Evidence rules / Completion conditionを新schemaへ同期する。
+
+少なくともsub-agent evidenceとして次を受け入れること。
+
+- requested profile
+- role/default-role plan
+- planned runtime profile
+- profile observability
+- exact applied profile when observable
+- `applied: null` + explicit unverified/inherited/fallback/capability-gap state when exact evidence is unavailable
+
+exact `applied`を全taskの必須条件にしない。
+
+### F65-R4-002 / HIGH
+
+- origin: `introduced_by_fix`
+- location: `skills/review-enforcer/SKILL.md` step 12 / 14 and `skills/sub-agent-task-manager/SKILL.md` step 11
+
+#### description
+
+independent-final report pathのreservation ownerが二重になっている。
+
+`review-enforcer` required flow:
+
+1. step 12で`report-output-manager` reservation-only phaseを実行
+2. exact report pathをmetadataとして予約
+3. その後implementation HEADをfreeze
+4. step 14で`sub-agent-task-manager`を`report_persistence_mode: deferred_attestation`として呼ぶ
+
+一方`sub-agent-task-manager` required flow step 11は、`deferred_attestation`の場合に再度`report-output-manager` reservation phaseを呼び、exact pathを予約する契約である。
+
+#### impact
+
+2回目のreservationはfreeze後に行われる。`sub-agent-task-manager`のInputs/flowにpre-reserved pathまたはreservation identityを受け取ってreuseする分岐がない。
+
+path namingがcollision回避、sequence、timestamp、existing reservation state等へ依存する場合、2回目に別pathを返す可能性がある。その場合、reviewerへ渡したpathやpassing verdict後にpersistするpathが「freeze前に予約されたpath」ではなくなり、report-attestation allowlistを満たせない。
+
+同じpathが偶然返る場合でも、reservationのsingle ownerとidentity continuityが契約化されていない。
+
+#### evidence
+
+- `skills/review-enforcer/SKILL.md` step 12: freeze前にreservation-only phaseを実行
+- 同step 14: freeze後に`sub-agent-task-manager`をdeferred attestationで呼ぶ
+- `skills/sub-agent-task-manager/SKILL.md` step 11: deferred attestationでreservation phaseを実行
+- `sub-agent-task-manager` Inputsに既存reservation path/identityの受け渡し契約なし
+
+#### required action
+
+reservation ownerを一つにする。
+
+推奨案:
+
+- `review-enforcer`がfreeze前のreservation owner
+- `sub-agent-task-manager`へ`pre_reserved_report_path` / reservation identityを渡す
+- deferred-attestationでpre-reserved pathがある場合、task managerは再予約せずvalidate/reuseする
+
+または、task managerにreservation ownershipを一本化する場合は、freeze前にdispatchなしのprepare/reservation phaseを呼び、freeze後はそのreservationを再利用するようphaseを分離する。
+
+### F65-R4-003 / MEDIUM
+
+- origin: `coverage_miss`
+- location: `skills/codex-delegation-executor/SKILL.md`, `design/skill-hierarchy-design.md`, `skills/design/skill-hierarchy-design.md`
+
+#### description
+
+R2/R3で導入した`deferred_attestation` semanticsが上流delegation contractとSkill hierarchy正本へ同期されていない。
+
+current `codex-delegation-executor`は全sub-agent/review taskへ次を要求している。
+
+- every sub-agent request must leave a report in `reports/`
+- pre-create report before dispatch
+- reviewer edits pre-created report directly
+- review chat-only outputを禁止しreport fileへのmaterializeを要求
+
+一方current independent-final contractはpassing verdict前のrepository report file creation/editを明示的に禁止している。
+
+またSkill hierarchyの正本`design/skill-hierarchy-design.md`（mirror含む）はfresh independent reviewer要件として「normal review reportとは別にindependent final review reportを作ること」と残っている。
+
+#### impact
+
+上流delegation ruleまたはhierarchy正本をそのまま実行すると、independent reviewerがpassing verdict前にreport fileを作成・編集し、`review-enforcer` / `report-output-manager`のpre-freeze stabilityとsingle attestation commit contractを破る。
+
+CodexSkillはSkill/Design自体が実行契約であるため、単なる文書表現差ではなくruntime workflow ambiguityになる。
+
+#### evidence
+
+- `skills/sub-agent-task-manager/SKILL.md`: independent finalは`deferred_attestation` exception
+- `skills/review-enforcer/SKILL.md`: passing verdictまでreserved report fileを作らない
+- `skills/report-output-manager/SKILL.md`: reservation phaseはmetadata only
+- `skills/codex-delegation-executor/SKILL.md`: pre-created report/direct editを全reviewへ要求
+- `design/skill-hierarchy-design.md`: independent reviewer自身に別report作成を要求
+- `skills/design/skill-hierarchy-design.md`: canonical mirrorとして同内容
+
+#### required action
+
+- `codex-delegation-executor`へ`report_persistence_mode`を伝播し、independent-final/deferred-attestationをpre-create/direct-edit規則の明示例外にする
+- `design/skill-hierarchy-design.md`と`skills/design/skill-hierarchy-design.md`を同時更新し、independent reviewerはstructured evidenceをparentへ返し、passing verdict後に`report-writer`がreserved pathへ初回persistすることを正本へ反映する
+- hierarchy topologyだけでなくreview/report semanticsが変わったことを同期対象とする
+
+## required coverage
+
+| criterion | disposition | evidence |
+| --- | --- | --- |
+| requirement and design conformance | `checked_finding` | Issue #13のprofile assignment自体は実装済み。上流contract/正本同期にR4 findingあり |
+| correctness and edge cases | `checked_finding` | hidden final profile、role/default role、reservation orderingを確認 |
+| scope discipline and unrelated changes | `checked_no_finding` | R3 fix rangeはfinding対応と設計/report同期に限定 |
+| changed files and direct dependency impact | `checked_finding` | R3変更9 fileに加えdelegator、hierarchy正本、runtime sourceを確認 |
+| API/data/config/workflow compatibility | `checked_finding` | Codex MultiAgent V2 role/spawn behaviorとの整合を確認。上流workflow mismatchあり |
+| error handling/failure diagnostics | `checked_no_finding` | capability-gap/unverified stateは明示化済み |
+| security/secret handling | `not_applicable` | 本変更にcredential/secret処理なし |
+| tests and validation adequacy | `checked_no_finding` | repository validator/ZIP build exact-head CI success。semantic integration fixtureなしはremaining risk |
+| current-HEAD CI evidence | `checked_no_finding` | run `33248577910`, head SHA `d56be39ce7e69a6fd051dea684f9b0be6958fec0`, success |
+| report/tracking/documentation accuracy | `checked_finding` | hierarchy正本とdeferred-attestation semantics不整合 |
+| regression/maintainability | `checked_finding` | duplicate reservation ownerとstale applied completion contract |
+
+## validation assessment
+
+### current implementation HEAD
+
+- target HEAD: `d56be39ce7e69a6fd051dea684f9b0be6958fec0`
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33248577910`
+- run number: `192`
+- event: `pull_request`
+- run `head_sha`: `d56be39ce7e69a6fd051dea684f9b0be6958fec0`
+- status: `completed`
+- conclusion: `success`
+
+このrunのみをcurrent implementation HEADのCI evidenceとして使用した。
+
+成功対象:
+
+- repository Skill architecture and active links
+- ChatGPT wrapper / core Skill ZIP build and listing
+- validation artifact upload
+
+### semantic validation limitation
+
+repository CIはSkill architecture、active link、distribution ZIPを検証するが、次のsemantic lifecycleまでは実行しない。
+
+- actual `spawn_agent` role/default-role behavior
+- hidden profile observability
+- independent-final reservation identity continuity
+- deferred-attestation lifecycle
+
+このためCI successはR4 findingを否定しない。
+
+## held / unexplored
+
+### held
+
+なし。
+
+### unexplored
+
+- area: live Codex `spawn_agent` integration
+- blocker: CodexSkill repositoryにlive collaboration fixtureがない
+- remaining risk: runtime version差によりrole/default-role/final profile observability behaviorが変化する可能性
+- verdict impact: current contractはunknown/capability gapを保持するためR4 finding以外の追加blockerにはしない
+
+## verdict
+
+`fail`
+
+理由:
+
+- required finding 3件あり
+- うち2件はindependent-final lifecycleまたはdelegated task completionを直接阻害するHIGH severity
+
+## remaining risks
+
+- Codex runtime version driftによりrole/default-role適用順またはmetadata exposureが変化する可能性
+- semantic lifecycleはrepository CIで自動実行されない
+- report reservation identityをsingle-owner化するまでindependent-final attestation path continuityが不安定
+
+## next action
+
+1. `F65-R4-001`〜`F65-R4-003`を実装修正する。
+2. 修正後は同一normal review chatでfix verificationを行う。
+3. current PR HEADと一致するworkflow runのみCI evidenceに使用する。
+4. required finding解消後にnormal review lifecycleを収束させる。
+5. mergeは利用者が行う。

--- a/reports/issue-13-pr65-r5-findings-followup-20260830.md
+++ b/reports/issue-13-pr65-r5-findings-followup-20260830.md
@@ -1,0 +1,171 @@
+# Issue #13 / PR #65 R5 指摘対応レポート
+
+## 目的
+
+PR #65 のfix verificationで再オープンされた`F65-R4-002`と、新規`F65-R5-001`へ対応し、independent-final terminal lifecycleのownerをrepository全体で`review-enforcer`へ一本化する。
+
+## 対象PR
+
+- Repository: `ssaattww/CodexSkill`
+- PR: #65 `feat: task特性に応じてsub-agent profileを自動選定する`
+- Branch: `feat/adaptive-agent-assignment`
+
+## 対象finding
+
+### F65-R4-002 / HIGH — fix verificationで再オープン
+
+`review-enforcer`と`sub-agent-task-manager`間の二重reservationは解消していたが、`development-orchestrator` step 20がindependent-final report reservation-only phaseとHEAD freezeを直接実行していた。
+
+その後`review-enforcer`も自分のstep 12でexactly-once reservationとfreezeを行うため、repository全体ではreservation ownerが一意になっていなかった。
+
+### F65-R5-001 / HIGH
+
+`development-orchestrator`は`review-enforcer`が独立最終reviewからattestation persistence、final push、PR publication、exact-head CIまで完了した後に、同じattestation persistence / publication / CI waitを再度実行する契約を持っていた。
+
+これにより次のinvariantを破りうる状態だった。
+
+- independent-final reservationは1件のみ
+- report-attestation commitは最大1件
+- final publicationは1 owner
+- exact-head merge-gate CI waitは1回
+
+## 原因
+
+R4で`review-enforcer`をreservation ownerへ一本化した際、downstreamの`sub-agent-task-manager`は同期したが、上位`development-orchestrator`のterminal stepsが旧owner modelのまま残っていた。
+
+つまり責務境界が次のように二重化していた。
+
+```text
+development-orchestrator
+  -> reservation / freeze
+  -> review-enforcer
+       -> reservation / freeze / independent review / attestation / publish / CI
+  -> attestation / publish / CI again
+```
+
+## 修正内容
+
+### development-orchestratorのterminal ownershipを修正
+
+`skills/development-orchestrator/SKILL.md`を更新した。
+
+新しい責務境界は次のとおり。
+
+```text
+development-orchestrator
+  -> implementation / validation / normal review / end-of-Issue work
+  -> pre_freeze_ready
+  -> review-enforcer
+       -> exactly-once reservation
+       -> reviewed implementation HEAD freeze
+       -> independent reviewer lifecycle
+       -> same-reviewer bounded closure
+       -> at most one report-attestation commit
+       -> attestation diff validation
+       -> final push
+       -> PR publication
+       -> exact-head required pull_request CI wait
+  -> consume terminal evidence only
+  -> optional Git-HEAD-neutral PR comment / external handoff
+```
+
+具体的には以下を変更した。
+
+- orchestrator step 20からindependent-final reservation-only phase直接実行を削除
+- orchestrator step 20からreviewed implementation HEAD freeze直接実行を削除
+- step 20は`pre_freeze_ready` evidenceを`review-enforcer`へ渡すだけに変更
+- step 21で`review-enforcer`がterminal lifecycleの唯一のownerであることを明記
+- finding修正時は同じ`review-enforcer` lifecycleへ戻し、新しいreservation/terminal ownerを作らない
+- passing terminal result後は`review-enforcer`の結果をconsumeするだけに変更
+- orchestratorから次の再実行を禁止
+  - attestation persistence
+  - second attestation commit
+  - final push
+  - `git-pr-submitter`
+  - exact-head CI wait
+- `Independent-final terminal ownership` sectionを追加
+- Core rules / Outputs / Completion conditionを同じowner modelへ同期
+
+Implementation commit:
+
+- `f4cd160c3908d581b0b2b8b32bee5903188ae38b` — `fix: delegate terminal review lifecycle to review enforcer`
+
+## 設計整合
+
+新規の設計方針は追加していない。
+
+既存`design/skill-hierarchy-design.md`とmirrorはR4で既に次を定義していた。
+
+- `review-enforcer`がindependent reservation-only phaseを一度だけ実行
+- stable reservation identityを保持
+- independent reviewerはpre-reserved identityをreuse
+- passing verdict後だけattestation persistence
+- report-attestation commitは最大1件
+
+今回の修正は、`development-orchestrator`をその既存正本へ戻すcontract alignmentであるため、hierarchy正本の意味論変更は不要と判断した。
+
+## TDD
+
+CodexSkill repositoryの保守方針に従い、TDDは適用していない。
+
+本変更はSkill contractの整合修正であり、repository workflowのvalidator/buildを検証に使用した。
+
+## 実装HEAD検証
+
+Report作成前の実装修正HEAD:
+
+- HEAD: `f4cd160c3908d581b0b2b8b32bee5903188ae38b`
+- Workflow: `Validate and release ChatGPT worker skills`
+- Run ID: `33259174217`
+- Run number: `200`
+- Run `head_sha`: `f4cd160c3908d581b0b2b8b32bee5903188ae38b`
+- Build job: `99118045557`
+- Conclusion: `success`
+
+成功step:
+
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
+
+Artifact:
+
+- Name: `chatgpt-worker-skills-33259174217`
+- Artifact ID: `9716737676`
+- Artifact run head SHA: `f4cd160c3908d581b0b2b8b32bee5903188ae38b`
+- Digest: `sha256:998af0f9467a15dfeac639b148b394a7b9629066eb767c944d0d2522b097da21`
+
+別SHAのrunは検証証跡として使用していない。
+
+## 最終exact-head CIの扱い
+
+このreport自体をcommitするとPR HEADが変わるため、上記run #200を最終CIとして代用しない。
+
+report commitを含むPR current HEADに対するworkflow runを別途確認し、run `head_sha`がcurrent HEADと完全一致する場合だけ最終CIとしてPR本文・PRコメントへ記録する。
+
+## Finding closure条件
+
+`F65-R4-002`をclosure可能とする条件:
+
+- `development-orchestrator`がreservation-only phaseを直接呼ばない
+- `development-orchestrator`がreviewed implementation HEADを直接freezeしない
+- `review-enforcer`だけがreservation ownerになる
+- `sub-agent-task-manager`はcaller reservationをreuseする
+
+`F65-R5-001`をclosure可能とする条件:
+
+- `review-enforcer` terminal result後にorchestratorがattestation persistenceを再実行しない
+- second attestation commitを作らない
+- final push / PR publication / exact-head CI waitを重複しない
+- orchestratorはterminal evidenceをconsumeするだけ
+
+## 残存リスク
+
+- runtimeがfinal sub-agent model/reasoningをparentへ公開しない場合の`applied` observability制約は継続する
+- role/default-role profile impactをspawn前に確認できないruntimeではcost approval gate保証のためcapability gapとして停止する
+- multi-agent review lifecycleは今回のscope外であり、現行review lifecycleはsingle reviewer execution policyを維持する
+
+## Merge
+
+mergeは実施しない。利用者がmergeを行う。

--- a/reports/issue-13-pr65-r5-rereview-20260829.md
+++ b/reports/issue-13-pr65-r5-rereview-20260829.md
@@ -1,0 +1,227 @@
+# PR #65 R5 再reviewレポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- review mode: normal reviewerによるfix verification + current-HEAD rereview
+- base: `main`
+- base SHA: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+- 前回R4 report HEAD: `485ab1f6bd2ef2afe4076ecc5a008744090cf1cf`
+- reviewed implementation/current HEAD: `691e95836c96faab2fb003dd76fff1153d19b29a`
+- reviewer continuity: R1〜R4を実施した同一normal review chat
+- target repository policy: CodexSkill repository maintenanceはnon-TDD
+
+## 対象差分
+
+`485ab1f6bd2ef2afe4076ecc5a008744090cf1cf..691e95836c96faab2fb003dd76fff1153d19b29a` は5 commits。
+
+R4対応で変更されたfile:
+
+- `skills/codex-delegation-executor/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/review-enforcer/SKILL.md`
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+- `reports/issue-13-pr65-r4-findings-followup-20260829.md`
+
+直接依存・同一lifecycle確認対象:
+
+- `skills/development-orchestrator/SKILL.md`
+- `skills/report-output-manager/SKILL.md`
+- `design/adaptive-agent-assignment-design.md`
+- root `AGENTS.md`
+
+## R4 finding fix verification
+
+### F65-R4-001 / HIGH
+
+Disposition: **resolved**
+
+`codex-delegation-executor`はR3 runtime-observability contractへ同期されている。
+
+現在はsub-agent evidenceとして次を保持する。
+
+- `requested`
+- `role_plan`
+- `planned_runtime_profile`
+- `profile_observability`
+- exact `applied`はparent-visibleなfinal evidenceがある場合のみ
+- metadata-hidden runtimeでは`spawn_succeeded_profile_unverified`等のexplicit state
+
+Outputs / Evidence rules / Completion conditionのいずれもexact `applied`を無条件必須にしていない。
+
+また`normal_persistence`とindependent-final `deferred_attestation`を分離し、後者ではpre-created repository reportの直接編集を要求していない。
+
+### F65-R4-002 / HIGH
+
+Disposition: **not resolved**
+
+`review-enforcer`と`sub-agent-task-manager`の間ではreservation ownershipが修正されている。
+
+- `review-enforcer`がsingle reservation owner
+- pre-freezeで`reservation_owner: review-enforcer`、stable `reservation_identity`、exact reserved path、`metadata_only` stateを作る
+- `sub-agent-task-manager`はそのreservationをvalidate/reuseし、reservation-only phaseを再実行しない
+
+しかし、上位entry pointの`skills/development-orchestrator/SKILL.md` step 20が依然として次を直接実行する。
+
+- `report-output-manager` reservation-only phase
+- independent-final-review report path reservation
+- current HEAD freeze
+
+その後step 21で`review-enforcer`を呼ぶ。`review-enforcer` step 12は自身をsingle reservation ownerとしてreservation-only phaseをexactly once実行する契約であるため、repository全体のexecution pathでは二重reservationが残る。
+
+Impact:
+
+- `review-enforcer`単独ownerというR4 required actionが成立しない
+- orchestrator側reservationとreview-enforcer側reservationが異なるidentity/pathになる可能性がある
+- freeze前にどのreservationがattestation allowlistを支配するか曖昧になる
+- PR body / R4 follow-up reportの「F65-R4-002 resolved」は現状では正しくない
+
+Required action:
+
+current designを維持する場合、`development-orchestrator` step 20から直接reservation/freeze ownershipを外し、independent-final reservation/freezeを`review-enforcer`へ委譲する。別設計にする場合は、orchestratorが作成したreservationを`review-enforcer`が明示的にconsumeして再予約しない契約へ全層を揃える必要がある。現行hierarchyは前者（`review-enforcer` owner）を選択している。
+
+### F65-R4-003 / MEDIUM
+
+Disposition: **resolved**
+
+- `design/skill-hierarchy-design.md`
+- `skills/design/skill-hierarchy-design.md`
+
+は同一blob SHA `984c549dd78c0f4f7f91e3e73768925219c3996e`。
+
+両方に次のdeferred-attestation sequenceが同期されている。
+
+- normal review = `normal_persistence`
+- independent-final前に`review-enforcer`がreservation-only
+- `report-writer`はreservation時に呼ばない
+- task managerはexisting reservationをreuse
+- reviewerはreserved fileを作成・編集しない
+- structured evidenceをparentへ返す
+- passing verdict後のみattestation persistence
+
+`codex-delegation-executor`側も同じ例外へ同期済み。
+
+## 新規finding
+
+### F65-R5-001 / HIGH
+
+Origin: current-HEAD full review / R4 lifecycle修正の直接依存確認
+
+Location:
+
+- `skills/development-orchestrator/SKILL.md` Required flow step 23-24
+- direct dependency: `skills/review-enforcer/SKILL.md` Required flow step 17-19
+
+Description:
+
+independent final reviewがpassした後のterminal lifecycleを`development-orchestrator`と`review-enforcer`の両方が所有している。
+
+`review-enforcer`は現在:
+
+1. step 17で同じreservation identityを使いattestation-persistence phaseを実行
+2. step 18でsingle report-attestation commitをpersist
+3. step 19でattestation diffをvalidateし、push、PR update、exact-head required CI waitを実行
+
+一方`development-orchestrator`は`review-enforcer`をstep 21で呼んだ後に:
+
+1. step 23で再び`report-output-manager` attestation-persistence phaseを実行しreport-attestation commitを作成
+2. step 24で再びattestation diff validate、push、PR update、exact-head CI waitを実行
+
+Impact:
+
+- `review-enforcer`が既にattestation commitを作成した後、orchestratorが第二のattestation persistenceを試行できる
+- 「at most one report-attestation commit」「no later repository commit」のterminal invariantを破る
+- second commitが作られればtechnical completion identityが無効化される
+- second commitを防げてもpush/PR/CI publication stateが二重実行され、ownershipと再実行条件が曖昧になる
+- hierarchy designの「review-enforcer wrapperがreport reservation identity / phase-specific persistence / completion gateを所有する」責務と矛盾する
+
+Evidence:
+
+- `development-orchestrator` step 23: passing後にattestation-persistenceを直接実行
+- `development-orchestrator` step 24: final push / PR / exact-head CIを直接実行
+- `review-enforcer` step 17-19: 同一処理を既にownerとして実行
+- hierarchy正本はindependent reservation / passing attestation persistenceを`review-enforcer`配下へ配置
+
+Required action:
+
+terminal lifecycle ownerを1層へ一本化する。current hierarchy/designを維持するなら、`development-orchestrator`は`review-enforcer`へindependent-final reservation/freeze/review/attestation/publication lifecycleを委譲し、戻り値のcompletion identityとCI evidenceをconsumeするだけにする。少なくともstep 23の再attestationとstep 24の重複publicationを削除し、`review-enforcer` outputsを確認するflowへ変更する。
+
+## Validation / CI assessment
+
+Reviewed current HEAD:
+
+`691e95836c96faab2fb003dd76fff1153d19b29a`
+
+Exact-head GitHub Actions evidence:
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33251205415`
+- run number: `198`
+- event: `pull_request`
+- run `head_sha`: `691e95836c96faab2fb003dd76fff1153d19b29a`
+- status: `completed`
+- conclusion: `success`
+
+Artifact:
+
+- name: `chatgpt-worker-skills-33251205415`
+- artifact ID: `9714412489`
+- workflow run head SHA: `691e95836c96faab2fb003dd76fff1153d19b29a`
+- digest: `sha256:aded1daa408d8ce6006844e00cb4af4034eb1b01818ca04033ad36464818d490`
+
+別SHAのrunはcurrent-HEAD CI evidenceとして使用していない。
+
+CI successはrepository validator/build/packageが成功した証拠だが、今回の2件はcross-Skill lifecycle ownershipのsemantic contradictionであり、現行validatorでは検出されていない。
+
+## Coverage dispositions
+
+- requirement / design conformance: `checked_finding`
+- correctness / edge cases: `checked_finding`
+- scope discipline / unrelated changes: `checked_no_finding`
+- changed files / direct dependency impact: `checked_finding`
+- API / data compatibility: `not_applicable`
+- configuration / workflow effects: `checked_finding`
+- error handling / failure diagnostics: `checked_no_finding`
+- security / secret handling: `not_applicable`
+- tests / validation adequacy: `checked_no_finding`（exact-head CI success。ただしsemantic cross-Skill contradictionはvalidator対象外）
+- current-HEAD CI: `checked_no_finding`
+- report / tracking / documentation accuracy: `checked_finding`（R4-002 closure記録が現状と不一致）
+- regression / maintainability risk: `checked_finding`
+
+## Held / unexplored
+
+Held:
+
+- parent-visible final runtime profile snapshotがないruntimeではexact `applied`を不明として保持する設計。これはR3/R4で意図的に扱われており、今回のblocking findingではない。
+- multi-agent review lifecycleは本PR scope外。現行single-reviewer policyを前提とした。
+
+Unexplored / unavailable:
+
+- live Codex runtimeでのrole/default-role integration fixture。repositoryには該当fixtureがないため、今回のfix verificationはSkill contractと既確認runtime source evidenceを基準にした。
+
+## Verdict
+
+**fail**
+
+Required findings:
+
+- `F65-R4-002 / HIGH` — unresolved
+- `F65-R5-001 / HIGH` — new
+
+Resolved in this round:
+
+- `F65-R4-001 / HIGH`
+- `F65-R4-003 / MEDIUM`
+
+## Next action
+
+1. `development-orchestrator`から独立final lifecycleの重複ownershipを除去する。
+2. `review-enforcer`をsingle ownerとするcurrent hierarchyへstep 20〜24を同期する。
+3. R4 follow-up report / PR bodyのR4-002 dispositionをfix後の実態へ同期する。
+4. repository validation/build/packageを実行する。
+5. 新しいimplementation HEADと完全一致するpull-request workflow runだけをCI evidenceとして確認する。
+6. 同一normal review chatで`F65-R4-002`と`F65-R5-001`のfix verificationを行う。
+
+mergeは行わない。

--- a/reports/issue-13-pr65-r6-rereview-20260830.md
+++ b/reports/issue-13-pr65-r6-rereview-20260830.md
@@ -1,0 +1,193 @@
+# PR #65 R6 再レビュー（fix verification）
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- review mode: `fix verification`
+- normal reviewer continuity: 前回R5 reviewと同じChatGPT review chatを継続
+- base ref: `main`
+- base SHA: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+- previous review report HEAD: `440ed6acca835de83cf28b46aba0a334f5b9af03`
+- reviewed current HEAD: `a618c1e6621032bcf5c4e638b5d840bd5fcbc248`
+- R5 technical fix HEAD: `f4cd160c3908d581b0b2b8b32bee5903188ae38b`
+- relevant fix range: `440ed6acca835de83cf28b46aba0a334f5b9af03..a618c1e6621032bcf5c4e638b5d840bd5fcbc248`
+- development policy: CodexSkill repository maintenanceはnon-TDD
+
+## 目的
+
+前回R5で未解決だった`F65-R4-002 / HIGH`と、新規指摘`F65-R5-001 / HIGH`について、current HEADの修正をfinding identityとseverityを維持してfix verificationする。
+
+あわせて、修正差分と直接依存を確認し、同一欠陥classまたは新規変更領域に新しいrequired findingがないかを確認する。
+
+## 修正差分
+
+前回review report HEAD `440ed6acca835de83cf28b46aba0a334f5b9af03` からcurrent HEAD `a618c1e6621032bcf5c4e638b5d840bd5fcbc248` までの変更は2commit、2file。
+
+- `skills/development-orchestrator/SKILL.md`
+- `reports/issue-13-pr65-r5-findings-followup-20260830.md`
+
+実装修正commit:
+
+- `f4cd160c3908d581b0b2b8b32bee5903188ae38b` — `fix: delegate terminal review lifecycle to review enforcer`
+
+その後、R5指摘対応report commitによりcurrent HEADが`a618c1e6621032bcf5c4e638b5d840bd5fcbc248`へ進んでいる。
+
+## Finding fix verification
+
+### F65-R4-002 / HIGH
+
+Source severity: `HIGH`
+
+前回状態:
+
+- `review-enforcer` / `sub-agent-task-manager`間の二重reservationは解消済みだった。
+- しかし上位`development-orchestrator` step 20がreservation-only phaseとreviewed implementation HEAD freezeを直接実行していたため、repository全体では`review-enforcer`単独ownerが成立していなかった。
+
+Required action:
+
+1. `development-orchestrator`からindependent-final reservation-only phase直接実行を除去する。
+2. `development-orchestrator`からreviewed implementation HEAD freeze直接実行を除去する。
+3. `review-enforcer`をreservation / stable identity / freezeの唯一のownerにする。
+4. `sub-agent-task-manager`は`review-enforcer`のpre-reserved identityをreuseする契約を維持する。
+
+Current HEAD evidence:
+
+- `development-orchestrator` Required Skills / Execution ownerで、independent-final reservation / attestationは`review-enforcer`のみがinvokeし、`review-enforcer`がterminal lifecycleを独占することを明記。
+- step 20は`pre_freeze_ready`を作り、**report pathを予約せず、reviewed implementation HEADをfreezeしない**。
+- step 21は同一`review-enforcer` lifecycleを継続し、exactly-once reservation、stable identity、freeze、independent reviewer lifecycleを`review-enforcer`へ委譲する。
+- Core rulesでも`review-enforcer`外でreservation / freezeしないことを明記。
+- 直接依存`review-enforcer`は、reservation ownerを`review-enforcer`とし、`sub-agent-task-manager`へ既存reservation identityを渡してreuseさせる契約を維持している。
+- Skill hierarchy正本も同じowner modelを定義している。
+
+Disposition: `resolved`
+
+### F65-R5-001 / HIGH
+
+Source severity: `HIGH`
+
+前回状態:
+
+- `review-enforcer`がpassing verdict後にattestation persistence / report-attestation commit / final push / PR publication / exact-head CI waitまで所有していた。
+- その後`development-orchestrator`も同じterminal operationsを再実行する契約で、second attestation commitやduplicate publication/CI waitを起こし得た。
+
+Required action:
+
+1. `review-enforcer` passing terminal result後にorchestratorがattestation persistenceを再実行しない。
+2. second attestation commitを作成しない。
+3. final push / PR publication / exact-head CI waitを重複しない。
+4. orchestratorは`review-enforcer` terminal evidenceをconsumeするだけにする。
+
+Current HEAD evidence:
+
+- step 23はpassing terminal resultをconsumeするだけとし、`report-output-manager` attestation-persistence、別attestation commit、`git-pr-submitter`、push、CI waitを明示的に禁止。
+- step 24はGit-HEAD-neutralなcaller workに限定し、final publicationやCI待機を重複しない。
+- `Independent-final terminal ownership` sectionでterminal ownerを`review-enforcer`へ一意化し、orchestratorの禁止操作を列挙。
+- Report-attestation terminal ruleでもorchestratorはreturned evidenceをconsume/checkするだけと明記。
+- Completion conditionでも`review-enforcer`のsingle reservation identity / at most one attestation commitを受け取り、orchestratorが再実行しなかったことを完了条件に含める。
+- 直接依存`review-enforcer` step 17-19のattestation / publication / exact-head CI ownershipと矛盾しない。
+
+Disposition: `resolved`
+
+## Finding completeness matrix
+
+| Finding | Required action | Production path | Direct composition evidence | Focused validation | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| F65-R4-002 | orchestrator reservation削除 | `development-orchestrator` step 20 | `review-enforcer` step 12とのowner分離 | current contract review + exact-head CI | complete |
+| F65-R4-002 | orchestrator freeze削除 | `development-orchestrator` step 20 | `pre_freeze_ready -> review-enforcer` | current contract review + exact-head CI | complete |
+| F65-R4-002 | review-enforcer single owner | `Independent-final terminal ownership` + `review-enforcer` | reservation identityをtask managerへreuse | dependency review | complete |
+| F65-R5-001 | attestation再実行禁止 | `development-orchestrator` step 23 | `review-enforcer` passing result consume-only | current contract review + exact-head CI | complete |
+| F65-R5-001 | second commit禁止 | step 23 + terminal ownership section | `review-enforcer` at-most-one attestation | dependency review | complete |
+| F65-R5-001 | push/PR/CI重複禁止 | step 23-24 | `review-enforcer` final publication / CI ownership | dependency review | complete |
+
+## 新規変更領域の確認
+
+R5修正で新たに追加された以下を確認した。
+
+- `pre_freeze_ready` boundary
+- terminal evidence consume-only flow
+- `Independent-final terminal ownership`
+- post-terminal Git-HEAD-neutral caller work
+- updated Core rules / Outputs / Completion condition
+- R5 follow-up reportの記述とCI identity
+
+これらについて新規required findingは認めなかった。
+
+## Required coverage disposition
+
+| Criterion | Disposition | Evidence / note |
+| --- | --- | --- |
+| requirement and design conformance | `checked_no_finding` | hierarchy正本のreview-enforcer owner modelとorchestrator current contractが整合 |
+| correctness and edge cases | `checked_no_finding` | reservation/freeze/attestation/publication/CIの二重実行を明示禁止 |
+| scope discipline and unrelated changes | `checked_no_finding` | fix deltaはorchestrator contract +対応reportのみ |
+| changed files and direct dependency impact | `checked_no_finding` | `development-orchestrator`、`review-enforcer`、Skill hierarchy、R5 reportを確認 |
+| API/data effects | `not_applicable` | Skill contract / documentation change |
+| configuration/workflow compatibility | `checked_no_finding` | repository validator/build CI成功、owner boundary整合 |
+| error handling / capability gaps | `checked_no_finding` | role/profile capability gap等の既存contractを維持 |
+| security / secret handling | `not_applicable` | secret handling変更なし |
+| tests and validation adequacy | `checked_no_finding` | repository policyに従うvalidator/build/package workflowがexact HEADで成功 |
+| current-HEAD CI evidence | `checked_no_finding` | run #201 head_shaがcurrent HEADと完全一致 |
+| report / documentation accuracy | `checked_no_finding` | R5 follow-up reportのimplementation HEAD、run、artifact、closure条件を確認 |
+| regression / maintainability risk | `checked_no_finding` | terminal lifecycle ownerが一意化され責務重複を解消 |
+
+## CI / validation
+
+### R5 technical fix HEAD
+
+- HEAD: `f4cd160c3908d581b0b2b8b32bee5903188ae38b`
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33259174217`
+- run number: `200`
+- run `head_sha`: `f4cd160c3908d581b0b2b8b32bee5903188ae38b`
+- conclusion: `success`
+- artifact ID: `9716737676`
+- artifact digest: `sha256:998af0f9467a15dfeac639b148b394a7b9629066eb767c944d0d2522b097da21`
+
+### Reviewed current HEAD
+
+- HEAD: `a618c1e6621032bcf5c4e638b5d840bd5fcbc248`
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33259244486`
+- run number: `201`
+- run `head_sha`: `a618c1e6621032bcf5c4e638b5d840bd5fcbc248`
+- conclusion: `success`
+- artifact ID: `9716758212`
+- artifact digest: `sha256:d851b7db26f7e0f5f98f7c32ee497197e9428cc7ba5b69e8c4c31346307dee52`
+
+別SHAのworkflow runは代用していない。
+
+## Held / unexplored / remaining risks
+
+### Held
+
+- runtimeがfinal sub-agent model/reasoningをparentへ公開しない場合のexact `applied` observability制約は設計上`spawn_succeeded_profile_unverified`として保持される。今回のfixをblockしない。
+- role/default-role effectをspawn前に安全確認できないruntimeはcapability gapで停止する既存方針を維持する。
+- multi-agent review lifecycleは本PR scope外で、current review lifecycleはsingle reviewer execution policy。
+
+### Unexplored
+
+- verdict-blockingなunexplored areaなし。
+- fix verification modeのため、前回までにreview済みで今回差分も直接依存もないPR全領域をゼロから再度 exhaustive reviewしてはいない。
+
+## Findings
+
+新規findingなし。
+
+- `F65-R4-002 / HIGH`: resolved
+- `F65-R5-001 / HIGH`: resolved
+
+## Verdict
+
+`pass`
+
+前回未解決のrequired findingはすべてclosureし、今回fix deltaと直接依存から新規required findingは認めなかった。
+
+このverdictはreviewed current HEAD `a618c1e6621032bcf5c4e638b5d840bd5fcbc248` に対するnormal fix-verification verdictである。独立最終reviewの代替ではない。
+
+## Next action
+
+normal review cycleは収束した。repository workflowに従い、独立最終reviewへ進む場合はfresh independent reviewer lifecycleを使用する。
+
+## Merge boundary
+
+mergeは実施しない。利用者がmergeを行う。

--- a/reports/issue-13-pr65-rereview-20260829.md
+++ b/reports/issue-13-pr65-rereview-20260829.md
@@ -1,0 +1,274 @@
+# PR #65 再reviewレポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- Issue: `#13 sub-agentの使用モデル`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- review mode: fix verification + current HEAD full re-review
+- base: `main`
+- base SHA: `2ea9522d494b2b37c1d8aabb340a3113cfd18240`
+- reviewed implementation HEAD: `3ae8a067b648ffbbc956fdc651f3bdfa7b1316d2`
+- previous review target: `46776a85f09b101018338309ccd3221cc10592ad`
+- previous review report persistence HEAD: `5beb9511cf0ec508456628e6fe556edc19d5cd14`
+- date: 2026-08-29
+- verdict: `fail`
+
+## 目的
+
+前回reviewの `F65-001`〜`F65-003` が解消されたかをfinding identity単位で確認し、そのfix deltaだけでなくcurrent PR HEADの全変更と直接依存を再走査して、新規欠陥が残っていないか確認する。
+
+## authoritative requirements
+
+- Issue #13: sub-agentのtask特性に応じてmodel / reasoning effortを適切に割り当てる。
+- user requirement: 一度で指摘点を網羅する。
+- current PR policy: `Sol xhigh` / `Sol max` は自動dispatchせず、current-task user approvalを得てから使用する。
+- repository policy: CodexSkill repository maintenanceはnon-TDD。
+- CI policy: PR current HEAD SHAとworkflow run `head_sha`が一致するrunのみCI evidenceとして採用する。
+- review lifecycle: normal reviewer continuityと、one fresh exhaustive independent final reviewerを維持する。
+- report-attestation lifecycle: independent-final-review report pathはreview前に予約し、passing verdict後にreportを生成・persistして最大1 attestation commitにする。
+
+## review scope
+
+### 前回review後のfix delta
+
+`5beb9511cf0ec508456628e6fe556edc19d5cd14...3ae8a067b648ffbbc956fdc651f3bdfa7b1316d2`
+
+7 commits、7 files:
+
+- `design/adaptive-agent-assignment-design.md`
+- `reports/issue-13-pr65-review-findings-followup-20260829.md`
+- `scripts/verify_skill_repository.py`
+- `skills/report-output-manager/references/sub-agent-report-template.md`
+- `skills/review-enforcer/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+
+### current PR changed files
+
+14 filesを確認した。
+
+- `design/adaptive-agent-assignment-design.md`
+- `reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml`
+- `reports/issue-13-adaptive-agent-assignment-implementation-20260826.md`
+- `reports/issue-13-pr65-normal-review-20260827.md`
+- `reports/issue-13-pr65-review-findings-followup-20260829.md`
+- `reports/issue-13-sol-expensive-profile-approval-followup-20260827.md`
+- `scripts/verify_skill_repository.py`
+- `skills/codex-delegation-executor/SKILL.md`
+- `skills/development-orchestrator/SKILL.md`
+- `skills/report-output-manager/references/sub-agent-report-template.md`
+- `skills/review-enforcer/SKILL.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
+
+Direct dependencyとして `skills/report-output-manager/SKILL.md`、`review-worker` contract、current Codex multi-agent / spawn-agent behavior、OpenAI GPT-5.6 model catalogも照合した。
+
+## 前回finding fix verification
+
+### F65-001 / HIGH — resolved
+
+前回: review経路が`sub-agent-task-manager`のprofile selection / expensive-profile approval gateを通る保証がなかった。
+
+確認結果:
+
+- `review-enforcer` Required Skillsへ`sub-agent-task-manager`が追加された。
+- new normal / replacement / independent reviewerは同Skill経由でdispatchする契約になった。
+- `Sol xhigh` / `Sol max` proposal時はreviewer spawn前にstopする。
+- repository validatorにも`review-enforcer -> sub-agent-task-manager` dependencyが追加された。
+
+Disposition: `resolved`
+
+### F65-002 / MEDIUM — resolved
+
+前回: focused fix verificationのTerra `high` defaultとsame normal reviewer continuityが両立しなかった。
+
+確認結果:
+
+- new reviewerのdefaultとexisting reviewer continuityが分離された。
+- reuseではoriginal applied profileを維持する。
+- `application_status: reused_existing_agent_profile`、reviewer identity、original profile evidence、continued modeを記録する契約が追加された。
+
+Disposition: `resolved`
+
+### F65-003 / MEDIUM — resolved
+
+前回: dispatch-profile evidence必須契約に対しfixed report templateへ記入欄がなかった。
+
+確認結果:
+
+- `sub-agent-report-template.md`へ固定`## Dispatch profile` sectionが追加された。
+- selection inputs / source / proposal / approval / requested / applied / application status / continuity / fork / reasons のplaceholderが追加された。
+- `sub-agent-task-manager`のStandard report sectionsと同期している。
+
+Disposition: `resolved`
+
+## 新規findings
+
+### F65-R2-001 / HIGH — requested/appliedの時系列契約が自己矛盾
+
+Origin: current HEAD full review
+
+Location:
+
+- `skills/sub-agent-task-manager/SKILL.md` Required flow step 7 / 14
+- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md` Call shape / After the call
+
+Description:
+
+`sub-agent-task-manager`はspawn前のstep 7で`requested` profileを`applied runtime profile`へresolveし、step 14で`applied model and reasoning effort`をactual tool-call argumentsとしてdispatchするよう要求している。
+
+一方`spawn-agent-model-overrides.md`は、spawn callの引数には`dispatch_profile.requested.model` / `requested.reasoning_effort`を使用し、call後にruntime evidenceから`applied`を記録し、requested値をruntime evidenceなしで`applied`へcopyしてはならないと定義している。
+
+Impact:
+
+`applied`はruntime applicationの結果であり、spawn前には確定できない。現契約のままでは、runtime evidence取得前に`applied`を捏造するか、spawn inputとruntime outcomeを同じ概念として扱うことになり、今回の主要要件であるrequested/applied分離が破綻する。hidden override rejection、full-history inheritance、fallback時に特に誤ったevidenceを生成しうる。
+
+Required action:
+
+flowを少なくとも次の順序に分離する。
+
+1. selectorが`requested`とfork policyを確定する
+2. runtime availability / full-history制約からcall可能なrequested argumentsを解決する
+3. `requested`値をactual spawn argumentsとしてdispatchする
+4. call outcome / runtime evidenceを取得する
+5. その後だけ`applied`と`application_status`を記録する
+6. rejection時はfallback / capability gapを記録する
+
+Severity: `high`
+
+### F65-R2-002 / HIGH — independent-final-review report-attestation lifecycleとpre-created child reportが衝突
+
+Origin: F65-001 fixによって顕在化したcross-contract defect
+
+Location:
+
+- `skills/sub-agent-task-manager/SKILL.md` Required flow step 9-13
+- `skills/review-enforcer/SKILL.md` Independent final review / Required flow step 11-15
+- `skills/report-output-manager/SKILL.md` Independent-final-review report-attestation mode
+
+Description:
+
+`review-enforcer`のfresh independent reviewerは今回のfixにより必ず`sub-agent-task-manager`を通る。しかし`sub-agent-task-manager`は全new sub-agentについてdispatch前にrepository内report fileを作成し、reviewer自身がそのfileを埋めることを要求する。
+
+一方independent-final-review lifecycleは、review前にはreport pathだけをreserveしてimplementation HEADをfreezeし、passing verdict後に`report-writer`を呼び、reserved pathへ初めてreportをpersistして最大1 report-attestation commitにする契約である。
+
+Impact:
+
+fresh independent reviewerをtask manager経由にすると、freeze後・verdict前にreserved report fileをcreate/editするrepository writeが発生し、pre-freeze repository-stable条件とpost-verdict report generation順序が崩れる。またreviewer-written child reportとpost-verdict `report-writer`のauthoritative report ownerが二重化する。
+
+Required action:
+
+independent final reviewを`sub-agent-task-manager`のreport pre-creationから明示的にspecial-caseする。例えば:
+
+- review前はreserved repository pathだけ保持し、repository fileをcreate/editしない
+- reviewer outputはparent-held evidenceまたはrepository外scratch artifactへ返す
+- passing verdict後にのみ`report-writer`がreserved pathへcomplete reportを生成する
+- そのreportだけをreport-attestation commitに含める
+
+normal review / fix verificationのpre-created report contractとは分離する。
+
+Severity: `high`
+
+### F65-R2-003 / HIGH — reviewer taskがmulti-agent decompositionへ戻れるためsingle reviewer保証がない
+
+Origin: F65-001 fixによって顕在化したreview lifecycle defect
+
+Location:
+
+- `skills/review-enforcer/SKILL.md` Reviewer dispatch contract / Required flow step 3, 12
+- `skills/sub-agent-task-manager/SKILL.md` Required flow step 4
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md` Multi-agent decision
+- `skills/codex-delegation-executor/SKILL.md` Multi-agent decomposition
+
+Description:
+
+`review-enforcer`はnormal reviewでone dedicated reviewer、independent final reviewでone fresh exhaustive reviewerを要求し、reviewer identity / continuity / independenceをcompletion gateとしている。
+
+しかし委譲先`sub-agent-task-manager`はbounded taskがindependent workstreamsへ分割可能と判断すると`codex-delegation-executor`へ戻し、multi-agent decompositionを選べる。review-enforcerから渡すreview taskについて`decomposability: single`固定またはdecomposition禁止のcontractがない。
+
+Impact:
+
+large reviewが複数reviewerへ分割されると、誰がauthoritative normal reviewer / independent reviewerなのか、finding continuityをどのagentへ保持するのか、one exhaustive independent passを誰が満たしたのかが不定になる。parent synthesisだけでは既存`review-worker` / `review-enforcer`のsingle-reviewer identity contractを満たさない。
+
+Required action:
+
+現行review lifecycleを維持するなら、`review-enforcer`が作るreviewer taskは`decomposability: single`または`multi_agent_decomposition: forbidden_for_reviewer_identity`として固定し、`sub-agent-task-manager`からdelegation executorへ戻さないことを明記する。
+
+review自体をmulti-agent化したい場合は別途、reviewer identity、finding authority、synthesis、continuity、independent-final-review completion semanticsをreview lifecycle側に設計する必要がある。
+
+Severity: `high`
+
+## validation assessment
+
+### exact-head CI
+
+Reviewed implementation HEAD:
+
+`3ae8a067b648ffbbc956fdc651f3bdfa7b1316d2`
+
+Matching pull_request workflow:
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33245090292`
+- run number: `173`
+- event: `pull_request`
+- run `head_sha`: `3ae8a067b648ffbbc956fdc651f3bdfa7b1316d2`
+- status: `completed`
+- conclusion: `success`
+
+PR bodyに記載されたrun identityとGitHub Actions API上のhead SHA / conclusionが一致している。
+
+### external/runtime verification
+
+OpenAI current model catalogでは `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` が存在し、GPT-5.6 familyは`none`, `low`, `medium`, `high`, `xhigh`, `max` reasoning effortをsupportしていることを確認した。
+
+Codex current sourceではspawn-agent model/reasoning override exposureとfull-history fork inheritance contractが存在することも確認した。
+
+## coverage
+
+- requirement/design conformance: `checked_finding`
+- correctness / state transitions: `checked_finding`
+- previous finding closure: `checked_no_finding`
+- scope discipline: `checked_no_finding`
+- changed files / direct dependencies: `checked_finding`
+- API/runtime model identifiers: `checked_no_finding`
+- fork / runtime application semantics: `checked_finding`
+- review lifecycle / reviewer identity: `checked_finding`
+- report lifecycle / attestation: `checked_finding`
+- validation / exact-head CI: `checked_no_finding`
+- documentation/report accuracy: `checked_no_finding`
+- security / secret handling: `not_applicable`
+
+## held / unexplored / unknown
+
+### held
+
+なし。
+
+### unexplored
+
+- live `collaboration.spawn_agent` integration fixtureはrepository CIに存在しないため、hidden overrideのactual backend behaviorはcontract/source reviewまで。
+
+### unknown
+
+- account/sessionごとの実際のCodex model availabilityはrepositoryから取得できない。
+
+これらは今回の3 required findingを緩和しない。
+
+## verdict
+
+`fail`
+
+前回3 findingはresolvedしたが、current HEADにはrequired high findingが3件残る。
+
+## next action
+
+1. `F65-R2-001` requested -> spawn -> applied の時系列を修正する。
+2. `F65-R2-002` independent final reviewだけreport pre-creationを禁止するspecial-caseを追加する。
+3. `F65-R2-003` review-enforcer配下reviewerのmulti-agent decomposition禁止または正式なmulti-agent review lifecycleを定義する。
+4. fix後、current HEAD固有のrepository validator / ZIP build / exact-head CIを確認する。
+5. 同じnormal reviewer contextで3 findingをidentity単位にfix verificationし、新規変更領域も再確認する。
+
+mergeは行わない。

--- a/reports/issue-13-pr65-review-findings-followup-20260829.md
+++ b/reports/issue-13-pr65-review-findings-followup-20260829.md
@@ -1,0 +1,167 @@
+# PR #65 指摘対応レポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- Issue: `#13 sub-agentの使用モデル`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- branch: `feat/adaptive-agent-assignment`
+- review target before fixes: `46776a85f09b101018338309ccd3221cc10592ad`
+- implementation fix HEAD: `111f7be8bbfce4c2b851f07d8c60ba8626f88cf8`
+- date: 2026-08-29
+
+## 対応対象
+
+PR #65 の未解決review finding 3件を対象とした。
+
+- `F65-001 / HIGH`: review経路が`sub-agent-task-manager`のprofile selection / approval gateを通る保証がない
+- `F65-002 / MEDIUM`: focused fix verificationのTerra `high` defaultと同一normal reviewer再利用契約が矛盾する
+- `F65-003 / MEDIUM`: dispatch-profile evidence必須契約と固定sub-agent report templateが不整合
+
+## development policy
+
+- CodexSkill repository maintenanceのためTDDは適用しない
+- Red/Green専用testは追加しない
+- 既存repository validator、active-link validation、distribution ZIP build、exact-head GitHub Actionsを検証に使用する
+- governing source: root `AGENTS.md`
+
+## F65-001 対応
+
+### 問題
+
+`development-orchestrator`とprofile selection側では`Sol xhigh` / `Sol max` proposal時のapproval stopを定義していたが、`review-enforcer`がnew reviewerを直接dispatchできる契約のままだった。
+
+### 変更
+
+`skills/review-enforcer/SKILL.md`を更新した。
+
+- Required Skillsへ`sub-agent-task-manager`を追加
+- new normal reviewer、replacement reviewer、independent final reviewerは必ず`sub-agent-task-manager`経由でdispatchする
+- `Sol xhigh` / `Sol max` proposalが返った場合はreviewer spawn前にparentへstopを返す
+- `review-enforcer`からapproval gateを迂回したdirect spawnを禁止
+- independent final reviewでも同じapproval gateを適用
+
+さらに`scripts/verify_skill_repository.py`の`review-enforcer` dependencyへ`sub-agent-task-manager`を追加し、repository validatorがRequired Skill宣言の欠落を検出できるようにした。
+
+### 結果
+
+reviewer lifecycle ownerとprofile-selection ownerを分離したまま、new reviewer dispatchが必ずapproval gateを通る契約になった。
+
+## F65-002 対応
+
+### 問題
+
+profile tableではfocused fix verificationをTerra `high`としていたが、normal review lifecycleはinitial reviewerをfix verificationでも再利用する。既存Sol reviewerへ後からTerra profileを適用するruntime pathはない。
+
+### 変更
+
+`skills/sub-agent-task-manager/references/agent-profile-selection.md`、`skills/sub-agent-task-manager/SKILL.md`、`skills/review-enforcer/SKILL.md`を更新した。
+
+- task defaultは「新しいagentを作る場合」のみ適用
+- focused fix verificationのTerra `high`はcontinuity reuseできない場合のnew reviewer defaultへ限定
+- existing normal reviewerまたはindependent reviewer reuseではoriginal applied model / reasoning / fork contextを維持
+- reuse時のstatusを`application_status: reused_existing_agent_profile`として定義
+- reviewer identity、original applied profile evidence、continued review modeをcontinuity evidenceとして記録
+- same review lifecycleで既にapproval済みのSol `xhigh` / `Sol max` reviewer reuseは新規profile選定ではないため再承認しない
+- replacement reviewerやnew task lifecycleは新規dispatchとしてprofile selectionとapproval gateを再度通す
+
+### 結果
+
+reviewer continuityとper-task defaultの責務が分離され、存在しないruntime profile switchを前提にしなくなった。
+
+## F65-003 対応
+
+### 問題
+
+`sub-agent-task-manager`はdispatch-profile evidenceをreport必須としていたが、fixed-format `sub-agent-report-template.md`に記入欄がなかった。childにはheading order維持とblank-only編集も要求しているため、追加情報を書こうとするとtemplate contractへ違反する状態だった。
+
+### 変更
+
+`skills/report-output-manager/references/sub-agent-report-template.md`へ固定`## Dispatch profile` sectionを追加した。
+
+placeholder:
+
+- selection inputs
+- selection source
+- proposed profile
+- approval status / evidence
+- requested profile
+- applied profile
+- application status
+- reviewer continuity
+- fork policy
+- reasons / constraints
+
+`skills/sub-agent-task-manager/SKILL.md`のStandard report sectionsにも同じsectionを同じ位置で追加し、childには既存template structureを変更せずblank fieldだけを埋めさせる契約とした。
+
+### 結果
+
+fixed-format制約とdispatch-profile evidence必須制約が同時に満たせるようになった。
+
+## 設計同期
+
+`design/adaptive-agent-assignment-design.md`を更新した。
+
+- new reviewer dispatchが`sub-agent-task-manager`を通ることを明記
+- approval proposalはreviewer spawn前にstopするflowを追加
+- reviewer continuityはnew profile selectionではないことを明記
+- `reused_existing_agent_profile` schemaを追加
+- fixed `Dispatch profile` report schemaを追加
+- normal reviewからfix verificationへの具体例を追加
+
+既存skill hierarchy上は`review-enforcer -> sub-agent-task-manager`経路が既に表現されており、topology自体は変更していない。
+
+## 変更commit
+
+- `4202004b620844d75f77de0414cb8c9165e80140`: reviewer dispatchをprofile selection経由へ変更
+- `083052510ecd301f5a1dfd598c2b3ee8d6a19496`: reviewer continuity profile rule追加
+- `fbc41dfb1e47f013a74f335ef70dd583ab50de16`: sub-agent report templateへDispatch profile section追加
+- `4f6383dcec47f6988c6f287e22aa363a5ea09bd3`: sub-agent managerのreport / continuity contract同期
+- `b1a8a76bbc9050421db84bc1aafe58636f1765af`: adaptive assignment design同期
+- `111f7be8bbfce4c2b851f07d8c60ba8626f88cf8`: repository validatorへreview-enforcer dependency追加
+
+## 検証
+
+implementation fix HEAD `111f7be8bbfce4c2b851f07d8c60ba8626f88cf8`に対して、同一SHAのpull-request workflow runのみを使用した。
+
+- workflow: `Validate and release ChatGPT worker skills`
+- run ID: `33245054317`
+- run number: `172`
+- run head SHA: `111f7be8bbfce4c2b851f07d8c60ba8626f88cf8`
+- conclusion: `success`
+- build job ID: `99080979605`
+
+成功step:
+
+- Checkout target HEAD without write credentials
+- Validate repository Skill architecture and active links
+- Build and verify ChatGPT wrapper and core Skill ZIP
+- Upload validation artifact
+
+Artifact:
+
+- name: `chatgpt-worker-skills-33245054317`
+- ID: `9712560075`
+- digest: `sha256:6435b996c3bb3b052fdaa2e4b8a8a4f20b24a68bd6bb215c3eb43de0cc3fa2a1`
+- workflow head SHA: `111f7be8bbfce4c2b851f07d8c60ba8626f88cf8`
+
+## failure diagnostics
+
+- test failure: なし
+- validator failure: なし
+- build failure: なし
+- standard output failure: なし
+- standard error failure: なし
+- failure investigation artifact: not applicable
+
+## final publication check
+
+このreport追加commitによりPR HEADはimplementation fix HEADから進む。そのためrun `33245054317`をfinal PR HEADのCIとして代用しない。
+
+report persistence後のcurrent PR HEADと一致するpull-request workflow runを別途確認し、PR commentへ結果を記録する。一致runが存在しない場合はCI未実施として報告する。
+
+## outcome
+
+`F65-001`、`F65-002`、`F65-003`の要求事項をSkill contract、runtime wrapper、report template、design、repository validatorへ反映した。
+
+mergeは行わない。

--- a/reports/issue-13-sol-expensive-profile-approval-followup-20260827.md
+++ b/reports/issue-13-sol-expensive-profile-approval-followup-20260827.md
@@ -1,0 +1,110 @@
+# Issue #13 Sol高コストprofile承認gate 追補レポート
+
+## メタデータ
+
+- repository: `ssaattww/CodexSkill`
+- Issue: `#13 sub-agentの使用モデル`
+- PR: `#65 feat: task特性に応じてsub-agent profileを自動選定する`
+- branch: `feat/adaptive-agent-assignment`
+- user request date: `2026-08-27`
+- development policy: CodexSkill repository maintenanceはnon-TDD
+
+## 追加要求
+
+コスト最適化のため、次のprofileは自動選定・自動dispatchせず、ユーザーへ提案して処理を停止し、明示的な了承を得た後だけ選択する。
+
+- `Sol xhigh`
+- `Sol max`
+
+## 実装内容
+
+### `agent-profile-selection.md`
+
+- `Sol xhigh` / `Sol max`をmandatory user-approval gate対象に変更した。
+- automatic classificationやrepository policyが該当profileを要求しても、まず`proposed_profile`として保持する。
+- proposal時にSol `high`では不足する理由と、higher reasoning effortによるexecution cost増加をユーザーへ提示する。
+- approval前は`requested: null`、`applied: null`、`application_status: awaiting_user_approval`とする。
+- current taskでの明示的なuser instructionのみapproval evidenceとして扱う。
+- repository policy、過去の別taskでのapproval、silence、inferred preferenceはapprovalとして扱わない。
+- rejectされた場合は`Sol xhigh` / `Sol max`を除外してprofileを再計算する。
+- dispatch profile schemaをversion 2へ更新し、proposalとapproval stateを追加した。
+
+### `sub-agent-task-manager`
+
+- profile selection flowへproposal / approval stopを追加した。
+- `Sol xhigh` / `Sol max`候補ではsub-agentをspawnせず、ユーザー確認までintentional incomplete stateとして停止する。
+- independent final review / release auditの従来の`Sol xhigh` defaultを、自動dispatchではなくapproval-gated proposalへ変更した。
+- approval evidenceをreport minimum contentsとcompletion gateへ追加した。
+- `Never dispatch Sol xhigh or Sol max without explicit current-task user approval`をstrong operational ruleとして追加した。
+
+### `development-orchestrator`
+
+- routine profileは従来どおり自動選定し、`Sol xhigh` / `Sol max`だけをuser confirmation boundaryとした。
+- implementation、normal review、independent final reviewのどのphaseでも、approval-gated profileが提案された場合はworkflowを停止する。
+- repository policyがapprovalを代替できないことを明記した。
+- task completion条件へexpensive Sol dispatchのapproval evidenceを追加した。
+
+### 設計書
+
+`design/adaptive-agent-assignment-design.md`を更新し、次の状態遷移を設計正本へ反映した。
+
+```text
+automatic classification
+  -> proposed_profile = Sol xhigh | Sol max
+  -> userへ理由とcost noticeを提示
+  -> STOP
+      |-- approve -> requestedへ昇格 -> runtime application
+      `-- reject  -> xhigh/maxを除外して再計算
+```
+
+## 変更ファイル
+
+- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
+- `skills/sub-agent-task-manager/SKILL.md`
+- `skills/development-orchestrator/SKILL.md`
+- `design/adaptive-agent-assignment-design.md`
+- `reports/issue-13-sol-expensive-profile-approval-followup-20260827.md`
+
+## TDD
+
+CodexSkill repositoryの方針に従いTDDは適用していない。
+
+- Red/Green専用test: 追加していない
+- repository validator / distribution build: GitHub Actionsで確認する
+
+## contract review
+
+次の条件を確認した。
+
+- `Sol high`以下は通常のautomatic selectionを継続する。
+- `Sol xhigh`と`Sol max`だけがuser approval boundaryになる。
+- approval前にspawnしない。
+- approval前にproposalを`requested`へ昇格しない。
+- repository policyはapprovalの代わりにならない。
+- current-task explicit requestはapproval evidenceになりうる。
+- rejection時はprofileを再計算し、rejected profileをsilent dispatchしない。
+- independent final reviewにも同じgateを適用する。
+- multi-agentと`Ultra`の扱いは変更しない。
+- full-history forkおよびrequested/applied分離の既存contractを維持する。
+
+## 検証
+
+このreport commit後のPR current HEADと一致するGitHub Actions runだけをfinal CI evidenceとして使用する。
+
+確認対象:
+
+- `python3 scripts/verify_skill_repository.py`
+- `python3 scripts/build_chatgpt_worker_skills.py --output chatgpt-worker-skills.zip`
+- ZIP listing
+- validation artifact upload
+
+final exact-head run ID、job ID、artifact IDはGitHub上のPR commentへ記録する。別SHAのrunは代用しない。
+
+## 残存リスク
+
+- approval gateはSkill contractであり、Codex runtime本体の強制機構ではない。callerがSkillを無視するruntimeまでは防止しない。
+- `Sol xhigh` / `Sol max`のcost差額そのものはruntime price情報を取得していないため、定量表示ではなくhigher-cost noticeとして扱う。
+
+## 結果
+
+ユーザー要求どおり、`Sol xhigh`と`Sol max`を「自動選択」から「提案して停止し、明示承認後のみ選択」へ変更した。PR #65へ追補し、mergeは行わない。

--- a/scripts/verify_skill_repository.py
+++ b/scripts/verify_skill_repository.py
@@ -55,6 +55,7 @@ WRAPPER_DEPENDENCIES = {
     },
     "review-enforcer": {
         "work-context-manager",
+        "sub-agent-task-manager",
         "review-worker",
         "report-writer",
         "report-output-manager",

--- a/skills/codex-delegation-executor/SKILL.md
+++ b/skills/codex-delegation-executor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-delegation-executor
-description: Delegate investigation, implementation, build, and test execution to Codex or sub-agents instead of performing those steps manually. Use for code investigation, implementation tasks, verification runs, review preparation, and evidence collection. This skill standardizes how work is delegated and how results are captured in reports.
+description: Delegate investigation, implementation, build, and test execution to Codex or sub-agents instead of performing those steps manually. Use for code investigation, implementation tasks, verification runs, review preparation, evidence collection, and multi-agent decomposition. This skill standardizes executor choice, delegation assessment, and report-backed results.
 ---
 
 # Codex Delegation Executor
@@ -9,25 +9,30 @@ Route executable work through Codex or sub-agents.
 
 ## Goal
 
-Ensure investigation, implementation, build, and verification work are delegated consistently, with executor choice made explicitly and evidenced.
+Ensure investigation, implementation, build, and verification work are delegated consistently, with executor choice and any multi-agent decomposition made explicitly and evidenced.
+
+This Skill decides whether work stays with the main agent, goes to one sub-agent, or is split into independently bounded sub-agent tasks. `sub-agent-task-manager` owns the model tier, reasoning effort, and fork policy for each bounded sub-agent task.
 
 ## Execution owner
 
 Run this skill as: `parent`
 
-- This skill is the policy owner for delegation and executor choice.
-- It may dispatch sub-agents, but the parent keeps the decision authority.
+- This skill is the policy owner for delegation, executor choice, and multi-agent decomposition.
+- It may dispatch sub-agents through `sub-agent-task-manager`, but the parent keeps decision and synthesis authority.
 
 ## Inputs
 
 Before running this skill, identify:
 
 - the concrete work item to delegate or execute
-- whether the work is implementation, review, verification, or investigation
+- whether the work is implementation, review, verification, investigation, design, intake, standards, or environment work
 - scope boundaries, target files, and non-goals when known
 - validation or evidence expectations
-- when a `sub-agent` is selected, the intended model, reasoning effort, and fork policy
-- for implementation `sub-agent` work, the model confirmed by `development-orchestrator` with the user
+- coupling, urgency, write-scope overlap, and whether parallelism helps
+- uncertainty, expected change radius, criticality, repetition, and context need
+- explicit user or repository model, reasoning, budget, availability, or fork constraints
+
+Do not require a routine user-selected implementation model. Preserve an explicit override when the user or repository supplies one; otherwise let `sub-agent-task-manager` select the per-task profile from the delegation assessment.
 
 ## Delegate these work types
 
@@ -43,6 +48,7 @@ Delegate:
 - environment verification
 - focused review preparation
 - requirement or issue-intake verification
+- standards detection or standards validation
 - other assumption-sensitive classification or confirmation work
 
 ## Fixed sub-agent categories
@@ -57,18 +63,37 @@ The following work must be executed by a `sub-agent` now, not merely preferred:
 - standards detection or standards validation
 
 Use `sub-agent-task-manager` for these categories and require a report in `reports/`.
-For review tasks, receive the parent-model plus reasoning-effort profile selected by `review-enforcer` and pass it to `sub-agent-task-manager`; do not define a reviewer default here.
+
+A fixed sub-agent category fixes the executor, not the model. Pass the task assessment and review or verification mode to `sub-agent-task-manager`, which applies [agent-profile-selection.md](../sub-agent-task-manager/references/agent-profile-selection.md).
+
+## Delegation assessment
+
+Before selecting or dispatching an executor, record:
+
+- `task_kind`
+- `work_class`: `mechanical`, `bounded_technical`, or `judgment_heavy`
+- `uncertainty`: `low`, `medium`, or `high`
+- `change_radius`: `local`, `cross_module`, or `cross_system`
+- `criticality`: `ordinary` or `high`
+- `repetition`: `single` or `high_volume`
+- `decomposability`: `single`, `sequential_dependencies`, or `independent_workstreams`
+- `context_need`: `fresh`, `bounded_history`, or `full_history`
+- source evidence for each non-obvious classification
+
+Estimate change radius by affected contracts and dependencies, not only by line or file count. A small security, compatibility, migration, concurrency, public-API, or release change is high-criticality even when its edit is local.
+
+If evidence is insufficient, classify uncertainty upward rather than inventing certainty. A later discovery that changes the classification must trigger profile recomputation before another dispatch.
 
 ## Executor selection
 
 Decide the executor inside this skill before running the work:
 
-- If the work matches a fixed sub-agent category, do not decide; use a `sub-agent`.
-- For implementation work, decide `main agent` vs `sub-agent` here based on coupling, urgency, write-scope overlap, and whether parallelism helps.
+- If the work matches a fixed sub-agent category, do not decide between parent and child; use a `sub-agent`.
+- For implementation work, decide `main agent` vs `sub-agent` here based on coupling, urgency, write-scope overlap, and whether isolation or parallelism helps.
 - Treat design-document edits, test authoring, and code authoring as implementation work for this decision.
 - When the work is design-document editing, make the executor read `design-executor`.
 - When the work is code or test authoring, make the executor read `implementation-executor`.
-- Keep the main agent responsible for scoping, integration, and final synthesis even when a sub-agent executes the task.
+- Keep the main agent responsible for scoping, integration, profile-adjudication evidence, and final synthesis even when a sub-agent executes the task.
 
 Use these provisional thresholds as the default trigger for switchable implementation work:
 
@@ -77,31 +102,63 @@ Use these provisional thresholds as the default trigger for switchable implement
 - expected edit chunks are 4 or more
 - the parent would otherwise need to read 5 or more implementation files before writing safely
 
-Use the main agent by default below those thresholds unless isolation or parallelism is clearly more valuable.
+Use the main agent by default below those thresholds unless isolation, independence, or parallelism is clearly more valuable.
+
+The thresholds decide executor ownership only. They do not imply Luna, Terra, or Sol; per-task model selection uses the qualitative assessment above.
+
+## Multi-agent decomposition
+
+Treat article-described `Ultra` execution as a strategy, not a reasoning level.
+
+Split work into multiple sub-agents only when all of the following hold:
+
+- at least two workstreams can execute independently
+- every workstream has explicit scope, non-goals, expected evidence, and report ownership
+- write ownership is non-overlapping, or the work is read-only
+- no blocking investigation result is required before another workstream can start
+- the parent defines a synthesis and conflict-resolution step
+- `execution-cost-stabilizer` confirms that parallel execution provides material value
+
+Do not split work merely because it is large. Keep sequential dependencies sequential.
+
+For every decomposed task:
+
+- run a separate delegation assessment
+- call `sub-agent-task-manager` separately
+- allow different model tiers and reasoning efforts
+- use a separate report path
+- preserve one parent-owned integration decision
+
+When one exceptionally difficult problem is not separable, leave it as one task and allow the selector to consider Sol `max`. Do not use `max` as a substitute for missing decomposition, and do not encode `ultra` in `reasoning_effort`.
 
 ## Required delegation pattern
 
 For each delegated task:
 
 1. classify the work as fixed-sub-agent vs implementation-side delegation
-2. if fixed-sub-agent, call `sub-agent-task-manager`
-3. otherwise choose executor and record why that executor was chosen
-4. when choosing a `sub-agent`, pass the selected model, reasoning effort, and fork policy to `sub-agent-task-manager`; for implementation, accept only the user-confirmed model from `development-orchestrator`; that skill owns the spawn-call contract
-5. define the exact scope
-6. identify any skill files the executor must read
-7. define expected outputs
-8. define validation commands or evidence
-9. run the delegated work
-10. capture results in `reports/`
+2. record the delegation assessment
+3. if the work has independent workstreams, decide whether multi-agent decomposition meets every gate above
+4. if fixed-sub-agent, call `sub-agent-task-manager`
+5. otherwise choose executor and record why that executor was chosen
+6. when choosing a `sub-agent`, pass the bounded task, assessment, explicit overrides or constraints, and decomposition disposition to `sub-agent-task-manager`
+7. define the exact scope and non-goals
+8. identify any skill files the executor must read
+9. define expected outputs
+10. define validation commands or evidence
+11. run the delegated work
+12. capture results, selected and applied dispatch profile, and synthesis evidence in `reports/`
 
 ## Rules
 
-- Keep delegated tasks small and sequential.
+- Keep delegated tasks small and sequential unless the multi-agent gate is fully satisfied.
 - Prefer one focused sub-task over one large ambiguous request.
 - Do not pre-decide implementation ownership outside this skill unless the user explicitly requires it.
 - Use the main agent for implementation only when the task is tightly coupled to current context, on the critical path, or risky to hand off.
 - Use a sub-agent for implementation when the task is bounded, parallelizable, or benefits from isolation.
 - Apply the same switchable implementation rule to design-document edits, test authoring, and code authoring.
+- Do not use file count as the model selector. Pass qualitative task signals to `sub-agent-task-manager`.
+- Do not hardcode model or reasoning defaults in this Skill; `sub-agent-task-manager` owns the central selection table.
+- Do not require implementation model confirmation when no user or repository override exists.
 - Do not leave concrete design-editing or code-editing workflow rules scattered across unrelated skills when `design-executor` or `implementation-executor` already covers them.
 - Every sub-agent request must leave a report in `reports/`.
 - Pre-create the report file before dispatch when using `sub-agent-task-manager`.
@@ -111,13 +168,14 @@ For each delegated task:
 - Do not instruct a `sub-agent` to run `codex exec`, nested Codex, or equivalent agent-spawning workflows inside the delegated task.
 - Do not instruct a `sub-agent` to re-enter `development-orchestrator` or any other parent-owned workflow unless that orchestration work is itself the explicit delegated task.
 - For review tasks, instruct the `sub-agent` to use the built-in review behavior rather than a custom ad hoc review style.
-- For review tasks, instruct the `sub-agent` to edit the pre-created report directly and treat parent-side report transcription as fallback only.
+- For review tasks, instruct the reviewer to edit the pre-created report directly and treat parent-side report transcription as fallback only.
 - For review tasks, instruct the reviewer to separate normal-path blockers, user-confirmation-required capability gaps, and non-blocking concerns that should only be recorded and held.
 - For review and investigation tasks, prefer workspace-direct inspection over parent-written excerpts when repository access is available.
 - For review tasks, do not accept chat-only review output; require the findings to be written into the report file.
 - When a delegated task depends on an existing skill, instruct the executor to read that skill file explicitly.
-- Do not encode model or reasoning selection only in a task prompt. Let `sub-agent-task-manager` apply the selected profile as actual spawn arguments and its central fallback rule when the runtime rejects an override.
-- Do not infer an implementation sub-agent model or dispatch implementation work without the user confirmation that `development-orchestrator` owns.
+- Do not encode model or reasoning selection only in a task prompt. Let `sub-agent-task-manager` select and apply the profile as actual spawn arguments.
+- Do not silently replace an explicit user or repository profile constraint.
+- Do not dispatch a dependent implementation task while a blocking investigation remains unresolved.
 
 ## Strong rule
 
@@ -130,7 +188,12 @@ Reviewer work is always `sub-agent` work.
 After this skill runs, there should be:
 
 - an explicit executor decision
+- a recorded delegation assessment
+- a bounded single task or an explicitly gated multi-agent decomposition
+- a decomposition disposition explaining why multi-agent execution was or was not used
 - a bounded delegated or locally executed work scope
+- selected and applied dispatch-profile evidence for every sub-agent task
+- synthesis evidence when multiple sub-agents were used
 - evidence captured in `reports/` for the work performed
 
 ## Evidence rules
@@ -138,10 +201,14 @@ After this skill runs, there should be:
 Record in `reports/`:
 
 - executor chosen and why
+- delegation assessment and source evidence
+- multi-agent decomposition disposition
 - what was delegated
 - what was changed or checked
 - what commands ran
+- requested and applied dispatch profile for every sub-agent
 - pass/fail outcome
+- synthesis result when applicable
 - unresolved risks if any
 
 When creating a new report file, call `report-output-manager` for placement and filename rules.
@@ -151,10 +218,13 @@ When creating a new report file, call `report-output-manager` for placement and 
 This skill is complete for the current work item only when:
 
 - executor choice has been made explicitly
+- the delegation assessment is recorded
+- any multi-agent split satisfies every decomposition gate
 - delegated or assigned work scope is fixed
 - required execution has run or been dispatched
+- selected and applied profiles are recorded for sub-agent work
 - results and evidence are captured in `reports/`
 
 ## Cross-cutting rule
 
-If recurring delegation failures or repeated workflow mistakes appear, call `feedback-points-manager`.
+If recurring delegation failures, profile misclassification, or repeated workflow mistakes appear, call `feedback-points-manager`.

--- a/skills/codex-delegation-executor/SKILL.md
+++ b/skills/codex-delegation-executor/SKILL.md
@@ -11,7 +11,7 @@ Route executable work through Codex or sub-agents.
 
 Ensure investigation, implementation, build, and verification work are delegated consistently, with executor choice and any multi-agent decomposition made explicitly and evidenced.
 
-This Skill decides whether work stays with the main agent, goes to one sub-agent, or is split into independently bounded sub-agent tasks. `sub-agent-task-manager` owns the model tier, reasoning effort, and fork policy for each bounded sub-agent task.
+This Skill decides whether work stays with the main agent, goes to one sub-agent, or is split into independently bounded sub-agent tasks. `sub-agent-task-manager` owns the model tier, reasoning effort, fork policy, role/default-role planning, runtime-profile observability, and report-persistence handling for each bounded sub-agent task.
 
 ## Execution owner
 
@@ -29,8 +29,11 @@ Before running this skill, identify:
 - scope boundaries, target files, and non-goals when known
 - validation or evidence expectations
 - coupling, urgency, write-scope overlap, and whether parallelism helps
-- uncertainty, expected change radius, criticality, repetition, and context need
-- explicit user or repository model, reasoning, budget, availability, or fork constraints
+- uncertainty, expected change radius, criticality, repetition, observed decomposability, and context need
+- `decomposition_policy: allowed | forbidden` when the caller owns an identity-sensitive execution constraint
+- report persistence mode when the caller requires `normal_persistence` or `deferred_attestation`
+- any pre-reserved report-path identity supplied by an upstream lifecycle owner
+- explicit user or repository model, reasoning, budget, availability, fork, or agent-role constraints
 
 Do not require a routine user-selected implementation model. Preserve an explicit override when the user or repository supplies one; otherwise let `sub-agent-task-manager` select the per-task profile from the delegation assessment.
 
@@ -62,7 +65,9 @@ The following work must be executed by a `sub-agent` now, not merely preferred:
 - requirement or issue-intake verification
 - standards detection or standards validation
 
-Use `sub-agent-task-manager` for these categories and require a report in `reports/`.
+Use `sub-agent-task-manager` for these categories.
+
+Ordinary fixed-sub-agent work uses `normal_persistence` and must produce a report under `reports/`. Independent-final review is the explicit exception: when `review-enforcer` supplies `report_persistence_mode: deferred_attestation` and a pre-reserved report-path identity, the reviewer returns structured evidence to the parent and must not create or edit that reserved repository path before a passing verdict.
 
 A fixed sub-agent category fixes the executor, not the model. Pass the task assessment and review or verification mode to `sub-agent-task-manager`, which applies [agent-profile-selection.md](../sub-agent-task-manager/references/agent-profile-selection.md).
 
@@ -77,8 +82,12 @@ Before selecting or dispatching an executor, record:
 - `criticality`: `ordinary` or `high`
 - `repetition`: `single` or `high_volume`
 - `decomposability`: `single`, `sequential_dependencies`, or `independent_workstreams`
+- `decomposition_policy`: `allowed` or `forbidden`
+- `decomposition_disposition` when policy suppresses an otherwise-decomposable task
 - `context_need`: `fresh`, `bounded_history`, or `full_history`
 - source evidence for each non-obvious classification
+
+`decomposability` is an observed work-structure signal. `decomposition_policy` is an execution constraint. Do not rewrite an observed `independent_workstreams` signal to `single` merely because a caller forbids decomposition.
 
 Estimate change radius by affected contracts and dependencies, not only by line or file count. A small security, compatibility, migration, concurrency, public-API, or release change is high-criticality even when its edit is local.
 
@@ -110,7 +119,7 @@ The thresholds decide executor ownership only. They do not imply Luna, Terra, or
 
 Treat article-described `Ultra` execution as a strategy, not a reasoning level.
 
-Split work into multiple sub-agents only when all of the following hold:
+Split work into multiple sub-agents only when `decomposition_policy: allowed` and all of the following hold:
 
 - at least two workstreams can execute independently
 - every workstream has explicit scope, non-goals, expected evidence, and report ownership
@@ -119,7 +128,7 @@ Split work into multiple sub-agents only when all of the following hold:
 - the parent defines a synthesis and conflict-resolution step
 - `execution-cost-stabilizer` confirms that parallel execution provides material value
 
-Do not split work merely because it is large. Keep sequential dependencies sequential.
+Do not split work merely because it is large. Keep sequential dependencies sequential. When decomposition is forbidden, preserve truthful decomposability and record the policy disposition instead of changing the signal.
 
 For every decomposed task:
 
@@ -129,24 +138,25 @@ For every decomposed task:
 - use a separate report path
 - preserve one parent-owned integration decision
 
-When one exceptionally difficult problem is not separable, leave it as one task and allow the selector to consider Sol `max`. Do not use `max` as a substitute for missing decomposition, and do not encode `ultra` in `reasoning_effort`.
+When one exceptionally difficult problem is intrinsically not separable, leave it as one task and allow the selector to consider Sol `max`. A caller prohibition on decomposition does not establish intrinsic non-decomposability and must not be used to justify `max`.
 
 ## Required delegation pattern
 
 For each delegated task:
 
 1. classify the work as fixed-sub-agent vs implementation-side delegation
-2. record the delegation assessment
-3. if the work has independent workstreams, decide whether multi-agent decomposition meets every gate above
+2. record the delegation assessment, including truthful decomposability and any separate decomposition policy/disposition
+3. if the work has independent workstreams and decomposition is allowed, decide whether multi-agent decomposition meets every gate above
 4. if fixed-sub-agent, call `sub-agent-task-manager`
 5. otherwise choose executor and record why that executor was chosen
-6. when choosing a `sub-agent`, pass the bounded task, assessment, explicit overrides or constraints, and decomposition disposition to `sub-agent-task-manager`
+6. when choosing a `sub-agent`, pass the bounded task, assessment, explicit overrides or constraints, decomposition disposition, report persistence mode, and any upstream pre-reserved report identity to `sub-agent-task-manager`
 7. define the exact scope and non-goals
 8. identify any skill files the executor must read
 9. define expected outputs
 10. define validation commands or evidence
-11. run the delegated work
-12. capture results, selected and applied dispatch profile, and synthesis evidence in `reports/`
+11. run or dispatch the delegated work
+12. capture results plus dispatch evidence: `requested`, `role_plan`, `planned_runtime_profile`, `profile_observability`, exact `applied` only when observable, otherwise the explicit unverified/inherited/fallback/capability-gap state, and synthesis evidence
+13. for `normal_persistence`, materialize the evidence in `reports/`; for `deferred_attestation`, retain it as parent-owned lifecycle evidence until the passing-verdict attestation owner permits persistence
 
 ## Rules
 
@@ -160,20 +170,23 @@ For each delegated task:
 - Do not hardcode model or reasoning defaults in this Skill; `sub-agent-task-manager` owns the central selection table.
 - Do not require implementation model confirmation when no user or repository override exists.
 - Do not leave concrete design-editing or code-editing workflow rules scattered across unrelated skills when `design-executor` or `implementation-executor` already covers them.
-- Every sub-agent request must leave a report in `reports/`.
-- Pre-create the report file before dispatch when using `sub-agent-task-manager`.
-- Instruct the `sub-agent` to read the pre-created report and preserve its format, filling only blank sections or placeholders.
+- Ordinary `normal_persistence` sub-agent work must leave a report in `reports/`.
+- Pre-create the report file before dispatch only for `normal_persistence`.
+- Independent-final `deferred_attestation` is reservation-only before review: do not create, edit, or require direct reviewer editing of the reserved report path.
+- For `normal_persistence`, instruct the child to read the pre-created report and preserve its format, filling only child-owned blank sections or placeholders.
+- For independent-final `deferred_attestation`, require structured reviewer output to the parent and preserve the pre-reserved report identity supplied by `review-enforcer`.
 - Exclude noisy diffs and irrelevant generated files from the explicit focus, but do not block the `sub-agent` from reading broader workspace context when needed.
 - Require concrete evidence instead of verbal assurance.
 - Do not instruct a `sub-agent` to run `codex exec`, nested Codex, or equivalent agent-spawning workflows inside the delegated task.
 - Do not instruct a `sub-agent` to re-enter `development-orchestrator` or any other parent-owned workflow unless that orchestration work is itself the explicit delegated task.
 - For review tasks, instruct the `sub-agent` to use the built-in review behavior rather than a custom ad hoc review style.
-- For review tasks, instruct the reviewer to edit the pre-created report directly and treat parent-side report transcription as fallback only.
+- For normal review/fix verification, direct report editing may be used under `normal_persistence`; for independent-final deferred attestation, repository report editing is prohibited before passing verdict.
 - For review tasks, instruct the reviewer to separate normal-path blockers, user-confirmation-required capability gaps, and non-blocking concerns that should only be recorded and held.
 - For review and investigation tasks, prefer workspace-direct inspection over parent-written excerpts when repository access is available.
-- For review tasks, do not accept chat-only review output; require the findings to be written into the report file.
+- Do not accept chat-only output for ordinary normal-persistence review. Deferred independent-final review is different: structured parent-returned review evidence is authoritative until attestation persistence is allowed.
 - When a delegated task depends on an existing skill, instruct the executor to read that skill file explicitly.
-- Do not encode model or reasoning selection only in a task prompt. Let `sub-agent-task-manager` select and apply the profile as actual spawn arguments.
+- Do not encode model or reasoning selection only in a task prompt. Let `sub-agent-task-manager` select and plan the profile as actual spawn arguments.
+- Do not infer exact `applied` from successful spawn. Accept `spawn_succeeded_profile_unverified` when the runtime hides the final profile and preserve `profile_observability`.
 - Do not silently replace an explicit user or repository profile constraint.
 - Do not dispatch a dependent implementation task while a blocking investigation remains unresolved.
 
@@ -192,39 +205,46 @@ After this skill runs, there should be:
 - a bounded single task or an explicitly gated multi-agent decomposition
 - a decomposition disposition explaining why multi-agent execution was or was not used
 - a bounded delegated or locally executed work scope
-- selected and applied dispatch-profile evidence for every sub-agent task
+- for every sub-agent task: `requested`, `role_plan`, `planned_runtime_profile`, and `profile_observability`
+- exact `applied` evidence when observable, otherwise an explicit `spawn_succeeded_profile_unverified`, inherited, fallback, or capability-gap state without inventing exact model/reasoning values
 - synthesis evidence when multiple sub-agents were used
-- evidence captured in `reports/` for the work performed
+- report-backed evidence for `normal_persistence`, or retained parent-owned evidence plus a stable pre-reserved report identity for `deferred_attestation`
 
 ## Evidence rules
 
-Record in `reports/`:
+Record or retain, according to persistence mode:
 
 - executor chosen and why
 - delegation assessment and source evidence
-- multi-agent decomposition disposition
+- multi-agent decomposition policy/disposition
 - what was delegated
 - what was changed or checked
 - what commands ran
-- requested and applied dispatch profile for every sub-agent
+- requested profile for every sub-agent
+- role/default-role plan and its configuration evidence
+- planned runtime profile
+- runtime profile observability
+- exact applied profile only when observable; otherwise the explicit unverified/inherited/fallback/capability-gap state
+- report persistence mode and, for deferred attestation, the upstream reservation owner/identity
 - pass/fail outcome
 - synthesis result when applicable
 - unresolved risks if any
 
-When creating a new report file, call `report-output-manager` for placement and filename rules.
+When creating a new normal-persistence report file, call `report-output-manager` for placement and filename rules. Do not create or re-reserve an independent-final deferred-attestation report path here when `review-enforcer` already owns its pre-freeze reservation.
 
 ## Completion condition
 
 This skill is complete for the current work item only when:
 
 - executor choice has been made explicitly
-- the delegation assessment is recorded
-- any multi-agent split satisfies every decomposition gate
+- the delegation assessment is recorded without falsifying observed decomposability
+- any multi-agent split satisfies every decomposition gate and caller policy
 - delegated or assigned work scope is fixed
 - required execution has run or been dispatched
-- selected and applied profiles are recorded for sub-agent work
-- results and evidence are captured in `reports/`
+- sub-agent dispatch evidence includes requested profile, role plan, planned runtime profile, and profile observability
+- exact applied profile is recorded when observable; otherwise an explicit supported unverified/inherited/fallback/capability-gap state is recorded
+- results/evidence are captured in the applicable normal report or retained deferred-attestation lifecycle evidence
 
 ## Cross-cutting rule
 
-If recurring delegation failures, profile misclassification, or repeated workflow mistakes appear, call `feedback-points-manager`.
+If recurring delegation failures, profile misclassification, runtime-observability gaps, report-lifecycle conflicts, or repeated workflow mistakes appear, call `feedback-points-manager`.

--- a/skills/design/skill-hierarchy-design.md
+++ b/skills/design/skill-hierarchy-design.md
@@ -56,7 +56,7 @@ runtime wrapper
 
 ### Runtime wrapper
 
-Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、一度だけのfresh independent reviewerと同reviewerによるbounded closure、report path、persistence、completion gateを所有する。
+Codex wrapperはsub-agent dispatch、reviewer identity、normal review continuity、一度だけのfresh independent reviewerと同reviewerによるbounded closure、report path reservation identity、phase-specific report persistence、completion gateを所有する。
 
 ChatGPT wrapperはcurrent-chat permission、connector、repository／PR persistence、chat continuity、cross-chat handoffを所有する。
 
@@ -105,17 +105,23 @@ development-orchestrator [親]
 │  │  └─ implementation-worker
 │  ├─ design-executor
 │  ├─ sub-agent-task-manager [verification]
-│  └─ report-output-manager [wrapper]
+│  └─ report-output-manager [normal persistence]
 │     ├─ work-context-manager
 │     └─ report-writer
 ├─ review-enforcer [wrapper]
 │  ├─ work-context-manager
 │  ├─ markdown-word-checker
-│  ├─ sub-agent-task-manager [normal reviewer]
+│  ├─ sub-agent-task-manager [normal reviewer / normal_persistence]
 │  │  └─ review-worker
-│  ├─ sub-agent-task-manager [fresh independent final reviewer]
+│  ├─ report-output-manager [normal-review persistence]
+│  │  ├─ work-context-manager
+│  │  └─ report-writer
+│  ├─ report-output-manager [independent reservation-only]
+│  │  └─ work-context-manager
+│  ├─ sub-agent-task-manager [fresh independent final reviewer / deferred_attestation / reuse reservation]
 │  │  └─ review-worker
-│  └─ report-output-manager
+│  └─ report-output-manager [passing attestation persistence]
+│     ├─ work-context-manager
 │     └─ report-writer
 ├─ progress-sync-manager
 ├─ git-workflow-manager
@@ -178,7 +184,9 @@ normal review cycleが収束した後、independent final reviewのtargetをfree
 
 ### 独立最終レビュー
 
-pre-freeze gateを通過し、全ての非final変更がcommitされた後に、independent-final-review report pathを予約する。`local_execution_available`ではvalidated local committed HEADをpushせずに、`remote_ci_only`ではauthorized pre-review pushとmatching current-HEAD CIをformal evidenceとして、そのHEADを`reviewed implementation HEAD`に固定する。
+pre-freeze gateを通過し、全ての非final変更がcommitされた後に、`review-enforcer`が`report-output-manager`のreservation-only phaseを一度だけ実行する。exact independent-final-review report pathをmetadataとして予約し、`reservation_owner: review-enforcer`、stable `reservation_identity`、reserved path、reservation evidence、`reservation_state: metadata_only`を記録する。ここでは`report-writer`を呼ばず、repository report fileを作成・編集しない。
+
+その後、`local_execution_available`ではvalidated local committed HEADをpushせずに、`remote_ci_only`ではauthorized pre-review pushとmatching current-HEAD CIをformal evidenceとして、そのHEADを`reviewed implementation HEAD`に固定する。
 
 fresh reviewerは次を満たす。
 
@@ -187,13 +195,17 @@ fresh reviewerは次を満たす。
 - review fixを実装していないこと
 - 原則`fork_turns: "none"`で起動すること
 - frozen reviewed implementation HEADを対象とすること
-- 要件、設計、final diff、全変更file、直接依存、tracking、report、current HEAD固有validation evidenceを読むこと
+- 要件、設計、final diff、全変更file、直接依存、tracking、normal report、current HEAD固有validation evidenceを読むこと
 - reviewer identityとindependence evidenceを記録すること
 - `review-worker`のindependent final reviewを実行すること
 - 過去review結論を読む前に独立passを行うこと
-- normal review reportとは別にindependent final review reportを作ること
+- `review-enforcer`が予約した`pre_reserved_report_path`と`reservation_identity`を`sub-agent-task-manager`からmetadataとして受け取ること
+- そのreservationを再作成せず、reserved repository report fileを作成・編集しないこと
+- findings、coverage、commands/evidence、verdict、risks、unexploredをstructured evidenceとしてparentへ返すこと
 
-独立最終レビューはtask lifecycleで一度だけの全coverage passである。required findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationとnormal reviewerのfix verificationへ戻る。HEAD更新後は最初の独立reviewerが、completeness matrixを満たしたfinding／CI-deltaだけをbounded closureとして確認し、新しい観点や再度の全coverage passを行わない。
+`sub-agent-task-manager`はindependent-final dispatch時に予約を作成しない。`review-enforcer`から渡されたpre-freeze reservation identityを検証・継承し、欠落・曖昧・post-freeze reservationであればdispatchをblockする。
+
+独立最終レビューはtask lifecycleで一度だけの全coverage passである。required findingまたは新しいrepository write obligationが出た場合はterminal stateを無効化し、implementationとnormal reviewerのfix verificationへ戻る。HEAD更新後は最初の独立reviewerが、同じreservation identityを保持したまま、completeness matrixを満たしたfinding／CI-deltaだけをbounded closureとして確認し、新しい観点や再度の全coverage passを行わない。passing verdict前にreserved report fileを作らない。
 
 normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身のreviewだけでは完了条件を満たさない。
 
@@ -201,12 +213,14 @@ normal reviewだけ、同じreviewerによる再reviewだけ、親agent自身の
 
 独立最終レビューのtechnical verdictは`reviewed implementation HEAD`へ結び付ける。
 
-詳細reportをrepositoryへ保存する必要がある場合、次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
+passing verdict後に詳細reportをrepositoryへ保存する場合だけ、`report-output-manager`のattestation-persistence phaseで`report-writer`を呼び、review開始前に予約した同じpathへreportを初めてmaterializeする。次の条件を全て満たす1回だけの`report-attestation commit`を許可する。
 
-- independent-final-review report pathはreview開始前に予約済みである
+- independent-final-review report pathはreview開始前に`review-enforcer`が一度だけmetadata予約している
+- stable `reservation_identity`がreview dispatch、bounded closure、attestation persistenceで同一である
+- passing verdict前にreserved report fileを作成・編集していない
 - report-attestation commitのfirst parentはreviewed implementation HEADである
 - reviewed implementation HEADの後に存在するcommitはこの1件だけである
-- diffは予約済みindependent-final-review report pathだけを変更する
+- diffはreservation identityに結び付くindependent-final-review report pathだけを変更する
 - reportはreviewed implementation HEADとadministrative attestationであることを明記する
 - executable、Skill、design、workflow、configuration、tracking、feedback、handoff、product fileを変更しない
 - report-attestation commit以後にrepository commitを作らない
@@ -427,17 +441,17 @@ Release時の共通file複製とrepository相対link書換は行わない。
 14. normal cycle収束後、end-of-Issue Skill-gap decisionを行う。
 15. current scopeで必要な`skill-authoring-wrapper`処理を実行し、feedback classification、feedback ledger、normal handoffを保存する。
 16. steps 14から15でrepositoryが変わった場合、validation、report、tracking、commit、verification routeに従うpush、normal fix verificationを再実施する。
-17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、independent-final-review report pathを予約する。
+17. 全pre-freeze変更を含むnormal cycleが収束したことを確認し、`review-enforcer`が`report-output-manager` reservation-only phaseを一度だけ実行してindependent-final-review report pathとstable reservation identityをmetadata予約する。report fileは作らない。
 18. current HEADをreviewed implementation HEADとしてfreezeする。
-19. 別fresh reviewerによる独立最終reviewを実施する。
-20. repository changeが必要になった場合はterminal stateを無効化し、normal cycleと同一independent reviewerのbounded finding／CI-delta closureへ戻る。
-21. passing reportを保存する場合は、予約済みreport pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
+19. `sub-agent-task-manager`へpre-reserved path／reservation identityを渡し、再予約せず、別fresh reviewerによる独立最終reviewを`deferred_attestation`で実施する。reviewerはrepository report fileを編集せずstructured evidenceをparentへ返す。
+20. repository changeが必要になった場合はterminal stateを無効化し、normal cycleと同一independent reviewerのbounded finding／CI-delta closureへ戻る。同じreservation identityを保持し、passing verdict前にreportをpersistしない。
+21. passing reportを保存する場合だけ、`report-output-manager` attestation-persistence phaseで`report-writer`を呼び、予約済みreport pathへ初めてmaterializeする。予約pathだけを変更する1回のreport-attestation commitを作成し、allowlist diffを検証する。
 22. report-attestation commitをfinal pushする。
 23. authorized PRを作成または更新する。
 24. publication後にexact-head `pull_request` required CIをmerge gateとして一度待つ。`remote_ci_only`ではroute内のmatching current-HEAD CIも正式verification evidenceとして扱う。
-25. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、validation evidenceを記録する。
-24. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
-25. mergeは利用者が行う。
+25. PR body／PR commentへreviewed implementation HEAD、report-attestation HEAD、reservation identity、validation evidenceを記録する。
+26. attestation後にrepository-writing Skillを呼ばず、repository commitを追加しない。final handoffはinlineまたはbranch外でtransportする。
+27. mergeは利用者が行う。
 
 ## Skill一覧
 
@@ -446,8 +460,8 @@ Release時の共通file複製とrepository相対link書換は行わない。
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
 | `development-orchestrator` | task選定から設計、実装、検証、レビュー、Git提出、pre-freeze gate、final attestation boundaryまでを統括する | 親が実行 |
-| `codex-delegation-executor` | 実作業の委譲先と実行profileを決める | 親が実行 |
-| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、report契約を固定する | 親が実行 |
+| `codex-delegation-executor` | 実作業の委譲先、executor、decomposition policy／dispositionを決め、sub-agent evidenceを統合する | 親が実行 |
+| `sub-agent-task-manager` | sub-agentのscope、model、reasoning、fork、role plan、runtime observability、report persistence契約を固定する | 親が実行 |
 | `execution-cost-stabilizer` | retry、parallelism、実行コストを安定化する | 親が実行 |
 | `feedback-autonomy-boundary-manager` | 自律継続と利用者確認の境界を決める | 親が実行 |
 | `skill-authoring-wrapper` | core Skill／runtime wrapperをrepository標準へ揃える | 親が実行 |
@@ -484,7 +498,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 
 | Skill | 役割 | 実行方式 |
 | --- | --- | --- |
-| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze gate、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
+| `review-enforcer` | reviewer identity、通常review cycle、pre-freeze reservation、独立最終review、report-attestation gateを管理するCodex wrapper | 親が実行、reviewはsub-agent |
 | `markdown-word-checker` | Markdown lintと表記ルールを検証する | 親が実行 |
 | `feedback-coding-standards-enforcer` | coding standardを検証する | 親が実行 |
 | `feedback-issue-intake-fallback-manager` | Issue取得失敗時に要件を確保する | 親が実行 |
@@ -498,7 +512,7 @@ Release時の共通file複製とrepository相対link書換は行わない。
 | `git-commit-manager` | scoped commitを作成する | 親が実行 |
 | `git-pr-submitter` | PRを作成または更新する | 親が実行 |
 | `git-review-followup-manager` | review findingをimplementation flowへ戻す | 親が実行 |
-| `report-output-manager` | report path／persistence／report-attestationを管理し、`report-writer`を呼び出すCodex wrapper | 親が実行 |
+| `report-output-manager` | normal persistence、independent reservation-only、passing attestation persistenceをphase別に管理するCodex wrapper | 親が実行 |
 
 ### ChatGPT runtime wrapper
 
@@ -517,7 +531,9 @@ Release時の共通file複製とrepository相対link書換は行わない。
 - implementationは自分の変更へreview verdictを出さない。
 - reviewerはfindingを実装しない。
 - finding identityとsource severityを維持し、severity変更はsource／new severity、理由、承認主体を明示する。
-- reviewは詳細reportへ記録する。
+- reviewは詳細reportへ記録する。ただしindependent-final `deferred_attestation`ではpassing verdict前にrepository reportを作成せず、structured evidenceをparentが保持し、passing後に同一reservation identityのpathへattestationとしてpersistする。
+- sub-agentのexact final model／reasoningがparent-visibleでないruntimeでは、successful spawnだけを根拠に`applied`を断定しない。`requested`、role plan、planned runtime profile、profile observabilityとexplicit unverified stateを保持する。
+- independent-final report reservationは`review-enforcer`がfreeze前に一度だけ所有し、`sub-agent-task-manager`はそのreservation identityを検証・継承して再予約しない。
 - CIは対象current HEAD SHAに紐づくrunだけを使用する。
 - 別SHAのrunを代用しない。
 - report、tracking、handoffは自己を含む将来のcommit SHAを要求しない。`commit_pending`、technical HEAD、administrative parentを区別する。

--- a/skills/development-orchestrator/SKILL.md
+++ b/skills/development-orchestrator/SKILL.md
@@ -41,11 +41,13 @@ Before running this Skill, establish:
 - repository-root `AGENTS.md` and its Skill-first constraints,
 - the user's intended work when it is not already explicit,
 - the target repository's development and testing policy,
-- the user-confirmed model for implementation sub-agent work when delegation may occur,
+- any explicit user or repository model, reasoning, budget, availability, or fork override for delegated work,
 - current `tasks-status.md` and `phases-status.md`,
 - recent relevant `reports/`,
 - active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`,
 - repository state needed to select one task.
+
+When no explicit dispatch override exists, do not ask the user to choose an implementation sub-agent model routinely. `codex-delegation-executor` and `sub-agent-task-manager` derive a profile from the bounded task.
 
 ## Required flow
 
@@ -54,13 +56,13 @@ Before running this Skill, establish:
 3. If the local Skill repository is clean and behind its intended source, update it before continuing.
 4. If it is dirty, diverged, or unsafe to update automatically, stop and resolve that state explicitly before trusting the workflow.
 5. For a resumed or restarted session, call `restart-handover-manager` to reconstruct the current position.
-6. At the first applicable user confirmation, confirm the implementation sub-agent model. When the intended work is not explicit, also read [start intake policy](references/start-intake-policy.md) and establish the work target.
+6. At the first applicable user confirmation, establish the intended work and any explicit dispatch override or budget constraint. When the intended work is not explicit, also read [start intake policy](references/start-intake-policy.md) and establish the work target. Do not request routine confirmation of an automatically selected implementation model.
 7. Invoke `work-context-manager` to resolve authority, current state, scope candidates, policy, validation targets, and write boundaries.
 8. Select exactly one next task from the resolved context.
 9. Call `task-consistency-manager`.
 10. Call `design-doc-maintainer` when design impact exists.
 11. If and only if the target repository explicitly requires TDD for the selected work, call `tdd-executor`. Otherwise record TDD as not applicable with the governing source and continue.
-12. Call `codex-delegation-executor` to choose an executor. The selected `implementation-executor` invokes `work-context-manager` and `implementation-worker` for implementation or review follow-up.
+12. Call `codex-delegation-executor` to classify the task, choose an executor, and decide whether independently bounded workstreams justify multi-agent decomposition. For each selected sub-agent task, `sub-agent-task-manager` selects and applies the model, reasoning effort, and fork policy. The selected `implementation-executor` invokes `work-context-manager` and `implementation-worker` for implementation or review follow-up.
 13. Route validation, commit, push, and CI waiting by `verification_capability`. For `local_execution_available`, reuse focused inner-loop evidence before review-target commits, keep normal review/fix loops local without CI waits, and keep broader validation distinct from the full local equivalence gate. For `remote_ci_only`, use matching current-HEAD CI after authorized push as formal verification evidence.
 14. Before review, create or update implementation and verification reports through `report-output-manager`, synchronize task and phase tracking, and create the review-target commit. Do not require a local-route review round to push or wait for CI.
 15. Call `review-enforcer` for the normal review cycle. Persist normal review and fix-verification reports before selecting the independent-final-review target. Required fixes return through `implementation-executor`, followed by route-appropriate validation, report and tracking synchronization, commit, and another normal fix-verification round.
@@ -70,11 +72,23 @@ Before running this Skill, establish:
 19. If steps 16 through 18 changed any repository file, run route-appropriate validation, update reports and tracking, commit, and return to the normal review or fix-verification cycle. Repeat until the normal cycle converges with all end-of-Issue and feedback changes included.
 20. Ensure every non-final repository change is committed. After normal convergence, run the repository-defined full local equivalence gate exactly once for the final publication candidate HEAD; record its exact-HEAD identity, retain invalidated prior runs, and rerun only if a content delta changes that candidate. Do not substitute inner-loop focused or broader validation. Reserve the independent-final-review report path, then freeze the current HEAD as the reviewed implementation HEAD.
 21. Call `review-enforcer` with one fresh independent reviewer against that frozen HEAD for the single exhaustive pass.
-22. If that review discovers required repository change, invalidate the terminal state and return to implementation, validation, reporting, tracking, feedback or Skill-action processing as applicable, followed by normal fix verification and the same reviewer's bounded finding/CI-delta closure against the updated reviewed HEAD.
+22. If that review discovers required repository change, invalidate the terminal state and return to implementation, validation, reporting, tracking, feedback or Skill-action processing as applicable, followed by normal fix verification and the same independent reviewer's bounded finding/CI-delta closure against the updated reviewed HEAD.
 23. When independent final review passes, persist its detailed report through `report-output-manager` as at most one report-attestation commit. The commit's first parent must be the reviewed implementation HEAD and its changed paths must be limited to the pre-reserved independent-final-review report path or paths.
 24. Validate the report-attestation diff, make the final authorized push, then invoke `git-pr-submitter` or the authorized equivalent to create or update the PR for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI as the merge gate. On `remote_ci_only`, matching current-HEAD CI may also be formal route evidence. Do not wait for an unrequired `push` run. Update the PR body, concise PR comment, review request, or external Issue only after the attestation commit because those operations do not change Git HEAD.
 25. Do not commit task, design, Skill, workflow, configuration, feedback, handoff, report, or implementation changes after the attestation head. Return the final handoff inline or outside the reviewed PR branch.
 26. Return to task confirmation. Starting another task begins a new lifecycle and must not append commits to the completed attestation pair.
+
+## Dispatch-profile policy
+
+The workflow must preserve the distinction between:
+
+- executor choice and multi-agent decomposition, owned by `codex-delegation-executor`
+- per-task model, reasoning effort, and fork policy, owned by `sub-agent-task-manager`
+- explicit user or repository overrides, which take precedence over automatic selection
+
+The parent records the delegation assessment, requested profile, applied profile, and runtime application status in the relevant report. It does not infer success from a model name written in the child prompt.
+
+A dispatch classification must be recomputed when investigation or implementation changes the task kind, uncertainty, change radius, or criticality. A failed deterministic verification becomes investigation; independently separable work returns to `codex-delegation-executor`; a full-history fork that prevents an override is recorded as an inherited-parent-profile constraint.
 
 ## Report-attestation terminal rule
 
@@ -105,7 +119,8 @@ After the freeze, only operations that do not change Git HEAD are permitted: PR 
 - If any of those actions changes the repository, require validation and normal review before freezing again.
 - Do not leave substantial local Skill changes without an explicit caller.
 - Do not choose parent versus sub-agent implementation outside `codex-delegation-executor`.
-- Do not dispatch implementation sub-agent work before the user-confirmed model is known.
+- Do not hardcode or require routine user confirmation of an implementation sub-agent model when no explicit override exists.
+- Do not bypass `sub-agent-task-manager` profile selection for delegated work.
 - Treat design editing, test authoring, code authoring, documentation, configuration, and workflow editing as implementation work owned through the applicable executor.
 - Do not call `tdd-executor` merely because code or tests may change. Call it only when the target repository explicitly requires TDD.
 - CodexSkill repository maintenance is non-TDD unless the user explicitly changes that repository policy.
@@ -123,6 +138,8 @@ After this Skill runs, the workflow has:
 - a structured context from `work-context-manager`,
 - the governing target-project development and testing policy,
 - a concrete route through applicable wrapper and core Skills,
+- an executor and multi-agent decomposition decision,
+- a delegation assessment plus requested and applied dispatch profile for every sub-agent task,
 - resolved `verification_capability` and separate commit, push, and CI-wait evidence,
 - implementation and validation evidence or an explicit blocking condition,
 - review, report, tracking, Skill-action, feedback, commit, and PR state,
@@ -136,6 +153,7 @@ A task cycle is complete only when:
 - target-project-required tests and validation are recorded,
 - TDD was applied only when required and otherwise recorded as not applicable,
 - normal review and independent final review are complete,
+- delegated work records the selected and actually applied dispatch profile,
 - required non-final reports, tracking, Skill decisions, feedback classification, feedback-ledger updates, and normal handoffs were committed before independent final review,
 - any repository change discovered during pre-freeze finalization returned through validation and normal review,
 - any post-review repository write is exactly one validated report-attestation commit,
@@ -145,6 +163,7 @@ A task cycle is complete only when:
 
 ## What this Skill must not do
 
+- Do not contain the detailed agent profile selection matrix.
 - Do not contain detailed TDD instructions.
 - Do not contain detailed Git instructions beyond the lifecycle boundary needed to keep review finite.
 - Do not contain detailed review criteria.

--- a/skills/development-orchestrator/SKILL.md
+++ b/skills/development-orchestrator/SKILL.md
@@ -17,7 +17,7 @@ Use independent Skills rather than repository-external shared files:
 
 - `work-context-manager` resolves authority, scope, target identity, policy, validation evidence, and write boundaries.
 - `implementation-executor` is the Codex wrapper that invokes `implementation-worker`.
-- `report-output-manager` is the Codex wrapper that invokes `report-writer`.
+- `report-output-manager` owns report phases and invokes `report-writer` only when content generation/persistence is allowed.
 - `review-enforcer` is the Codex wrapper that invokes `review-worker`.
 
 If a required Skill is unavailable, stop with a missing dependency. Do not reproduce its rules locally and do not fall back to `shared/` files.
@@ -41,13 +41,13 @@ Before running this Skill, establish:
 - repository-root `AGENTS.md` and its Skill-first constraints,
 - the user's intended work when it is not already explicit,
 - the target repository's development and testing policy,
-- any explicit user or repository model, reasoning, budget, availability, or fork override for delegated work,
+- any explicit user or repository model, reasoning, budget, availability, fork, or agent-role override for delegated work,
 - current `tasks-status.md` and `phases-status.md`,
 - recent relevant `reports/`,
 - active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`,
 - repository state needed to select one task.
 
-When no explicit dispatch override exists, do not ask the user to choose an implementation sub-agent model routinely. `codex-delegation-executor` and `sub-agent-task-manager` derive a profile from the bounded task. The exception is an approval-gated `Sol xhigh` or `Sol max` proposal: those profiles require explicit current-task user approval before dispatch.
+When no explicit dispatch override exists, do not ask the user to choose an implementation sub-agent model routinely. `codex-delegation-executor` and `sub-agent-task-manager` derive a profile from the bounded task. The exception is an approval-gated Sol `xhigh` or Sol `max` proposal, including one produced by agent-role/default-role planning; those profiles require explicit current-task user approval before dispatch.
 
 ## Required flow
 
@@ -56,120 +56,125 @@ When no explicit dispatch override exists, do not ask the user to choose an impl
 3. If the local Skill repository is clean and behind its intended source, update it before continuing.
 4. If it is dirty, diverged, or unsafe to update automatically, stop and resolve that state explicitly before trusting the workflow.
 5. For a resumed or restarted session, call `restart-handover-manager` to reconstruct the current position.
-6. At the first applicable user confirmation, establish the intended work and any explicit dispatch override or budget constraint. When the intended work is not explicit, also read [start intake policy](references/start-intake-policy.md) and establish the work target. Do not request routine confirmation of an automatically selected implementation model.
+6. At the first applicable user confirmation, establish the intended work and any explicit dispatch override or budget constraint. When intended work is not explicit, read [start intake policy](references/start-intake-policy.md) and establish the work target. Do not request routine confirmation of an automatically selected implementation model.
 7. Invoke `work-context-manager` to resolve authority, current state, scope candidates, policy, validation targets, and write boundaries.
 8. Select exactly one next task from the resolved context.
 9. Call `task-consistency-manager`.
 10. Call `design-doc-maintainer` when design impact exists.
-11. If and only if the target repository explicitly requires TDD for the selected work, call `tdd-executor`. Otherwise record TDD as not applicable with the governing source and continue.
-12. Call `codex-delegation-executor` to classify the task, choose an executor, and decide whether independently bounded workstreams justify multi-agent decomposition. For each selected sub-agent task, `sub-agent-task-manager` selects the model, reasoning effort, and fork policy. If it proposes `Sol xhigh` or `Sol max`, present the proposal and cost rationale to the user and stop the lifecycle before dispatch until explicit approval is received. The selected `implementation-executor` invokes `work-context-manager` and `implementation-worker` for implementation or review follow-up.
-13. Route validation, commit, push, and CI waiting by `verification_capability`. For `local_execution_available`, reuse focused inner-loop evidence before review-target commits, keep normal review/fix loops local without CI waits, and keep broader validation distinct from the full local equivalence gate. For `remote_ci_only`, use matching current-HEAD CI after authorized push as formal verification evidence.
-14. Before review, create or update implementation and verification reports through `report-output-manager`, synchronize task and phase tracking, and create the review-target commit. Do not require a local-route review round to push or wait for CI.
-15. Call `review-enforcer` for the normal review cycle. Persist normal review and fix-verification reports before selecting the independent-final-review target. Required fixes return through `implementation-executor`, followed by route-appropriate validation, report and tracking synchronization, commit, and another normal fix-verification round. Any `Sol xhigh` or `Sol max` review proposal remains subject to the same explicit approval stop.
-16. After the normal cycle converges, make the parent-owned end-of-Issue Skill-gap decision: `no skill action needed`, `update an existing skill`, or `propose a new skill`.
-17. When the chosen Skill action should be executed in the current scope, call `skill-authoring-wrapper` now. Otherwise record the action as follow-up work before the final-review freeze.
-18. Call `feedback-points-manager` for reusable process feedback, Skillization state, or a follow-up Issue. Persist any repository-backed normal handoff, feedback ledger, report, or tracking change now.
-19. If steps 16 through 18 changed any repository file, run route-appropriate validation, update reports and tracking, commit, and return to the normal review or fix-verification cycle. Repeat until the normal cycle converges with all end-of-Issue and feedback changes included.
-20. Ensure every non-final repository change is committed. After normal convergence, run the repository-defined full local equivalence gate exactly once for the final publication candidate HEAD; record its exact-HEAD identity, retain invalidated prior runs, and rerun only if a content delta changes that candidate. Do not substitute inner-loop focused or broader validation. Reserve the independent-final-review report path, then freeze the current HEAD as the reviewed implementation HEAD.
-21. Call `review-enforcer` with one fresh independent reviewer against that frozen HEAD for the single exhaustive pass. If profile selection proposes `Sol xhigh` or `Sol max`, do not dispatch the reviewer until the user explicitly approves that cost-gated profile.
-22. If that review discovers required repository change, invalidate the terminal state and return to implementation, validation, reporting, tracking, feedback or Skill-action processing as applicable, followed by normal fix verification and the same independent reviewer's bounded finding/CI-delta closure against the updated reviewed HEAD.
-23. When independent final review passes, persist its detailed report through `report-output-manager` as at most one report-attestation commit. The commit's first parent must be the reviewed implementation HEAD and its changed paths must be limited to the pre-reserved independent-final-review report path or paths.
-24. Validate the report-attestation diff, make the final authorized push, then invoke `git-pr-submitter` or the authorized equivalent to create or update the PR for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI as the merge gate. On `remote_ci_only`, matching current-HEAD CI may also be formal route evidence. Do not wait for an unrequired `push` run. Update the PR body, concise PR comment, review request, or external Issue only after the attestation commit because those operations do not change Git HEAD.
-25. Do not commit task, design, Skill, workflow, configuration, feedback, handoff, report, or implementation changes after the attestation head. Return the final handoff inline or outside the reviewed PR branch.
-26. Return to task confirmation. Starting another task begins a new lifecycle and must not append commits to the completed attestation pair.
+11. If and only if the target repository explicitly requires TDD for selected work, call `tdd-executor`. Otherwise record TDD as not applicable with governing source and continue.
+12. Call `codex-delegation-executor` to classify the task, choose an executor, and decide whether independently bounded workstreams justify multi-agent decomposition when decomposition is allowed. For each sub-agent task, `sub-agent-task-manager` selects model/reasoning/fork, preserves truthful decomposability separately from decomposition policy, plans explicit/default agent-role effects, and records runtime profile observability. If initial or role-adjusted planning proposes Sol `xhigh`/`max`, present rationale/cost to the user and stop before dispatch until explicit approval. If role impact cannot be inspected sufficiently to enforce the gate, stop with capability gap rather than dispatch.
+13. Route validation, commit, push, and CI waiting by `verification_capability`. For `local_execution_available`, reuse focused inner-loop evidence before review-target commits, keep normal review/fix loops local without CI waits, and keep broader validation distinct from full local equivalence gate. For `remote_ci_only`, use matching current-HEAD CI after authorized push as formal verification evidence.
+14. Before review, create/update implementation and verification reports through `report-output-manager`, synchronize task/phase tracking, and create review-target commit. Do not require local-route review round to push or wait for CI.
+15. Call `review-enforcer` for normal review cycle. Persist normal-review/fix-verification reports before selecting independent-final-review target. Required fixes return through `implementation-executor`, followed by route-appropriate validation, report/tracking synchronization, commit, and another normal fix-verification round. Any initial/role-adjusted Sol `xhigh`/`max` review proposal remains subject to explicit approval stop.
+16. After normal cycle converges, make parent-owned end-of-Issue Skill-gap decision: `no skill action needed`, `update an existing skill`, or `propose a new skill`.
+17. When chosen Skill action should execute in current scope, call `skill-authoring-wrapper`. Otherwise record follow-up before final-review freeze.
+18. Call `feedback-points-manager` for reusable process feedback, Skillization state, or follow-up Issue. Persist any repository-backed normal handoff, feedback ledger, report, or tracking change now.
+19. If steps 16 through 18 changed repository files, run route-appropriate validation, update reports/tracking, commit, and return to normal review/fix-verification cycle. Repeat until normal cycle converges with all end-of-Issue/feedback changes included.
+20. Ensure every non-final repository change is committed. After normal convergence, run repository-defined full local equivalence gate exactly once for final publication candidate HEAD; record exact-HEAD identity, retain invalidated prior runs, and rerun only if content delta changes candidate. Reserve independent-final-review report path through `report-output-manager` reservation-only phase; do not invoke `report-writer` or create report file. Freeze current HEAD as reviewed implementation HEAD.
+21. Call `review-enforcer` with one fresh independent reviewer against frozen HEAD for single exhaustive pass. If profile/role planning proposes Sol `xhigh`/`max`, do not dispatch until user explicitly approves. If role-profile safety is unresolved, stop with capability gap.
+22. If review discovers required repository change, invalidate terminal state and return to implementation, validation, reporting, tracking, feedback, or Skill-action processing as applicable, followed by normal fix verification and same independent reviewer's bounded finding/CI-delta closure against updated reviewed HEAD.
+23. When independent final review passes, call `report-output-manager` attestation-persistence phase; only then invoke `report-writer` to persist detailed report as at most one report-attestation commit. First parent must be reviewed implementation HEAD and changed paths limited to pre-reserved independent-final-review report paths.
+24. Validate report-attestation diff, make final authorized push, then invoke `git-pr-submitter` or authorized equivalent to create/update PR for exact HEAD. Wait once after publication for exact-head required `pull_request` CI as merge gate. On `remote_ci_only`, matching current-HEAD CI may also be formal route evidence. Do not wait for unrequired `push` run. Update PR body/comment/review request/external Issue only after attestation commit because these do not change Git HEAD.
+25. Do not commit task, design, Skill, workflow, configuration, feedback, handoff, report, or implementation changes after attestation head. Return final handoff inline/outside reviewed PR branch.
+26. Return to task confirmation. Starting another task begins a new lifecycle and must not append commits to completed attestation pair.
 
 ## Dispatch-profile policy
 
 The workflow must preserve the distinction between:
 
 - executor choice and multi-agent decomposition, owned by `codex-delegation-executor`
-- per-task model, reasoning effort, fork policy, and expensive-profile proposal state, owned by `sub-agent-task-manager`
-- explicit user or repository overrides, subject to the mandatory user-approval gate for `Sol xhigh` and `Sol max`
+- per-task model, reasoning effort, fork policy, truthful decomposability, decomposition policy, agent-role/default-role planning, expensive-profile proposal state, and runtime-profile observability, owned by `sub-agent-task-manager`
+- explicit user/repository overrides, subject to mandatory user-approval gate for Sol `xhigh` and Sol `max`
 
-The parent records the delegation assessment, proposed profile when applicable, approval evidence, requested profile, applied profile, and runtime application status in the relevant report. It does not infer success from a model name written in the child prompt.
+The parent records delegation assessment, proposal/approval evidence, requested profile, role plan, planned runtime profile, runtime observability, exact applied profile when observable, and application status. It does not infer success from a model name in child prompt or from spawn success alone.
 
-`Sol xhigh` and `Sol max` are a user-confirmation boundary for cost optimization. If either profile is proposed, the parent must tell the user why `Sol high` is insufficient, disclose that the higher effort increases execution cost, and stop before dispatch. Repository policy cannot waive this confirmation. Explicit current-task user instruction requesting the profile counts as approval; prior unrelated approval or silence does not.
+When final model/reasoning metadata is not parent-visible, preserve `applied: null` and an explicit state such as `spawn_succeeded_profile_unverified`; do not fabricate an exact applied profile. This unverified state is valid lifecycle evidence, not automatic success/failure of the delegated task itself.
 
-A dispatch classification must be recomputed when investigation or implementation changes the task kind, uncertainty, change radius, or criticality. A failed deterministic verification becomes investigation; independently separable work returns to `codex-delegation-executor`; a full-history fork that prevents an override is recorded as an inherited-parent-profile constraint. If the user rejects an expensive-profile proposal, recompute with `Sol xhigh` and `Sol max` excluded rather than silently dispatching the rejected profile.
+Sol `xhigh` and Sol `max` are a user-confirmation boundary for cost optimization. If initial selection or role/default-role planning proposes either, parent must explain why Sol `high` is insufficient, disclose higher execution cost, and stop before dispatch. Repository policy cannot waive confirmation. Explicit current-task user instruction counts as approval; prior unrelated approval/silence does not.
+
+A dispatch classification must be recomputed when investigation/implementation changes task kind, uncertainty, change radius, criticality, or known role-adjusted runtime plan. Failed deterministic verification becomes investigation. Independently separable work returns to `codex-delegation-executor` only when decomposition policy permits; identity-sensitive review may preserve `decomposability: independent_workstreams` while suppressing decomposition by policy. Full-history/role constraints remain explicit runtime planning evidence. If user rejects expensive-profile proposal, recompute with Sol `xhigh`/`max` excluded.
 
 ## Report-attestation terminal rule
 
 An independent-final-review verdict remains attached to its reviewed implementation HEAD. A later Git HEAD may be accepted only as a report-attestation head when all conditions below hold:
 
-- exactly one commit follows the reviewed implementation HEAD,
-- its first parent is the reviewed implementation HEAD,
-- only the independent-final-review report path or paths reserved before review are changed,
-- the report identifies the reviewed implementation HEAD and states that the commit is an administrative attestation rather than reviewed implementation,
-- an automated or explicit diff check confirms that no executable, Skill, design, workflow, configuration, task-tracking, feedback, handoff, or product file changed,
+- exactly one commit follows reviewed implementation HEAD,
+- its first parent is reviewed implementation HEAD,
+- only independent-final-review report path(s) reserved before review are changed,
+- report identifies reviewed implementation HEAD and states commit is administrative attestation rather than reviewed implementation,
+- automated/explicit diff check confirms no executable, Skill, design, workflow, configuration, task-tracking, feedback, handoff, or product file changed,
 - no later repository commit exists.
 
-The completion identity is the pair `reviewed implementation HEAD + validated report-attestation HEAD`. Any other post-review commit invalidates completion and requires normal fix verification followed by the same independent reviewer's bounded finding/CI-delta closure.
+Completion identity is `reviewed implementation HEAD + validated report-attestation HEAD`. Any other post-review commit invalidates completion and requires normal fix verification followed by same independent reviewer's bounded finding/CI-delta closure.
 
-After the freeze, only operations that do not change Git HEAD are permitted: PR body or comment updates, review requests, external Issue creation or update, and branch-external or inline transport. Discovery of a required repository write invalidates the terminal state and returns the workflow to the normal cycle.
+After freeze, only operations that do not change Git HEAD are permitted: PR body/comment updates, review requests, external Issue operations, and branch-external/inline transport. Discovery of required repository write invalidates terminal state and returns workflow to normal cycle.
 
 ## Core rules
 
 - Work on one task at a time.
-- Do not start implementation or resume flows from another standard entry point.
-- Do not select a task while the run target remains ambiguous.
+- Do not start implementation/resume flows from another standard entry point.
+- Do not select a task while run target remains ambiguous.
 - Do not treat implementation as complete before required validation, review, progress synchronization, commit, and PR creation.
 - Do not skip task reconciliation, design reflection, review, or progress updates.
-- Do not enter the workflow on stale local Skills when a safe latest synchronization was available.
-- Do not trust the workflow entry until `AGENTS.md` contains the required Skill-first constraints or the user has been explicitly notified.
+- Do not enter workflow on stale local Skills when safe latest synchronization was available.
+- Do not trust workflow entry until `AGENTS.md` contains required Skill-first constraints or user has been explicitly notified.
 - Do not skip parent-owned end-of-Issue Skill-gap reflection.
-- Complete Skill action decisions, feedback classification, feedback-ledger synchronization, normal handoff persistence, reports, and tracking before freezing the independent-final-review target.
-- If any of those actions changes the repository, require validation and normal review before freezing again.
-- Do not leave substantial local Skill changes without an explicit caller.
+- Complete Skill action decisions, feedback classification/ledger synchronization, normal handoff persistence, reports, and tracking before freezing independent-final-review target.
+- If any of those actions changes repository, require validation and normal review before freezing again.
+- Do not leave substantial local Skill changes without explicit caller.
 - Do not choose parent versus sub-agent implementation outside `codex-delegation-executor`.
-- Do not hardcode or require routine user confirmation of an implementation sub-agent model when no explicit override exists, except for the mandatory `Sol xhigh` / `Sol max` approval gate.
-- Never dispatch `Sol xhigh` or `Sol max` without explicit current-task user approval.
-- Do not bypass `sub-agent-task-manager` profile selection for delegated work.
-- Treat design editing, test authoring, code authoring, documentation, configuration, and workflow editing as implementation work owned through the applicable executor.
-- Do not call `tdd-executor` merely because code or tests may change. Call it only when the target repository explicitly requires TDD.
-- CodexSkill repository maintenance is non-TDD unless the user explicitly changes that repository policy.
-- When work is delegated, make the sub-agent read the applicable wrapper and core Skill files instead of relying only on a paraphrased prompt.
+- Do not hardcode or routinely confirm implementation sub-agent model when no explicit override exists, except mandatory Sol `xhigh`/`max` gate.
+- Never dispatch Sol `xhigh` or Sol `max` without explicit current-task user approval, including role-adjusted proposals.
+- Do not bypass `sub-agent-task-manager` profile/role planning for delegated work.
+- Do not falsify `decomposability` to enforce one-agent policy; record policy separately.
+- Do not claim exact `applied` when final runtime profile is hidden.
+- Treat design editing, test authoring, code authoring, documentation, configuration, and workflow editing as implementation work owned through applicable executor.
+- Do not call `tdd-executor` merely because code/tests may change. Call it only when target repository explicitly requires TDD.
+- CodexSkill repository maintenance is non-TDD unless user explicitly changes that policy.
+- When work is delegated, make sub-agent read applicable wrapper/core Skill files instead of relying only on paraphrased prompt.
 - Do not make delegated tasks re-enter this orchestration Skill unless orchestration analysis itself was delegated.
-- Do not use deleted or repository-external `shared/` contracts as a fallback.
-- Stop and re-plan when required work is missing from task tracking.
-- After report attestation, do not call any Skill that can write to the reviewed repository branch.
+- Do not use deleted or repository-external `shared/` contracts as fallback.
+- Stop/re-plan when required work is missing from task tracking.
+- After report attestation, do not call any Skill that can write to reviewed repository branch.
 
 ## Outputs
 
-After this Skill runs, the workflow has:
+After this Skill runs, workflow has:
 
 - one explicitly selected task,
-- a structured context from `work-context-manager`,
-- the governing target-project development and testing policy,
-- a concrete route through applicable wrapper and core Skills,
-- an executor and multi-agent decomposition decision,
-- a delegation assessment plus proposal/approval evidence when applicable and requested/applied dispatch profile for every dispatched sub-agent task,
-- resolved `verification_capability` and separate commit, push, and CI-wait evidence,
-- implementation and validation evidence or an explicit blocking condition,
-- review, report, tracking, Skill-action, feedback, commit, and PR state,
-- a reviewed implementation HEAD and, when repository persistence is required, a validated report-attestation head.
+- structured context from `work-context-manager`,
+- governing target-project development/testing policy,
+- concrete route through applicable wrapper/core Skills,
+- executor and decomposition decision/policy,
+- delegation assessment plus proposal/approval evidence when applicable,
+- requested profile, role/default-role plan, planned runtime profile, runtime observability, and exact applied profile when observable or explicit unverified/capability state for every dispatched sub-agent task,
+- resolved `verification_capability` and separate commit/push/CI-wait evidence,
+- implementation/validation evidence or explicit blocking condition,
+- review/report/tracking/Skill-action/feedback/commit/PR state,
+- reviewed implementation HEAD and, when repository persistence is required, validated report-attestation head.
 
 ## Completion condition
 
 A task cycle is complete only when:
 
 - accepted implementation is complete or explicitly blocked,
-- target-project-required tests and validation are recorded,
-- TDD was applied only when required and otherwise recorded as not applicable,
+- target-project-required tests/validation are recorded,
+- TDD was applied only when required and otherwise recorded not applicable,
 - normal review and independent final review are complete,
-- delegated work records the selected and actually applied dispatch profile,
-- any `Sol xhigh` or `Sol max` dispatch has explicit current-task user approval evidence,
-- required non-final reports, tracking, Skill decisions, feedback classification, feedback-ledger updates, and normal handoffs were committed before independent final review,
-- any repository change discovered during pre-freeze finalization returned through validation and normal review,
+- delegated work records requested/role-plan evidence and either exact applied profile or an explicit unverified/inherited/fallback/capability state,
+- any initial/role-adjusted Sol `xhigh`/`max` dispatch has explicit current-task approval evidence,
+- required non-final reports/tracking/Skill decisions/feedback/normal handoffs were committed before independent final review,
+- any repository change discovered during pre-freeze finalization returned through validation/normal review,
 - any post-review repository write is exactly one validated report-attestation commit,
-- no repository-writing Skill ran after the attestation head,
-- commit and PR actions are complete,
+- no repository-writing Skill ran after attestation head,
+- commit/PR actions are complete,
 - no merge was performed.
 
 ## What this Skill must not do
 
-- Do not contain the detailed agent profile selection matrix.
+- Do not contain detailed agent profile selection matrix.
 - Do not contain detailed TDD instructions.
-- Do not contain detailed Git instructions beyond the lifecycle boundary needed to keep review finite.
+- Do not contain detailed Git instructions beyond lifecycle boundary needed to keep review finite.
 - Do not contain detailed review criteria.
 - Do not directly replace child Skills.
 - Do not bypass `codex-delegation-executor` when executable work needs an owner decision.

--- a/skills/development-orchestrator/SKILL.md
+++ b/skills/development-orchestrator/SKILL.md
@@ -47,7 +47,7 @@ Before running this Skill, establish:
 - active `/home/ibis/AI/CodexSkill/feedback-points/feedback-points.md`,
 - repository state needed to select one task.
 
-When no explicit dispatch override exists, do not ask the user to choose an implementation sub-agent model routinely. `codex-delegation-executor` and `sub-agent-task-manager` derive a profile from the bounded task.
+When no explicit dispatch override exists, do not ask the user to choose an implementation sub-agent model routinely. `codex-delegation-executor` and `sub-agent-task-manager` derive a profile from the bounded task. The exception is an approval-gated `Sol xhigh` or `Sol max` proposal: those profiles require explicit current-task user approval before dispatch.
 
 ## Required flow
 
@@ -62,16 +62,16 @@ When no explicit dispatch override exists, do not ask the user to choose an impl
 9. Call `task-consistency-manager`.
 10. Call `design-doc-maintainer` when design impact exists.
 11. If and only if the target repository explicitly requires TDD for the selected work, call `tdd-executor`. Otherwise record TDD as not applicable with the governing source and continue.
-12. Call `codex-delegation-executor` to classify the task, choose an executor, and decide whether independently bounded workstreams justify multi-agent decomposition. For each selected sub-agent task, `sub-agent-task-manager` selects and applies the model, reasoning effort, and fork policy. The selected `implementation-executor` invokes `work-context-manager` and `implementation-worker` for implementation or review follow-up.
+12. Call `codex-delegation-executor` to classify the task, choose an executor, and decide whether independently bounded workstreams justify multi-agent decomposition. For each selected sub-agent task, `sub-agent-task-manager` selects the model, reasoning effort, and fork policy. If it proposes `Sol xhigh` or `Sol max`, present the proposal and cost rationale to the user and stop the lifecycle before dispatch until explicit approval is received. The selected `implementation-executor` invokes `work-context-manager` and `implementation-worker` for implementation or review follow-up.
 13. Route validation, commit, push, and CI waiting by `verification_capability`. For `local_execution_available`, reuse focused inner-loop evidence before review-target commits, keep normal review/fix loops local without CI waits, and keep broader validation distinct from the full local equivalence gate. For `remote_ci_only`, use matching current-HEAD CI after authorized push as formal verification evidence.
 14. Before review, create or update implementation and verification reports through `report-output-manager`, synchronize task and phase tracking, and create the review-target commit. Do not require a local-route review round to push or wait for CI.
-15. Call `review-enforcer` for the normal review cycle. Persist normal review and fix-verification reports before selecting the independent-final-review target. Required fixes return through `implementation-executor`, followed by route-appropriate validation, report and tracking synchronization, commit, and another normal fix-verification round.
+15. Call `review-enforcer` for the normal review cycle. Persist normal review and fix-verification reports before selecting the independent-final-review target. Required fixes return through `implementation-executor`, followed by route-appropriate validation, report and tracking synchronization, commit, and another normal fix-verification round. Any `Sol xhigh` or `Sol max` review proposal remains subject to the same explicit approval stop.
 16. After the normal cycle converges, make the parent-owned end-of-Issue Skill-gap decision: `no skill action needed`, `update an existing skill`, or `propose a new skill`.
 17. When the chosen Skill action should be executed in the current scope, call `skill-authoring-wrapper` now. Otherwise record the action as follow-up work before the final-review freeze.
 18. Call `feedback-points-manager` for reusable process feedback, Skillization state, or a follow-up Issue. Persist any repository-backed normal handoff, feedback ledger, report, or tracking change now.
 19. If steps 16 through 18 changed any repository file, run route-appropriate validation, update reports and tracking, commit, and return to the normal review or fix-verification cycle. Repeat until the normal cycle converges with all end-of-Issue and feedback changes included.
 20. Ensure every non-final repository change is committed. After normal convergence, run the repository-defined full local equivalence gate exactly once for the final publication candidate HEAD; record its exact-HEAD identity, retain invalidated prior runs, and rerun only if a content delta changes that candidate. Do not substitute inner-loop focused or broader validation. Reserve the independent-final-review report path, then freeze the current HEAD as the reviewed implementation HEAD.
-21. Call `review-enforcer` with one fresh independent reviewer against that frozen HEAD for the single exhaustive pass.
+21. Call `review-enforcer` with one fresh independent reviewer against that frozen HEAD for the single exhaustive pass. If profile selection proposes `Sol xhigh` or `Sol max`, do not dispatch the reviewer until the user explicitly approves that cost-gated profile.
 22. If that review discovers required repository change, invalidate the terminal state and return to implementation, validation, reporting, tracking, feedback or Skill-action processing as applicable, followed by normal fix verification and the same independent reviewer's bounded finding/CI-delta closure against the updated reviewed HEAD.
 23. When independent final review passes, persist its detailed report through `report-output-manager` as at most one report-attestation commit. The commit's first parent must be the reviewed implementation HEAD and its changed paths must be limited to the pre-reserved independent-final-review report path or paths.
 24. Validate the report-attestation diff, make the final authorized push, then invoke `git-pr-submitter` or the authorized equivalent to create or update the PR for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI as the merge gate. On `remote_ci_only`, matching current-HEAD CI may also be formal route evidence. Do not wait for an unrequired `push` run. Update the PR body, concise PR comment, review request, or external Issue only after the attestation commit because those operations do not change Git HEAD.
@@ -83,12 +83,14 @@ When no explicit dispatch override exists, do not ask the user to choose an impl
 The workflow must preserve the distinction between:
 
 - executor choice and multi-agent decomposition, owned by `codex-delegation-executor`
-- per-task model, reasoning effort, and fork policy, owned by `sub-agent-task-manager`
-- explicit user or repository overrides, which take precedence over automatic selection
+- per-task model, reasoning effort, fork policy, and expensive-profile proposal state, owned by `sub-agent-task-manager`
+- explicit user or repository overrides, subject to the mandatory user-approval gate for `Sol xhigh` and `Sol max`
 
-The parent records the delegation assessment, requested profile, applied profile, and runtime application status in the relevant report. It does not infer success from a model name written in the child prompt.
+The parent records the delegation assessment, proposed profile when applicable, approval evidence, requested profile, applied profile, and runtime application status in the relevant report. It does not infer success from a model name written in the child prompt.
 
-A dispatch classification must be recomputed when investigation or implementation changes the task kind, uncertainty, change radius, or criticality. A failed deterministic verification becomes investigation; independently separable work returns to `codex-delegation-executor`; a full-history fork that prevents an override is recorded as an inherited-parent-profile constraint.
+`Sol xhigh` and `Sol max` are a user-confirmation boundary for cost optimization. If either profile is proposed, the parent must tell the user why `Sol high` is insufficient, disclose that the higher effort increases execution cost, and stop before dispatch. Repository policy cannot waive this confirmation. Explicit current-task user instruction requesting the profile counts as approval; prior unrelated approval or silence does not.
+
+A dispatch classification must be recomputed when investigation or implementation changes the task kind, uncertainty, change radius, or criticality. A failed deterministic verification becomes investigation; independently separable work returns to `codex-delegation-executor`; a full-history fork that prevents an override is recorded as an inherited-parent-profile constraint. If the user rejects an expensive-profile proposal, recompute with `Sol xhigh` and `Sol max` excluded rather than silently dispatching the rejected profile.
 
 ## Report-attestation terminal rule
 
@@ -119,7 +121,8 @@ After the freeze, only operations that do not change Git HEAD are permitted: PR 
 - If any of those actions changes the repository, require validation and normal review before freezing again.
 - Do not leave substantial local Skill changes without an explicit caller.
 - Do not choose parent versus sub-agent implementation outside `codex-delegation-executor`.
-- Do not hardcode or require routine user confirmation of an implementation sub-agent model when no explicit override exists.
+- Do not hardcode or require routine user confirmation of an implementation sub-agent model when no explicit override exists, except for the mandatory `Sol xhigh` / `Sol max` approval gate.
+- Never dispatch `Sol xhigh` or `Sol max` without explicit current-task user approval.
 - Do not bypass `sub-agent-task-manager` profile selection for delegated work.
 - Treat design editing, test authoring, code authoring, documentation, configuration, and workflow editing as implementation work owned through the applicable executor.
 - Do not call `tdd-executor` merely because code or tests may change. Call it only when the target repository explicitly requires TDD.
@@ -139,7 +142,7 @@ After this Skill runs, the workflow has:
 - the governing target-project development and testing policy,
 - a concrete route through applicable wrapper and core Skills,
 - an executor and multi-agent decomposition decision,
-- a delegation assessment plus requested and applied dispatch profile for every sub-agent task,
+- a delegation assessment plus proposal/approval evidence when applicable and requested/applied dispatch profile for every dispatched sub-agent task,
 - resolved `verification_capability` and separate commit, push, and CI-wait evidence,
 - implementation and validation evidence or an explicit blocking condition,
 - review, report, tracking, Skill-action, feedback, commit, and PR state,
@@ -154,6 +157,7 @@ A task cycle is complete only when:
 - TDD was applied only when required and otherwise recorded as not applicable,
 - normal review and independent final review are complete,
 - delegated work records the selected and actually applied dispatch profile,
+- any `Sol xhigh` or `Sol max` dispatch has explicit current-task user approval evidence,
 - required non-final reports, tracking, Skill decisions, feedback classification, feedback-ledger updates, and normal handoffs were committed before independent final review,
 - any repository change discovered during pre-freeze finalization returned through validation and normal review,
 - any post-review repository write is exactly one validated report-attestation commit,

--- a/skills/development-orchestrator/SKILL.md
+++ b/skills/development-orchestrator/SKILL.md
@@ -17,8 +17,8 @@ Use independent Skills rather than repository-external shared files:
 
 - `work-context-manager` resolves authority, scope, target identity, policy, validation evidence, and write boundaries.
 - `implementation-executor` is the Codex wrapper that invokes `implementation-worker`.
-- `report-output-manager` owns report phases and invokes `report-writer` only when content generation/persistence is allowed.
-- `review-enforcer` is the Codex wrapper that invokes `review-worker`.
+- `report-output-manager` owns normal report phases used before the terminal independent-review lifecycle. Independent-final reservation and attestation are invoked only by `review-enforcer`.
+- `review-enforcer` is the Codex wrapper that invokes `review-worker` and owns the independent-final terminal lifecycle from report reservation through final exact-head CI.
 
 If a required Skill is unavailable, stop with a missing dependency. Do not reproduce its rules locally and do not fall back to `shared/` files.
 
@@ -28,7 +28,8 @@ The target repository owns its development method and testing order. This orches
 
 Run this Skill as: `parent`.
 
-- This Skill owns task selection, lifecycle routing, and final workflow decisions.
+- This Skill owns task selection, lifecycle routing, pre-freeze readiness, and final workflow decisions.
+- `review-enforcer` exclusively owns independent-final report reservation, reviewed-HEAD freeze, independent reviewer lifecycle, report attestation, final publication, and exact-head merge-gate CI.
 - End-of-Issue Skill-gap reflection is parent work, not sub-agent work.
 - This Skill owns the start-of-workflow check that repository-local Skills are current enough to trust.
 - Restart and handover flows re-enter through this Skill.
@@ -70,13 +71,30 @@ When no explicit dispatch override exists, do not ask the user to choose an impl
 17. When chosen Skill action should execute in current scope, call `skill-authoring-wrapper`. Otherwise record follow-up before final-review freeze.
 18. Call `feedback-points-manager` for reusable process feedback, Skillization state, or follow-up Issue. Persist any repository-backed normal handoff, feedback ledger, report, or tracking change now.
 19. If steps 16 through 18 changed repository files, run route-appropriate validation, update reports/tracking, commit, and return to normal review/fix-verification cycle. Repeat until normal cycle converges with all end-of-Issue/feedback changes included.
-20. Ensure every non-final repository change is committed. After normal convergence, run repository-defined full local equivalence gate exactly once for final publication candidate HEAD; record exact-HEAD identity, retain invalidated prior runs, and rerun only if content delta changes candidate. Reserve independent-final-review report path through `report-output-manager` reservation-only phase; do not invoke `report-writer` or create report file. Freeze current HEAD as reviewed implementation HEAD.
-21. Call `review-enforcer` with one fresh independent reviewer against frozen HEAD for single exhaustive pass. If profile/role planning proposes Sol `xhigh`/`max`, do not dispatch until user explicitly approves. If role-profile safety is unresolved, stop with capability gap.
-22. If review discovers required repository change, invalidate terminal state and return to implementation, validation, reporting, tracking, feedback, or Skill-action processing as applicable, followed by normal fix verification and same independent reviewer's bounded finding/CI-delta closure against updated reviewed HEAD.
-23. When independent final review passes, call `report-output-manager` attestation-persistence phase; only then invoke `report-writer` to persist detailed report as at most one report-attestation commit. First parent must be reviewed implementation HEAD and changed paths limited to pre-reserved independent-final-review report paths.
-24. Validate report-attestation diff, make final authorized push, then invoke `git-pr-submitter` or authorized equivalent to create/update PR for exact HEAD. Wait once after publication for exact-head required `pull_request` CI as merge gate. On `remote_ci_only`, matching current-HEAD CI may also be formal route evidence. Do not wait for unrequired `push` run. Update PR body/comment/review request/external Issue only after attestation commit because these do not change Git HEAD.
-25. Do not commit task, design, Skill, workflow, configuration, feedback, handoff, report, or implementation changes after attestation head. Return final handoff inline/outside reviewed PR branch.
-26. Return to task confirmation. Starting another task begins a new lifecycle and must not append commits to completed attestation pair.
+20. Ensure every non-final repository change is committed. After normal convergence, run the repository-defined full local equivalence gate exactly once for the final publication candidate HEAD; record exact-HEAD identity, retain invalidated prior runs, and rerun only if a content delta changes the candidate. **Do not reserve an independent-final report path and do not freeze the reviewed implementation HEAD here.** Mark the lifecycle as `pre_freeze_ready` and pass the completed pre-freeze evidence to `review-enforcer`.
+21. Continue the same `review-enforcer` lifecycle for independent final review. `review-enforcer` alone performs the exactly-once reservation-only phase, records `reservation_owner: review-enforcer` and the stable reservation identity, freezes `reviewed_implementation_head`, selects/dispatches the fresh independent reviewer, retains structured evidence, handles same-reviewer bounded closure, persists at most one report-attestation commit, validates the attestation diff, performs the final authorized push/PR publication, and waits once for exact-head required `pull_request` CI. If profile/role planning proposes Sol `xhigh`/`max`, surface the proposal and stop before dispatch until the user explicitly approves. If role-profile safety is unresolved, stop with capability gap.
+22. If `review-enforcer` returns a required repository-change disposition, invalidate terminal readiness and execute only the requested implementation, validation, reporting, tracking, feedback, or Skill-action work. Commit the changes, complete normal fix verification, then return to the **same** `review-enforcer` independent lifecycle so it can reuse its reviewer/reservation evidence as defined by that Skill. Do not create a second reservation or a new terminal owner.
+23. When `review-enforcer` returns a passing terminal result, consume its completion evidence: `reviewed_implementation_head`, reservation identity/path evidence, independent reviewer verdict/coverage, `report_attestation_head` or explicit absence, attestation allowlist validation, final push state, PR publication state, and exact-head CI state. **Do not call `report-output-manager` attestation-persistence phase, create another attestation commit, invoke `git-pr-submitter` again, push again, or wait for CI again.**
+24. After terminal completion, allow only Git-HEAD-neutral caller work that is not already represented by the returned evidence, such as a concise PR comment, review request, external Issue update, or inline/branch-external handoff transport. Do not duplicate final publication or CI waiting already owned by `review-enforcer`.
+25. Do not commit task, design, Skill, workflow, configuration, feedback, handoff, report, or implementation changes after the attestation head. Return final handoff inline/outside reviewed PR branch.
+26. Return to task confirmation. Starting another task begins a new lifecycle and must not append commits to the completed attestation pair.
+
+## Independent-final terminal ownership
+
+The independent-final terminal lifecycle has exactly one owner: `review-enforcer`.
+
+`development-orchestrator` owns only readiness before that boundary and consumption after it. It must not directly invoke any of these terminal operations:
+
+- independent-final `report-output-manager` reservation-only phase,
+- reviewed implementation HEAD freeze,
+- independent reviewer identity/lifecycle management,
+- report-attestation persistence,
+- report-attestation commit creation or allowlist validation,
+- final push,
+- final PR creation/update,
+- exact-head required `pull_request` CI wait.
+
+A returned `review-enforcer` terminal result is authoritative lifecycle evidence. Repeating any terminal operation after that result risks a second reservation, a second attestation commit, duplicate publication, or duplicate CI gating and is prohibited.
 
 ## Dispatch-profile policy
 
@@ -96,18 +114,20 @@ A dispatch classification must be recomputed when investigation/implementation c
 
 ## Report-attestation terminal rule
 
+`review-enforcer` owns application of this terminal rule. `development-orchestrator` consumes and checks the returned evidence but does not re-execute the rule.
+
 An independent-final-review verdict remains attached to its reviewed implementation HEAD. A later Git HEAD may be accepted only as a report-attestation head when all conditions below hold:
 
 - exactly one commit follows reviewed implementation HEAD,
 - its first parent is reviewed implementation HEAD,
-- only independent-final-review report path(s) reserved before review are changed,
+- only independent-final-review report path(s) reserved by the `review-enforcer` pre-freeze reservation identity are changed,
 - report identifies reviewed implementation HEAD and states commit is administrative attestation rather than reviewed implementation,
 - automated/explicit diff check confirms no executable, Skill, design, workflow, configuration, task-tracking, feedback, handoff, or product file changed,
 - no later repository commit exists.
 
-Completion identity is `reviewed implementation HEAD + validated report-attestation HEAD`. Any other post-review commit invalidates completion and requires normal fix verification followed by same independent reviewer's bounded finding/CI-delta closure.
+Completion identity is `reviewed implementation HEAD + validated report-attestation HEAD`. Any other post-review commit invalidates completion and requires normal fix verification followed by same independent reviewer's bounded finding/CI-delta closure under `review-enforcer`.
 
-After freeze, only operations that do not change Git HEAD are permitted: PR body/comment updates, review requests, external Issue operations, and branch-external/inline transport. Discovery of required repository write invalidates terminal state and returns workflow to normal cycle.
+After terminal completion, only operations that do not change Git HEAD are permitted: PR body/comment updates not already performed, review requests, external Issue operations, and branch-external/inline transport. Discovery of required repository write invalidates terminal state and returns workflow to normal cycle through `review-enforcer`.
 
 ## Core rules
 
@@ -119,8 +139,8 @@ After freeze, only operations that do not change Git HEAD are permitted: PR body
 - Do not enter workflow on stale local Skills when safe latest synchronization was available.
 - Do not trust workflow entry until `AGENTS.md` contains required Skill-first constraints or user has been explicitly notified.
 - Do not skip parent-owned end-of-Issue Skill-gap reflection.
-- Complete Skill action decisions, feedback classification/ledger synchronization, normal handoff persistence, reports, and tracking before freezing independent-final-review target.
-- If any of those actions changes repository, require validation and normal review before freezing again.
+- Complete Skill action decisions, feedback classification/ledger synchronization, normal handoff persistence, reports, and tracking before independent-final terminal lifecycle begins.
+- If any of those actions changes repository, require validation and normal review before entering terminal lifecycle again.
 - Do not leave substantial local Skill changes without explicit caller.
 - Do not choose parent versus sub-agent implementation outside `codex-delegation-executor`.
 - Do not hardcode or routinely confirm implementation sub-agent model when no explicit override exists, except mandatory Sol `xhigh`/`max` gate.
@@ -135,6 +155,8 @@ After freeze, only operations that do not change Git HEAD are permitted: PR body
 - Do not make delegated tasks re-enter this orchestration Skill unless orchestration analysis itself was delegated.
 - Do not use deleted or repository-external `shared/` contracts as fallback.
 - Stop/re-plan when required work is missing from task tracking.
+- Do not reserve the independent-final report path or freeze the reviewed implementation HEAD outside `review-enforcer`.
+- Do not call attestation persistence, create a second report-attestation commit, repeat final push/PR publication, or wait for final exact-head CI after `review-enforcer` has completed those operations.
 - After report attestation, do not call any Skill that can write to reviewed repository branch.
 
 ## Outputs
@@ -150,8 +172,8 @@ After this Skill runs, workflow has:
 - requested profile, role/default-role plan, planned runtime profile, runtime observability, and exact applied profile when observable or explicit unverified/capability state for every dispatched sub-agent task,
 - resolved `verification_capability` and separate commit/push/CI-wait evidence,
 - implementation/validation evidence or explicit blocking condition,
-- review/report/tracking/Skill-action/feedback/commit/PR state,
-- reviewed implementation HEAD and, when repository persistence is required, validated report-attestation head.
+- review/report/tracking/Skill-action/feedback state,
+- `review-enforcer` terminal evidence including the single reservation identity, reviewed implementation HEAD, report-attestation head or explicit absence, attestation validation, final publication state, and exact-head CI state.
 
 ## Completion condition
 
@@ -163,11 +185,12 @@ A task cycle is complete only when:
 - normal review and independent final review are complete,
 - delegated work records requested/role-plan evidence and either exact applied profile or an explicit unverified/inherited/fallback/capability state,
 - any initial/role-adjusted Sol `xhigh`/`max` dispatch has explicit current-task approval evidence,
-- required non-final reports/tracking/Skill decisions/feedback/normal handoffs were committed before independent final review,
+- required non-final reports/tracking/Skill decisions/feedback/normal handoffs were committed before independent-final terminal lifecycle,
 - any repository change discovered during pre-freeze finalization returned through validation/normal review,
-- any post-review repository write is exactly one validated report-attestation commit,
+- `review-enforcer` created exactly one independent-final reservation identity and, when persistence was required, at most one validated report-attestation commit,
+- this Skill did not repeat reservation, attestation persistence, final push, PR publication, or exact-head CI waiting after consuming `review-enforcer` completion,
 - no repository-writing Skill ran after attestation head,
-- commit/PR actions are complete,
+- terminal PR/CI evidence is complete or explicitly blocked,
 - no merge was performed.
 
 ## What this Skill must not do

--- a/skills/report-output-manager/SKILL.md
+++ b/skills/report-output-manager/SKILL.md
@@ -21,11 +21,11 @@ Do not replace these Skills with `shared/` files or duplicate their semantics lo
 ## Codex responsibilities
 
 - Parent owns report mode, source selection, path reservation, template choice, persistence, and post-persistence validation.
-- Reserve a path under the target repository's report rules before delegated section writing.
+- Reserve a path under the target repository's report rules before delegated section writing when normal persistence applies.
+- For independent-final-review attestation, reserve the exact path as metadata only before freeze; do not create or pre-populate the repository file before a passing verdict.
 - Pass authoritative context and complete evidence to `report-writer`.
 - Persist the complete result without changing verdict, severity, validation status, uncertainty, reviewed implementation identity, or reserved-path metadata.
-- Preserve `verification_capability` and distinct validation, commit, push, and
-  CI-wait state supplied by the caller.
+- Preserve `verification_capability` and distinct validation, commit, push, and CI-wait state supplied by the caller.
 - Leave PR commenting and handoff transport to the caller unless explicitly delegated.
 
 ## Normal persistence mode
@@ -33,6 +33,7 @@ Do not replace these Skills with `shared/` files or duplicate their semantics lo
 For implementation, verification, normal review, fix verification, and consolidated reports:
 
 - use target-repository report rules,
+- reserve and create the report path as required by the caller's normal workflow,
 - persist and commit the report before the independent-final-review implementation HEAD is frozen,
 - synchronize task and phase tracking before that freeze,
 - preserve legacy names unless renaming is explicitly requested.
@@ -41,27 +42,33 @@ For implementation, verification, normal review, fix verification, and consolida
 
 Use this mode only after the one exhaustive independent reviewer has passed a frozen implementation HEAD, or that same reviewer has completed bounded finding/CI-delta closure for its updated reviewed HEAD.
 
-Before review:
+### Before review: reservation only
 
-- reserve the exact independent-final-review report path or paths,
-- commit all other implementation, design, workflow, configuration, tracking, handoff, and report changes,
+Before the independent review starts:
+
+- reserve the exact independent-final-review report path or paths as parent-owned metadata,
+- do not create, pre-populate, stage, or edit those repository files,
+- commit all other implementation, design, workflow, configuration, tracking, handoff, and normal-report changes,
 - for `local_execution_available`, freeze the validated local committed HEAD without pre-review push; for `remote_ci_only`, record authorized pre-review push and matching current-HEAD CI,
 - freeze that HEAD as `reviewed_implementation_head`.
 
-After a passing verdict:
+The reserved path is not a delegated child report during review. The independent reviewer returns structured findings, coverage, commands/evidence, verdict, risks, unexplored areas, and dispatch-profile evidence to the parent. The parent retains that evidence outside frozen repository content.
 
-1. Invoke `report-writer` with persistence mode `report_attestation_commit` and the pre-reserved path or paths.
-2. Persist the generated report without modifying any other path.
+If the independent review fails and requires repository changes, do not persist the reserved report path. Return through implementation and normal fix verification, keep the independent evidence as lifecycle state, then reuse the same independent reviewer for bounded closure as required. The reserved path remains unwritten until that independent lifecycle reaches a passing verdict.
+
+### After a passing verdict: one attestation persistence
+
+After the independent lifecycle passes:
+
+1. Invoke `report-writer` with persistence mode `report_attestation_commit`, the retained independent-review evidence, and the pre-reserved path or paths.
+2. Persist the generated report for the first time without modifying any other path.
 3. Create at most one commit whose first parent is `reviewed_implementation_head`.
 4. Validate that the commit diff contains only the reserved independent-final-review report path or paths.
 5. Validate that the report names `reviewed_implementation_head`, describes itself as administrative attestation, and does not claim its own commit SHA was reviewed implementation.
 6. Record the resulting `report_attestation_head` externally in the PR body, PR comment, or handoff returned outside the branch.
 7. Do not create another repository commit.
 
-Generated reports and tracking must not require their own future commit SHA.
-Before persistence, use `commit_pending` with `technical_head` and, for an
-attestation, `administrative_parent`; record the resulting SHA only externally
-after the commit is created and validated.
+Generated reports and tracking must not require their own future commit SHA. Before persistence, use `commit_pending` with `technical_head` and, for an attestation, `administrative_parent`; record the resulting SHA only externally after the commit is created and validated.
 
 The completion identity is:
 
@@ -70,7 +77,7 @@ reviewed_implementation_head: full_sha
 report_attestation_head: full_sha
 ```
 
-Any extra changed path, parent mismatch, second attestation commit, or later repository commit invalidates the terminal state and requires normal fix verification plus same-reviewer bounded closure before a new attestation decision.
+Any pre-verdict write to the reserved report path, extra changed path, parent mismatch, second attestation commit, or later repository commit invalidates the terminal state and requires normal fix verification plus same-reviewer bounded closure before a new attestation decision.
 
 ## Default path rules
 
@@ -78,7 +85,7 @@ Any extra changed path, parent mismatch, second attestation commit, or later rep
 - Use existing repository filename, language, and template rules.
 - Preserve legacy names unless renaming is explicitly requested.
 - Existing helper references in this Skill directory remain available for deterministic path construction.
-- Reserve independent-final-review report paths before freezing the reviewed implementation HEAD.
+- Reserve independent-final-review report paths before freezing the reviewed implementation HEAD, but treat reservation as metadata only until a passing verdict.
 
 ## Boundaries
 
@@ -87,6 +94,7 @@ Any extra changed path, parent mismatch, second attestation commit, or later rep
 - Do not let a concise PR comment replace the detailed report.
 - Do not modify implementation merely to improve a report.
 - Do not redefine report rules locally when `report-writer` is unavailable.
+- In independent-final-review mode, do not create or modify the reserved report file before a passing verdict.
 - In report-attestation mode, do not modify tasks, phases, design, Skills, workflows, configuration, implementation, handoffs, or non-reserved report paths.
 - Do not create more than one report-attestation commit.
 - Do not merge.
@@ -99,7 +107,9 @@ Return:
 - authoritative source identities,
 - reviewed implementation HEAD,
 - reserved report path or paths,
-- complete report body,
+- reservation state: `metadata_only` or `persisted`,
+- retained independent-review evidence identity when attestation is deferred,
+- complete report body when persistence is allowed,
 - persistence mode,
 - created or updated outcome,
 - report-attestation head or explicit absence,
@@ -109,4 +119,6 @@ Return:
 
 ## Completion condition
 
-Complete when the required Skills have produced an evidence-faithful report and either normal persistence completed before the final-review freeze or one independent-final-review report-attestation commit satisfies every allowlist condition. A concrete target path or explicit persistence limitation is available, authoritative sources and uncertainty are preserved, no later repository commit exists in attestation mode, and no merge was performed.
+Normal persistence completes when the required Skills have produced an evidence-faithful report and it is persisted before the final-review freeze.
+
+Independent-final-review reservation completes before review when the exact path is reserved as metadata, no repository file exists or changes at that path, and the reviewed implementation HEAD can be frozen repository-stable. Independent-final-review persistence completes only after a passing verdict when one report-attestation commit satisfies every allowlist condition. A concrete target path or explicit persistence limitation is available, authoritative sources and uncertainty are preserved, no later repository commit exists in attestation mode, and no merge was performed.

--- a/skills/report-output-manager/SKILL.md
+++ b/skills/report-output-manager/SKILL.md
@@ -9,21 +9,45 @@ description: Coordinate runtime-neutral report generation with Codex-specific pa
 
 Act as the Codex runtime wrapper for report output without redefining report semantics, and persist independent-final-review evidence without creating an infinite review/commit cycle.
 
-## Required Skills
+## Phase-specific required Skills
+
+Required Skills depend on the report phase. Do not invoke `report-writer` during a reservation-only phase that has no complete review evidence yet.
+
+### Normal persistence phase
 
 Invoke:
 
 1. `work-context-manager`
 2. `report-writer`
 
+Use for implementation, verification, normal review, fix verification, and consolidated reports.
+
+### Independent-final-review reservation phase
+
+Invoke:
+
+1. `work-context-manager`
+
+Do **not** invoke `report-writer` in this phase. The independent review has not happened yet, so complete coverage, findings, verdict, and final evidence do not exist. This phase owns only deterministic path reservation metadata and freeze-readiness checks.
+
+### Independent-final-review attestation persistence phase
+
+Invoke:
+
+1. `work-context-manager`
+2. `report-writer`
+
+Enter this phase only after the independent-review lifecycle has a passing verdict and complete retained evidence.
+
 Do not replace these Skills with `shared/` files or duplicate their semantics locally.
 
 ## Codex responsibilities
 
-- Parent owns report mode, source selection, path reservation, template choice, persistence, and post-persistence validation.
+- Parent owns report phase, source selection, path reservation, template choice, persistence, and post-persistence validation.
 - Reserve a path under the target repository's report rules before delegated section writing when normal persistence applies.
 - For independent-final-review attestation, reserve the exact path as metadata only before freeze; do not create or pre-populate the repository file before a passing verdict.
-- Pass authoritative context and complete evidence to `report-writer`.
+- During reservation-only work, do not ask `report-writer` to generate content from incomplete/nonexistent review evidence.
+- During content-generation phases, pass authoritative context and complete evidence to `report-writer`.
 - Persist the complete result without changing verdict, severity, validation status, uncertainty, reviewed implementation identity, or reserved-path metadata.
 - Preserve `verification_capability` and distinct validation, commit, push, and CI-wait state supplied by the caller.
 - Leave PR commenting and handoff transport to the caller unless explicitly delegated.
@@ -33,6 +57,7 @@ Do not replace these Skills with `shared/` files or duplicate their semantics lo
 For implementation, verification, normal review, fix verification, and consolidated reports:
 
 - use target-repository report rules,
+- invoke the normal-persistence required Skills,
 - reserve and create the report path as required by the caller's normal workflow,
 - persist and commit the report before the independent-final-review implementation HEAD is frozen,
 - synchronize task and phase tracking before that freeze,
@@ -40,14 +65,18 @@ For implementation, verification, normal review, fix verification, and consolida
 
 ## Independent-final-review report-attestation mode
 
-Use this mode only after the one exhaustive independent reviewer has passed a frozen implementation HEAD, or that same reviewer has completed bounded finding/CI-delta closure for its updated reviewed HEAD.
+This mode has two separate phases: reservation before review and persistence after a passing verdict. Never collapse them.
 
 ### Before review: reservation only
+
+Run only the reservation-phase required Skills.
 
 Before the independent review starts:
 
 - reserve the exact independent-final-review report path or paths as parent-owned metadata,
+- do not invoke `report-writer`,
 - do not create, pre-populate, stage, or edit those repository files,
+- do not synthesize a report body or placeholder verdict,
 - commit all other implementation, design, workflow, configuration, tracking, handoff, and normal-report changes,
 - for `local_execution_available`, freeze the validated local committed HEAD without pre-review push; for `remote_ci_only`, record authorized pre-review push and matching current-HEAD CI,
 - freeze that HEAD as `reviewed_implementation_head`.
@@ -58,15 +87,16 @@ If the independent review fails and requires repository changes, do not persist 
 
 ### After a passing verdict: one attestation persistence
 
-After the independent lifecycle passes:
+Only now enter the attestation-persistence phase and invoke `report-writer`.
 
-1. Invoke `report-writer` with persistence mode `report_attestation_commit`, the retained independent-review evidence, and the pre-reserved path or paths.
-2. Persist the generated report for the first time without modifying any other path.
-3. Create at most one commit whose first parent is `reviewed_implementation_head`.
-4. Validate that the commit diff contains only the reserved independent-final-review report path or paths.
-5. Validate that the report names `reviewed_implementation_head`, describes itself as administrative attestation, and does not claim its own commit SHA was reviewed implementation.
-6. Record the resulting `report_attestation_head` externally in the PR body, PR comment, or handoff returned outside the branch.
-7. Do not create another repository commit.
+1. Re-resolve authoritative context with `work-context-manager` for the reviewed implementation identity and retained evidence.
+2. Invoke `report-writer` with persistence mode `report_attestation_commit`, the complete retained independent-review evidence, and the pre-reserved path or paths.
+3. Persist the generated report for the first time without modifying any other path.
+4. Create at most one commit whose first parent is `reviewed_implementation_head`.
+5. Validate that the commit diff contains only the reserved independent-final-review report path or paths.
+6. Validate that the report names `reviewed_implementation_head`, describes itself as administrative attestation, and does not claim its own commit SHA was reviewed implementation.
+7. Record the resulting `report_attestation_head` externally in the PR body, PR comment, or handoff returned outside the branch.
+8. Do not create another repository commit.
 
 Generated reports and tracking must not require their own future commit SHA. Before persistence, use `commit_pending` with `technical_head` and, for an attestation, `administrative_parent`; record the resulting SHA only externally after the commit is created and validated.
 
@@ -77,7 +107,7 @@ reviewed_implementation_head: full_sha
 report_attestation_head: full_sha
 ```
 
-Any pre-verdict write to the reserved report path, extra changed path, parent mismatch, second attestation commit, or later repository commit invalidates the terminal state and requires normal fix verification plus same-reviewer bounded closure before a new attestation decision.
+Any pre-verdict write to the reserved report path, premature `report-writer` invocation that invents unavailable verdict evidence, extra changed path, parent mismatch, second attestation commit, or later repository commit invalidates the terminal state and requires normal fix verification plus same-reviewer bounded closure before a new attestation decision.
 
 ## Default path rules
 
@@ -90,28 +120,54 @@ Any pre-verdict write to the reserved report path, extra changed path, parent mi
 ## Boundaries
 
 - Do not invent evidence.
+- Do not invoke `report-writer` during independent-final-review reservation.
 - Do not convert missing current-HEAD CI into success.
 - Do not let a concise PR comment replace the detailed report.
 - Do not modify implementation merely to improve a report.
-- Do not redefine report rules locally when `report-writer` is unavailable.
-- In independent-final-review mode, do not create or modify the reserved report file before a passing verdict.
-- In report-attestation mode, do not modify tasks, phases, design, Skills, workflows, configuration, implementation, handoffs, or non-reserved report paths.
+- Do not redefine report rules locally when `report-writer` is unavailable in a phase that requires it.
+- In independent-final-review reservation, do not create or modify the reserved report file before a passing verdict.
+- In report-attestation persistence, do not modify tasks, phases, design, Skills, workflows, configuration, implementation, handoffs, or non-reserved report paths.
 - Do not create more than one report-attestation commit.
 - Do not merge.
 
 ## Outputs
 
+### Normal persistence
+
 Return:
 
-- report mode,
+- report mode and phase,
+- authoritative source identities,
+- complete report body,
+- reserved/persisted report path,
+- created or updated outcome,
+- preserved unknowns and remaining risks.
+
+### Independent-final-review reservation
+
+Return:
+
+- report mode: `independent_final_review`,
+- phase: `reservation_only`,
+- authoritative context identity,
+- reviewed implementation candidate HEAD,
+- reserved report path or paths,
+- reservation state: `metadata_only`,
+- report body: absent,
+- `report_writer_invoked: false`,
+- persistence outcome: not started.
+
+### Independent-final-review attestation persistence
+
+Return:
+
+- report mode: `independent_final_review`,
+- phase: `attestation_persistence`,
 - authoritative source identities,
 - reviewed implementation HEAD,
-- reserved report path or paths,
-- reservation state: `metadata_only` or `persisted`,
-- retained independent-review evidence identity when attestation is deferred,
-- complete report body when persistence is allowed,
-- persistence mode,
-- created or updated outcome,
+- retained independent-review evidence identity,
+- complete report body,
+- reserved/persisted report path or paths,
 - report-attestation head or explicit absence,
 - attestation diff validation,
 - preserved unknowns and remaining risks,
@@ -119,6 +175,8 @@ Return:
 
 ## Completion condition
 
-Normal persistence completes when the required Skills have produced an evidence-faithful report and it is persisted before the final-review freeze.
+Normal persistence completes when the normal-phase required Skills have produced an evidence-faithful report and it is persisted before the final-review freeze.
 
-Independent-final-review reservation completes before review when the exact path is reserved as metadata, no repository file exists or changes at that path, and the reviewed implementation HEAD can be frozen repository-stable. Independent-final-review persistence completes only after a passing verdict when one report-attestation commit satisfies every allowlist condition. A concrete target path or explicit persistence limitation is available, authoritative sources and uncertainty are preserved, no later repository commit exists in attestation mode, and no merge was performed.
+Independent-final-review reservation completes before review when `work-context-manager` has established authoritative context, the exact path is reserved as metadata, `report-writer` was not invoked, no repository file exists or changes at that path, and the reviewed implementation HEAD can be frozen repository-stable.
+
+Independent-final-review attestation persistence completes only after a passing verdict when the persistence-phase required Skills have produced one evidence-faithful report-attestation commit satisfying every allowlist condition. A concrete target path or explicit persistence limitation is available, authoritative sources and uncertainty are preserved, no later repository commit exists in attestation mode, and no merge was performed.

--- a/skills/report-output-manager/references/sub-agent-report-template.md
+++ b/skills/report-output-manager/references/sub-agent-report-template.md
@@ -23,11 +23,17 @@
 
 - selection inputs (parent, pre-dispatch):
 - selection source (parent, pre-dispatch):
+- observed decomposability (parent, pre-dispatch):
+- decomposition policy / disposition (parent, pre-dispatch):
 - proposed profile (parent, pre-dispatch if applicable):
 - approval status / evidence (parent):
 - requested profile (parent, pre-dispatch):
-- applied profile (parent, post-runtime evidence only):
+- agent role / default-role plan (parent, pre-dispatch):
+- role config evidence / profile effect (parent, pre-dispatch):
+- planned runtime profile after known role constraints (parent, pre-dispatch):
+- applied profile (parent, post-runtime exact evidence only; null when unverified):
 - application status (parent, post-runtime evidence only):
+- runtime profile observability (parent, post-runtime):
 - reviewer continuity (parent, if applicable):
 - fork policy (parent):
 - reasons / constraints (parent):

--- a/skills/report-output-manager/references/sub-agent-report-template.md
+++ b/skills/report-output-manager/references/sub-agent-report-template.md
@@ -19,16 +19,18 @@
 
 ## Dispatch profile
 
-- selection inputs:
-- selection source:
-- proposed profile:
-- approval status / evidence:
-- requested profile:
-- applied profile:
-- application status:
-- reviewer continuity:
-- fork policy:
-- reasons / constraints:
+<!-- This section is parent-owned. The child must not infer or rewrite hidden runtime state. -->
+
+- selection inputs (parent, pre-dispatch):
+- selection source (parent, pre-dispatch):
+- proposed profile (parent, pre-dispatch if applicable):
+- approval status / evidence (parent):
+- requested profile (parent, pre-dispatch):
+- applied profile (parent, post-runtime evidence only):
+- application status (parent, post-runtime evidence only):
+- reviewer continuity (parent, if applicable):
+- fork policy (parent):
+- reasons / constraints (parent):
 
 ## 実行コマンド
 

--- a/skills/report-output-manager/references/sub-agent-report-template.md
+++ b/skills/report-output-manager/references/sub-agent-report-template.md
@@ -17,6 +17,19 @@
 
 - 対象外:
 
+## Dispatch profile
+
+- selection inputs:
+- selection source:
+- proposed profile:
+- approval status / evidence:
+- requested profile:
+- applied profile:
+- application status:
+- reviewer continuity:
+- fork policy:
+- reasons / constraints:
+
 ## 実行コマンド
 
 - 実行コマンド:

--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -27,7 +27,7 @@ Do not replace these Skills with `shared/` files or duplicate their semantics lo
 
 Every newly created reviewer sub-agent must be dispatched through `sub-agent-task-manager` as one identity-bearing reviewer execution.
 
-- `review-enforcer` owns reviewer identity, continuity, independence, review mode, one-reviewer execution policy, report persistence mode, and lifecycle state.
+- `review-enforcer` owns reviewer identity, continuity, independence, review mode, one-reviewer execution policy, independent-final report reservation identity, report persistence mode, and lifecycle state.
 - `sub-agent-task-manager` owns per-task model, reasoning effort, fork policy, role/default-role planning, expensive-profile approval gating, runtime-profile evidence, and dispatch.
 - Every new reviewer task created by this Skill must set `decomposition_policy: forbidden` and `parallelism_mode: single_agent`.
 - `decomposability` remains a truthful observed signal. Do not force it to `single` merely because execution decomposition is forbidden.
@@ -57,15 +57,19 @@ Use `report_persistence_mode: normal_persistence`.
 
 Use `report_persistence_mode: deferred_attestation`.
 
-- call `report-output-manager` in reservation-only phase before freeze
+`review-enforcer` is the single reservation owner for this mode.
+
+- call `report-output-manager` in reservation-only phase before freeze exactly once for the independent lifecycle
 - reserve the exact independent-final-review report path as metadata only
+- record `reservation_owner: review-enforcer`, a stable `reservation_identity`, the reserved path, reservation timing/evidence, and `reservation_state: metadata_only`
 - do not invoke `report-writer` during reservation
 - do not create, pre-populate, or edit the repository report path before/during independent review
+- pass the existing `pre_reserved_report_path` and reservation evidence to `sub-agent-task-manager`; it must validate/reuse that reservation and must not reserve another path
 - the independent reviewer returns structured review evidence to the parent instead of editing a report file
 - the parent retains reviewer output and dispatch-profile evidence outside frozen repository content
-- only after a passing verdict may `report-writer` and `report-output-manager` materialize that evidence into the reserved path as the single report-attestation commit
+- only after a passing verdict may `report-writer` and `report-output-manager` materialize that evidence into the same reserved path as the single report-attestation commit
 
-If the independent review finds required changes, keep its evidence as parent-owned lifecycle state, invalidate terminal state, return through implementation and normal fix verification, and later reuse the same independent reviewer for bounded closure without creating the reserved report file. Persist only after that independent lifecycle reaches a passing verdict.
+If the independent review finds required changes, keep its evidence and the same reservation identity as parent-owned lifecycle state, invalidate terminal state, return through implementation and normal fix verification, and later reuse the same independent reviewer for bounded closure without creating the reserved report file or creating a second reservation. Persist only after that independent lifecycle reaches a passing verdict.
 
 ## Codex reviewer lifecycle
 
@@ -81,11 +85,12 @@ After the normal cycle converges:
 
 - finish every implementation, design, workflow, configuration, tracking, feedback-ledger, normal handoff, and non-final report change,
 - finish the parent-owned end-of-Issue Skill-gap decision and execute any in-scope Skill update,
-- reserve the independent-final-review report path or paths without creating those files,
+- call `report-output-manager` reservation-only phase and reserve the independent-final-review report path or paths without creating those files,
+- record the reservation owner/identity/path as lifecycle evidence,
 - commit all other changes,
 - for `local_execution_available`, freeze the validated local committed HEAD without pre-review push; for `remote_ci_only`, complete authorized pre-review push and matching current-HEAD CI,
 - freeze that HEAD as `reviewed_implementation_head`,
-- ask `sub-agent-task-manager` to prepare one different fresh reviewer sub-agent with decomposition forbidden and deferred attestation.
+- ask `sub-agent-task-manager` to prepare one different fresh reviewer sub-agent with decomposition forbidden, deferred attestation, and the exact pre-reserved report identity.
 
 The independent reviewer must differ from the implementation agent and normal reviewer, must not have implemented fixes, must remain one reviewer for the entire independent lifecycle, and should use `fork_turns: "none"` unless a bounded exception is justified.
 
@@ -104,13 +109,13 @@ If independent-final-review profile or role planning proposes Sol `xhigh` or Sol
 9. After each fix, require route-appropriate validation, report/tracking synchronization, and a review-target commit before another normal-review round. On `local_execution_available`, do not wait for CI in this loop; on `remote_ci_only`, record matching current-HEAD CI after authorized push when required for formal verification.
 10. After convergence, verify that the parent completed end-of-Issue Skill-gap decision, any in-scope `skill-authoring-wrapper` work, feedback classification/ledger synchronization, normal handoff persistence, reports, and tracking.
 11. If step 10 creates/discovers repository change, require route-appropriate validation, commit, and another normal review/fix-verification round. Do not freeze yet.
-12. Only after normal convergence with all pre-freeze work included, ensure every non-final repository change is committed. On local route, require the repository-defined full local gate before final push. Call `report-output-manager` reservation-only phase to reserve independent-final-review report path as metadata, then freeze implementation HEAD.
+12. Only after normal convergence with all pre-freeze work included, ensure every non-final repository change is committed. On local route, require the repository-defined full local gate before final push. Call `report-output-manager` reservation-only phase exactly once; record `reservation_owner: review-enforcer`, stable `reservation_identity`, `pre_reserved_report_path`, reservation evidence, and `reservation_state: metadata_only`; then freeze implementation HEAD.
 13. Classify the independent-review task truthfully, including observed `decomposability`; set `decomposition_policy: forbidden`, `parallelism_mode: single_agent`, and relevant disposition.
-14. Ask `sub-agent-task-manager` to select/plan one fresh independent final reviewer using `report_persistence_mode: deferred_attestation`. If expensive-profile approval or role-profile safety is unresolved, stop before spawn. After approval/safe planning, dispatch that one reviewer without creating the reserved report file.
-15. Retain structured findings, coverage, commands/evidence, verdict, risks, unexplored areas, truthful decomposability/policy evidence, and runtime-profile observability evidence as parent-owned lifecycle evidence.
-16. If the one exhaustive independent review finds required changes, invalidate terminal state, return to implementation and normal fix verification, then reuse the same independent reviewer only for finding/CI-delta closure against updated reviewed HEAD. Preserve original runtime-profile/observability evidence; do not spawn another fresh exhaustive reviewer, execute multi-agent review, add new review criteria, or create reserved report file.
-17. When the independent lifecycle reaches a passing verdict, call `report-output-manager` attestation-persistence phase; only then invoke `report-writer` with retained complete evidence and the pre-reserved path.
-18. Persist at most one report-attestation commit whose first parent is reviewed implementation HEAD and changed paths are limited to pre-reserved independent-final-review report paths.
+14. Ask `sub-agent-task-manager` to select/plan one fresh independent final reviewer using `report_persistence_mode: deferred_attestation` **and pass the existing `pre_reserved_report_path`, `reservation_owner`, `reservation_identity`, and reservation evidence from step 12**. The task manager must validate/reuse this reservation and must not call reservation-only phase again. If expensive-profile approval, role-profile safety, or reservation identity is unresolved, stop before spawn. After approval/safe planning, dispatch that one reviewer without creating the reserved report file.
+15. Retain structured findings, coverage, commands/evidence, verdict, risks, unexplored areas, truthful decomposability/policy evidence, reservation identity, and runtime-profile observability evidence as parent-owned lifecycle evidence.
+16. If the one exhaustive independent review finds required changes, invalidate terminal state, return to implementation and normal fix verification, then reuse the same independent reviewer only for finding/CI-delta closure against updated reviewed HEAD. Preserve original runtime-profile/observability and reservation evidence; do not spawn another fresh exhaustive reviewer, execute multi-agent review, add new review criteria, create reserved report file, or create a second reservation.
+17. When the independent lifecycle reaches a passing verdict, call `report-output-manager` attestation-persistence phase with the same reservation identity; only then invoke `report-writer` with retained complete evidence and the pre-reserved path.
+18. Persist at most one report-attestation commit whose first parent is reviewed implementation HEAD and changed paths are limited to the path(s) bound to that reservation identity.
 19. Validate attestation diff, make final authorized push, then invoke `git-pr-submitter` or authorized equivalent for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI. Do not wait for unrequired `push` run.
 20. After attestation commit, permit only operations that do not change Git HEAD: PR body/comment updates, review requests, external Issue operations, and inline/branch-external handoff transport.
 21. Do not call repository-writing Skills after attestation and do not commit later handoff/tracking/design/Skill/workflow/configuration/feedback/report/implementation changes.
@@ -127,12 +132,12 @@ The independent-final-review target must not be frozen until all of the followin
 - any selected in-scope Skill update,
 - feedback classification and any feedback ledger write,
 - repository-backed normal handoff,
-- independent-final-review report-path reservation as metadata only, with no file created yet,
+- exactly one independent-final-review report-path reservation owned by `review-enforcer`, with stable reservation identity, metadata-only state, and no file created yet,
 - current-HEAD validation evidence and verification-route disposition.
 
 For `remote_ci_only`, matching current-HEAD CI may be formal evidence; for local route, do not require CI completion before attestation.
 
-A newly discovered repository write after this gate invalidates it and returns workflow to normal cycle. Creating/editing reserved independent-final-review report before passing verdict also invalidates the gate.
+A newly discovered repository write after this gate invalidates it and returns workflow to normal cycle. Creating/editing reserved independent-final-review report before passing verdict or replacing the reservation identity after freeze also invalidates the gate.
 
 ## Report-attestation gate
 
@@ -140,7 +145,7 @@ A report-attestation head is acceptable only when:
 
 - exactly one commit follows reviewed implementation HEAD,
 - commit first parent is reviewed implementation HEAD,
-- only pre-reserved independent-final-review report paths changed,
+- only report paths bound to the pre-freeze reservation identity changed,
 - those paths did not exist/change during frozen independent review,
 - report names reviewed implementation HEAD and identifies commit as administrative attestation,
 - no executable, Skill, design, workflow, configuration, tracking, feedback, handoff, or product path changed,
@@ -150,13 +155,13 @@ Technical verdict remains attached to reviewed implementation HEAD. Attestation 
 
 ## Codex responsibilities
 
-- Parent owns reviewer identity, continuity, independence, single-reviewer execution policy, truthful decomposability evidence, report-path reservation, retained independent evidence, pre-freeze gating, lifecycle gating, attestation validation, and integration.
-- `sub-agent-task-manager` owns every new reviewer spawn/profile/role plan/runtime observability evidence and must honor no-decomposition/report-persistence constraints.
+- Parent owns reviewer identity, continuity, independence, single-reviewer execution policy, truthful decomposability evidence, independent-final report-path reservation owner/identity, retained independent evidence, pre-freeze gating, lifecycle gating, attestation validation, and integration.
+- `sub-agent-task-manager` owns every new reviewer spawn/profile/role plan/runtime observability evidence and must honor no-decomposition/report-persistence constraints while reusing the caller-supplied deferred reservation.
 - Parent review cannot replace reviewer sub-agent work.
 - Do not cancel a reviewer merely because it is slow.
 - Reviewers do not implement findings.
 - Do not reuse a verdict from an earlier implementation HEAD.
-- Do not create more than one report-attestation commit.
+- Do not create more than one independent-final reservation or report-attestation commit.
 - Do not permit a repository-writing Skill after attestation.
 - Do not merge.
 
@@ -166,6 +171,7 @@ Return:
 
 - normal review and fix-verification evidence,
 - pre-freeze gate evidence,
+- independent-final reservation owner, identity, exact path(s), timing/evidence, and metadata-only state,
 - independent-final-review evidence retained outside frozen repository until attestation,
 - reviewed implementation HEAD,
 - report-attestation head or explicit absence,
@@ -179,7 +185,7 @@ Return:
 
 ## Completion condition
 
-Complete only when required Skills produced normal-review and independent-final-review evidence; every new reviewer went through `sub-agent-task-manager` under single-agent execution policy without falsifying decomposability; any required initial/role-adjusted Sol `xhigh`/`max` approval preceded reviewer spawn; runtime-profile observability uncertainty is preserved; reused reviewers preserved original profile evidence; independent reviewer did not write reserved report path before passing; all non-final repository changes and mandatory end-of-Issue/feedback work preceded frozen reviewed implementation HEAD; no unresolved required finding or verdict-invalidating unexplored area remains; and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit/writing Skill. No merge is performed.
+Complete only when required Skills produced normal-review and independent-final-review evidence; every new reviewer went through `sub-agent-task-manager` under single-agent execution policy without falsifying decomposability; any required initial/role-adjusted Sol `xhigh`/`max` approval preceded reviewer spawn; runtime-profile observability uncertainty is preserved; reused reviewers preserved original profile evidence; exactly one pre-freeze independent-final reservation identity was created by `review-enforcer` and reused by the task manager; the independent reviewer did not write reserved report path before passing; all non-final repository changes and mandatory end-of-Issue/feedback work preceded frozen reviewed implementation HEAD; no unresolved required finding or verdict-invalidating unexplored area remains; and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit/writing Skill. No merge is performed.
 
 ## Cross-cutting rule
 

--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -19,21 +19,26 @@ Invoke:
 4. `report-writer`
 5. `report-output-manager`
 
+Use `report-writer` only in phases where report content is actually generated. Independent-final reservation uses `report-output-manager`'s reservation-only phase and must not invoke `report-writer` before review evidence exists.
+
 Do not replace these Skills with `shared/` files or duplicate their semantics locally.
 
 ## Reviewer dispatch contract
 
-Every newly created reviewer sub-agent must be dispatched through `sub-agent-task-manager` as one identity-bearing reviewer task.
+Every newly created reviewer sub-agent must be dispatched through `sub-agent-task-manager` as one identity-bearing reviewer execution.
 
-- `review-enforcer` owns reviewer identity, continuity, independence, review mode, single-reviewer scope, report persistence mode, and lifecycle state.
-- `sub-agent-task-manager` owns per-task model, reasoning effort, fork policy, expensive-profile approval gating, runtime application, and dispatch-profile evidence.
-- Every reviewer task created by this Skill must set `decomposability: single`, `decomposition_policy: forbidden`, and `parallelism_mode: single_agent`.
-- Reviewer breadth never authorizes multi-agent decomposition. Large reviews remain one reviewer because normal-review continuity and the independent one-exhaustive-pass guarantee are identity-sensitive lifecycle contracts.
-- If `sub-agent-task-manager` produces an unapproved `Sol xhigh` or `Sol max` `proposed_profile`, return that proposal to the parent and stop before spawning the reviewer.
-- Do not bypass the proposal stop by directly spawning a reviewer from this Skill.
+- `review-enforcer` owns reviewer identity, continuity, independence, review mode, one-reviewer execution policy, report persistence mode, and lifecycle state.
+- `sub-agent-task-manager` owns per-task model, reasoning effort, fork policy, role/default-role planning, expensive-profile approval gating, runtime-profile evidence, and dispatch.
+- Every new reviewer task created by this Skill must set `decomposition_policy: forbidden` and `parallelism_mode: single_agent`.
+- `decomposability` remains a truthful observed signal. Do not force it to `single` merely because execution decomposition is forbidden.
+- If the review scope contains independently executable review areas, record `decomposability: independent_workstreams` together with `decomposition_disposition: prohibited_by_review_lifecycle`.
+- Reviewer breadth never authorizes multi-agent execution in the current lifecycle. Large reviews remain one reviewer because normal-review continuity and the independent one-exhaustive-pass guarantee are identity-sensitive execution contracts.
+- If `sub-agent-task-manager` produces an unapproved Sol `xhigh` or Sol `max` `proposed_profile`, return that proposal to the parent and stop before spawning the reviewer.
+- Role/default-role planning is subject to the same approval gate. A role must not raise the effective plan to Sol `xhigh`/`max` without current-task approval.
+- Do not bypass the proposal or role-profile capability stop by directly spawning a reviewer from this Skill.
 - A reviewer that already exists is reused directly for continuity; reuse is not a new profile selection or new spawn.
 
-When an existing reviewer is reused, preserve its originally applied execution profile. Record `application_status: reused_existing_agent_profile`, the original applied profile, the reviewer identity, and the review mode being continued. Do not claim that a new default such as Terra `high` was applied to an already-running Sol reviewer.
+When an existing reviewer is reused, preserve its original runtime-profile evidence and observability state. Record `application_status: reused_existing_agent_profile`, reviewer identity, original exact/unverified profile evidence, and continued review mode. Do not claim a new default was applied to an already-running reviewer.
 
 ## Report persistence by review mode
 
@@ -43,28 +48,30 @@ Use two distinct report modes.
 
 Use `report_persistence_mode: normal_persistence`.
 
-- `sub-agent-task-manager` may pre-create the normal-review report from the standard template.
+- `sub-agent-task-manager` may pre-create the normal-review report from the standard template
 - the reviewer may fill child-owned report sections directly
-- parent-owned dispatch-profile fields are completed from actual spawn/runtime evidence
+- parent-owned dispatch-profile fields are completed from pre-spawn planning and post-runtime observability evidence
 - persist and commit these reports before the independent-final-review target is frozen
 
 ### Independent final review and bounded independent closure
 
 Use `report_persistence_mode: deferred_attestation`.
 
-- reserve the exact independent-final-review report path before freeze through `report-output-manager`
-- reservation is metadata only; do not create, pre-populate, or edit that repository path before or during independent review
+- call `report-output-manager` in reservation-only phase before freeze
+- reserve the exact independent-final-review report path as metadata only
+- do not invoke `report-writer` during reservation
+- do not create, pre-populate, or edit the repository report path before/during independent review
 - the independent reviewer returns structured review evidence to the parent instead of editing a report file
-- the parent retains reviewer output and dispatch-profile evidence outside the frozen repository content
+- the parent retains reviewer output and dispatch-profile evidence outside frozen repository content
 - only after a passing verdict may `report-writer` and `report-output-manager` materialize that evidence into the reserved path as the single report-attestation commit
 
-If the independent review finds required changes, keep its evidence as parent-owned lifecycle state, invalidate the terminal state, return through implementation and normal fix verification, and later reuse the same independent reviewer for bounded closure without creating the reserved report file. Persist only after that independent lifecycle reaches a passing verdict.
+If the independent review finds required changes, keep its evidence as parent-owned lifecycle state, invalidate terminal state, return through implementation and normal fix verification, and later reuse the same independent reviewer for bounded closure without creating the reserved report file. Persist only after that independent lifecycle reaches a passing verdict.
 
 ## Codex reviewer lifecycle
 
 ### Normal review cycle
 
-Use one dedicated reviewer sub-agent for initial review and fix verification while available. Create that reviewer through `sub-agent-task-manager` with decomposition forbidden and normal persistence. Preserve finding identity, reviewed HEAD, selected criteria, held and unexplored items, fix context, reviewer identity, and the originally applied reviewer profile.
+Use one dedicated reviewer sub-agent for initial review and fix verification while available. Create that reviewer through `sub-agent-task-manager` with decomposition forbidden and normal persistence. Preserve truthful decomposability, finding identity, reviewed HEAD, selected criteria, held/unexplored items, fix context, reviewer identity, and original runtime-profile/observability evidence.
 
 Persist normal-review and fix-verification reports, synchronize tracking, and commit all resulting repository changes before selecting the independent-final-review target. Push and CI waiting remain separate, verification-route-owned states.
 
@@ -80,31 +87,33 @@ After the normal cycle converges:
 - freeze that HEAD as `reviewed_implementation_head`,
 - ask `sub-agent-task-manager` to prepare one different fresh reviewer sub-agent with decomposition forbidden and deferred attestation.
 
-The independent reviewer must differ from the implementation agent and normal reviewer, must not have implemented fixes, must remain a single reviewer for the entire independent lifecycle, and should use `fork_turns: "none"` unless a bounded exception is justified.
+The independent reviewer must differ from the implementation agent and normal reviewer, must not have implemented fixes, must remain one reviewer for the entire independent lifecycle, and should use `fork_turns: "none"` unless a bounded exception is justified.
 
-If independent-final-review profile selection proposes `Sol xhigh` or `Sol max`, stop before reviewer creation and return the proposal to the user. Continue only after explicit current-task approval. If the user rejects the proposal, let `sub-agent-task-manager` recompute the profile with the rejected expensive profiles excluded.
+If independent-final-review profile or role planning proposes Sol `xhigh` or Sol `max`, stop before reviewer creation and return the proposal to the user. Continue only after explicit current-task approval. If role/default-role impact cannot be inspected sufficiently to enforce this gate, stop with a capability gap instead of dispatching.
 
 ## Required flow
 
 1. Invoke `work-context-manager` for the current committed HEAD and matching evidence.
 2. Run applicable Markdown and repository gates.
-3. Ask `sub-agent-task-manager` to select the profile for one new normal reviewer with `decomposability: single`, `decomposition_policy: forbidden`, `parallelism_mode: single_agent`, and `report_persistence_mode: normal_persistence`; dispatch that reviewer to invoke `review-worker` in the selected mode. If an expensive Sol proposal is awaiting approval, stop before spawn and return the proposal to the parent.
-4. Invoke `report-writer` and persist normal-review evidence through `report-output-manager`.
-5. Return required findings to the implementation flow.
-6. Reuse the normal reviewer for fix verification when available. Reuse the existing agent and its original applied profile; do not create a new profile or claim that the focused-fix default replaced the running reviewer's profile. Record `application_status: reused_existing_agent_profile`.
-7. Before requesting finding closure, require a finding-by-finding completeness matrix covering every required action, production path, actual composition fixture, and focused evidence. Do not dispatch closure review while any cell is incomplete.
-8. After each fix, require route-appropriate validation, report and tracking synchronization, and a review-target commit before another normal-review round. On `local_execution_available`, do not wait for CI in this loop; on `remote_ci_only`, record matching current-HEAD CI evidence after authorized push when it is required for formal verification.
-9. After convergence, verify that the parent has completed the end-of-Issue Skill-gap decision, any in-scope `skill-authoring-wrapper` work, feedback classification and ledger synchronization, normal handoff persistence, reports, and tracking.
-10. If step 9 creates or discovers any repository change, require route-appropriate validation, commit, and another normal review or fix-verification round. Do not freeze the target yet.
-11. Only after the normal cycle converges again with all pre-freeze work included, ensure every non-final repository change is committed. On the local route, require the repository-defined full local gate before final push. Reserve the independent-final-review report path as metadata only, and freeze the implementation HEAD.
-12. Ask `sub-agent-task-manager` to select the profile for one fresh independent final reviewer with `decomposability: single`, `decomposition_policy: forbidden`, `parallelism_mode: single_agent`, and `report_persistence_mode: deferred_attestation`. If it returns an unapproved `Sol xhigh` or `Sol max` proposal, stop before spawn; after approval, dispatch that single reviewer through `sub-agent-task-manager` without creating the reserved report file.
-13. Retain the independent reviewer's structured findings, coverage, commands/evidence, verdict, risks, unexplored areas, and post-runtime dispatch-profile evidence as parent-owned lifecycle evidence.
-14. If the one exhaustive independent review finds required changes, invalidate the terminal state, return to implementation and normal fix verification, then reuse that same independent reviewer only for finding/CI-delta closure against the updated reviewed HEAD. Preserve the reviewer's original applied profile and record `application_status: reused_existing_agent_profile`; do not spawn another fresh exhaustive reviewer, decompose the review, add new review criteria, or create the reserved report file.
-15. When the independent lifecycle reaches a passing verdict, invoke `report-writer` and `report-output-manager` in report-attestation mode using the retained reviewer evidence and pre-reserved path.
-16. Persist at most one report-attestation commit whose first parent is the reviewed implementation HEAD and whose changed paths are limited to the pre-reserved independent-final-review report path or paths.
-17. Validate the attestation diff, make the final authorized push, then invoke `git-pr-submitter` or the authorized equivalent to create or update the PR for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI. Do not wait for an unrequired `push` run.
-18. After the attestation commit, permit only operations that do not change Git HEAD: PR body or comment updates, review requests, external Issue operations, and inline or branch-external handoff transport.
-19. Do not call any repository-writing Skill after attestation and do not commit any later handoff, tracking, design, Skill, workflow, configuration, feedback, report, or implementation change.
+3. Classify the normal-review task truthfully, including observed `decomposability`; set `decomposition_policy: forbidden`, `parallelism_mode: single_agent`, and when relevant `decomposition_disposition: prohibited_by_review_lifecycle`.
+4. Ask `sub-agent-task-manager` to select/plan/dispatch one new normal reviewer using `report_persistence_mode: normal_persistence`. If expensive-profile approval or role-profile safety is unresolved, stop before spawn.
+5. Invoke `report-writer` and persist normal-review evidence through `report-output-manager`.
+6. Return required findings to the implementation flow.
+7. Reuse the normal reviewer for fix verification when available. Preserve original exact/unverified runtime-profile evidence; record `application_status: reused_existing_agent_profile`.
+8. Before requesting finding closure, require a finding-by-finding completeness matrix covering every required action, production path, actual composition fixture, and focused evidence. Do not dispatch closure review while any cell is incomplete.
+9. After each fix, require route-appropriate validation, report/tracking synchronization, and a review-target commit before another normal-review round. On `local_execution_available`, do not wait for CI in this loop; on `remote_ci_only`, record matching current-HEAD CI after authorized push when required for formal verification.
+10. After convergence, verify that the parent completed end-of-Issue Skill-gap decision, any in-scope `skill-authoring-wrapper` work, feedback classification/ledger synchronization, normal handoff persistence, reports, and tracking.
+11. If step 10 creates/discovers repository change, require route-appropriate validation, commit, and another normal review/fix-verification round. Do not freeze yet.
+12. Only after normal convergence with all pre-freeze work included, ensure every non-final repository change is committed. On local route, require the repository-defined full local gate before final push. Call `report-output-manager` reservation-only phase to reserve independent-final-review report path as metadata, then freeze implementation HEAD.
+13. Classify the independent-review task truthfully, including observed `decomposability`; set `decomposition_policy: forbidden`, `parallelism_mode: single_agent`, and relevant disposition.
+14. Ask `sub-agent-task-manager` to select/plan one fresh independent final reviewer using `report_persistence_mode: deferred_attestation`. If expensive-profile approval or role-profile safety is unresolved, stop before spawn. After approval/safe planning, dispatch that one reviewer without creating the reserved report file.
+15. Retain structured findings, coverage, commands/evidence, verdict, risks, unexplored areas, truthful decomposability/policy evidence, and runtime-profile observability evidence as parent-owned lifecycle evidence.
+16. If the one exhaustive independent review finds required changes, invalidate terminal state, return to implementation and normal fix verification, then reuse the same independent reviewer only for finding/CI-delta closure against updated reviewed HEAD. Preserve original runtime-profile/observability evidence; do not spawn another fresh exhaustive reviewer, execute multi-agent review, add new review criteria, or create reserved report file.
+17. When the independent lifecycle reaches a passing verdict, call `report-output-manager` attestation-persistence phase; only then invoke `report-writer` with retained complete evidence and the pre-reserved path.
+18. Persist at most one report-attestation commit whose first parent is reviewed implementation HEAD and changed paths are limited to pre-reserved independent-final-review report paths.
+19. Validate attestation diff, make final authorized push, then invoke `git-pr-submitter` or authorized equivalent for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI. Do not wait for unrequired `push` run.
+20. After attestation commit, permit only operations that do not change Git HEAD: PR body/comment updates, review requests, external Issue operations, and inline/branch-external handoff transport.
+21. Do not call repository-writing Skills after attestation and do not commit later handoff/tracking/design/Skill/workflow/configuration/feedback/report/implementation changes.
 
 Any other post-review commit invalidates completion and requires normal fix verification followed by same-reviewer bounded finding/CI-delta closure.
 
@@ -118,29 +127,31 @@ The independent-final-review target must not be frozen until all of the followin
 - any selected in-scope Skill update,
 - feedback classification and any feedback ledger write,
 - repository-backed normal handoff,
-- the independent-final-review report path reservation as metadata only, with no file created yet,
-- current-HEAD validation evidence and verification-route disposition. For `remote_ci_only`, matching current-HEAD CI may be formal evidence; for the local route, do not require CI completion before attestation.
+- independent-final-review report-path reservation as metadata only, with no file created yet,
+- current-HEAD validation evidence and verification-route disposition.
 
-A newly discovered repository write after this gate invalidates the gate and returns the workflow to the normal cycle. Creating or editing the reserved independent-final-review report before a passing verdict also invalidates the gate.
+For `remote_ci_only`, matching current-HEAD CI may be formal evidence; for local route, do not require CI completion before attestation.
+
+A newly discovered repository write after this gate invalidates it and returns workflow to normal cycle. Creating/editing reserved independent-final-review report before passing verdict also invalidates the gate.
 
 ## Report-attestation gate
 
 A report-attestation head is acceptable only when:
 
-- exactly one commit follows the reviewed implementation HEAD,
-- the commit's first parent is the reviewed implementation HEAD,
+- exactly one commit follows reviewed implementation HEAD,
+- commit first parent is reviewed implementation HEAD,
 - only pre-reserved independent-final-review report paths changed,
-- those paths did not exist or change during the frozen independent review itself,
-- the report names the reviewed implementation HEAD and identifies the commit as administrative attestation,
+- those paths did not exist/change during frozen independent review,
+- report names reviewed implementation HEAD and identifies commit as administrative attestation,
 - no executable, Skill, design, workflow, configuration, tracking, feedback, handoff, or product path changed,
 - no later repository commit exists.
 
-The technical verdict remains attached to the reviewed implementation HEAD. The attestation commit does not expand the reviewed implementation scope.
+Technical verdict remains attached to reviewed implementation HEAD. Attestation commit does not expand reviewed implementation scope.
 
 ## Codex responsibilities
 
-- Parent owns reviewer identity, continuity, independence, single-reviewer enforcement, report path reservation, retained independent evidence, pre-freeze gating, lifecycle gating, attestation validation, and integration.
-- `sub-agent-task-manager` owns every new reviewer spawn and its dispatch profile, but must honor the caller's no-decomposition and report-persistence constraints.
+- Parent owns reviewer identity, continuity, independence, single-reviewer execution policy, truthful decomposability evidence, report-path reservation, retained independent evidence, pre-freeze gating, lifecycle gating, attestation validation, and integration.
+- `sub-agent-task-manager` owns every new reviewer spawn/profile/role plan/runtime observability evidence and must honor no-decomposition/report-persistence constraints.
 - Parent review cannot replace reviewer sub-agent work.
 - Do not cancel a reviewer merely because it is slow.
 - Reviewers do not implement findings.
@@ -155,21 +166,21 @@ Return:
 
 - normal review and fix-verification evidence,
 - pre-freeze gate evidence,
-- independent-final-review evidence retained outside the frozen repository until attestation,
+- independent-final-review evidence retained outside frozen repository until attestation,
 - reviewed implementation HEAD,
 - report-attestation head or explicit absence,
 - attestation allowlist validation,
 - reviewer identity and independence evidence,
-- reviewer dispatch-profile evidence, including any expensive-profile proposal and approval evidence,
-- reviewer continuity evidence, including `reused_existing_agent_profile` when applicable,
-- single-reviewer/decomposition-forbidden evidence for every review dispatch,
-- full findings, coverage, held and unexplored items, validation assessment, verdict, remaining risks, and next action,
-- finding completeness matrix and verification capability with separate commit, push, and CI-wait evidence.
+- reviewer dispatch-profile evidence including role plan, runtime observability, and any expensive-profile approval,
+- reviewer continuity evidence including `reused_existing_agent_profile` when applicable,
+- truthful `decomposability`, `decomposition_policy`, and decomposition disposition for every review dispatch,
+- full findings, coverage, held/unexplored items, validation assessment, verdict, remaining risks, next action,
+- finding completeness matrix and verification capability with separate commit/push/CI-wait evidence.
 
 ## Completion condition
 
-Complete only when the required Skills have produced normal review and independent-final-review evidence, every newly created reviewer went through `sub-agent-task-manager` as a single non-decomposable reviewer, any required `Sol xhigh` or `Sol max` approval preceded reviewer spawn, reused reviewers preserved their original applied profile, the independent reviewer did not write the reserved report path before passing, all non-final repository changes and mandatory end-of-Issue or feedback work preceded the frozen reviewed implementation HEAD, no unresolved required finding or verdict-invalidating unexplored area remains, and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit or repository-writing Skill execution. No merge is performed.
+Complete only when required Skills produced normal-review and independent-final-review evidence; every new reviewer went through `sub-agent-task-manager` under single-agent execution policy without falsifying decomposability; any required initial/role-adjusted Sol `xhigh`/`max` approval preceded reviewer spawn; runtime-profile observability uncertainty is preserved; reused reviewers preserved original profile evidence; independent reviewer did not write reserved report path before passing; all non-final repository changes and mandatory end-of-Issue/feedback work preceded frozen reviewed implementation HEAD; no unresolved required finding or verdict-invalidating unexplored area remains; and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit/writing Skill. No merge is performed.
 
 ## Cross-cutting rule
 
-If a repeated review-related instruction appears, call `feedback-points-manager` and persist any resulting repository change before freezing the independent-final-review target. After freeze, record newly discovered feedback only through a non-Git external operation or invalidate the terminal state and return to the normal cycle.
+If a repeated review-related instruction appears, call `feedback-points-manager` and persist any resulting repository change before freezing the independent-final-review target. After freeze, record newly discovered feedback only through a non-Git external operation or invalidate terminal state and return to normal cycle.

--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -14,17 +14,30 @@ Act as the Codex runtime wrapper for review without redefining review semantics,
 Invoke:
 
 1. `work-context-manager`
-2. `review-worker`
-3. `report-writer`
-4. `report-output-manager`
+2. `sub-agent-task-manager`
+3. `review-worker`
+4. `report-writer`
+5. `report-output-manager`
 
 Do not replace these Skills with `shared/` files or duplicate their semantics locally.
+
+## Reviewer dispatch contract
+
+Every newly created reviewer sub-agent must be dispatched through `sub-agent-task-manager`.
+
+- `review-enforcer` owns reviewer identity, continuity, independence, review mode, and lifecycle state.
+- `sub-agent-task-manager` owns per-task model, reasoning effort, fork policy, expensive-profile approval gating, runtime application, and dispatch-profile evidence.
+- If `sub-agent-task-manager` produces an unapproved `Sol xhigh` or `Sol max` `proposed_profile`, return that proposal to the parent and stop before spawning the reviewer.
+- Do not bypass the proposal stop by directly spawning a reviewer from this Skill.
+- A reviewer that already exists is reused directly for continuity; reuse is not a new profile selection or new spawn.
+
+When an existing reviewer is reused, preserve its originally applied execution profile. Record `application_status: reused_existing_agent_profile`, the original applied profile, the reviewer identity, and the review mode being continued. Do not claim that a new default such as Terra `high` was applied to an already-running Sol reviewer.
 
 ## Codex reviewer lifecycle
 
 ### Normal review cycle
 
-Use one dedicated reviewer sub-agent for initial review and fix verification while available. Preserve finding identity, reviewed HEAD, selected criteria, held and unexplored items, and fix context.
+Use one dedicated reviewer sub-agent for initial review and fix verification while available. Create that reviewer through `sub-agent-task-manager`. Preserve finding identity, reviewed HEAD, selected criteria, held and unexplored items, fix context, reviewer identity, and the originally applied reviewer profile.
 
 Persist normal-review and fix-verification reports, synchronize tracking, and
 commit all resulting repository changes before selecting the
@@ -41,18 +54,20 @@ After the normal cycle converges:
 - commit those changes,
 - for `local_execution_available`, freeze the validated local committed HEAD without pre-review push; for `remote_ci_only`, complete authorized pre-review push and matching current-HEAD CI,
 - freeze that HEAD as `reviewed_implementation_head`,
-- start a different fresh reviewer sub-agent.
+- ask `sub-agent-task-manager` to prepare a different fresh reviewer sub-agent.
 
 The independent reviewer must differ from the implementation agent and normal reviewer, must not have implemented fixes, and should use `fork_turns: "none"` unless a bounded exception is justified.
+
+If independent-final-review profile selection proposes `Sol xhigh` or `Sol max`, stop before reviewer creation and return the proposal to the user. Continue only after explicit current-task approval. If the user rejects the proposal, let `sub-agent-task-manager` recompute the profile with the rejected expensive profiles excluded.
 
 ## Required flow
 
 1. Invoke `work-context-manager` for the current committed HEAD and matching evidence.
 2. Run applicable Markdown and repository gates.
-3. Dispatch a normal reviewer sub-agent that invokes `review-worker` in the selected mode.
+3. Ask `sub-agent-task-manager` to select and apply the profile for a new normal reviewer and dispatch that reviewer to invoke `review-worker` in the selected mode. If an expensive Sol proposal is awaiting approval, stop before spawn and return the proposal to the parent.
 4. Invoke `report-writer` and persist through `report-output-manager`.
 5. Return required findings to the implementation flow.
-6. Reuse the normal reviewer for fix verification when available.
+6. Reuse the normal reviewer for fix verification when available. Reuse the existing agent and its original applied profile; do not create a new profile or claim that the focused-fix default replaced the running reviewer's profile. Record `application_status: reused_existing_agent_profile`.
 7. Before requesting finding closure, require a finding-by-finding completeness
    matrix covering every required action, production path, actual composition
    fixture, and focused evidence. Do not dispatch closure review while any cell
@@ -65,8 +80,8 @@ The independent reviewer must differ from the implementation agent and normal re
 9. After convergence, verify that the parent has completed the end-of-Issue Skill-gap decision, any in-scope `skill-authoring-wrapper` work, feedback classification and ledger synchronization, normal handoff persistence, reports, and tracking.
 10. If step 9 creates or discovers any repository change, require route-appropriate validation, commit, and another normal review or fix-verification round. Do not freeze the target yet.
 11. Only after the normal cycle converges again with all pre-freeze work included, ensure every non-final repository change is committed. On the local route, require the repository-defined full local gate before final push. Reserve the independent-final-review report path, and freeze the implementation HEAD.
-12. Dispatch a fresh independent final reviewer against that frozen implementation HEAD.
-13. If the one exhaustive independent review finds required changes, invalidate the terminal state, return to implementation and normal fix verification, then reuse that same independent reviewer only for finding/CI-delta closure against the updated reviewed HEAD. Do not spawn another fresh exhaustive reviewer or add new review criteria.
+12. Ask `sub-agent-task-manager` to select the profile for a fresh independent final reviewer against that frozen implementation HEAD. If it returns an unapproved `Sol xhigh` or `Sol max` proposal, stop before spawn; after approval, dispatch the reviewer through `sub-agent-task-manager`.
+13. If the one exhaustive independent review finds required changes, invalidate the terminal state, return to implementation and normal fix verification, then reuse that same independent reviewer only for finding/CI-delta closure against the updated reviewed HEAD. Preserve the reviewer's original applied profile and record `application_status: reused_existing_agent_profile`; do not spawn another fresh exhaustive reviewer or add new review criteria.
 14. When the verdict passes, invoke `report-writer` and `report-output-manager` in report-attestation mode.
 15. Persist at most one report-attestation commit whose first parent is the reviewed implementation HEAD and whose changed paths are limited to the pre-reserved independent-final-review report path or paths.
 16. Validate the attestation diff, make the final authorized push, then invoke `git-pr-submitter` or the authorized equivalent to create or update the PR for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI. Do not wait for an unrequired `push` run.
@@ -106,7 +121,8 @@ The technical verdict remains attached to the reviewed implementation HEAD. The 
 
 ## Codex responsibilities
 
-- Parent owns reviewer identity, sub-agent dispatch, report path reservation, pre-freeze gating, lifecycle gating, attestation validation, and integration.
+- Parent owns reviewer identity, continuity, independence, report path reservation, pre-freeze gating, lifecycle gating, attestation validation, and integration.
+- `sub-agent-task-manager` owns every new reviewer spawn and its dispatch profile.
 - Parent review cannot replace reviewer sub-agent work.
 - Do not cancel a reviewer merely because it is slow.
 - Reviewers do not implement findings.
@@ -126,13 +142,15 @@ Return:
 - report-attestation head or explicit absence,
 - attestation allowlist validation,
 - reviewer identity and independence evidence,
-- full findings, coverage, held and unexplored items, validation assessment, verdict, remaining risks, and next action.
+- reviewer dispatch-profile evidence, including any expensive-profile proposal and approval evidence,
+- reviewer continuity evidence, including `reused_existing_agent_profile` when applicable,
+- full findings, coverage, held and unexplored items, validation assessment, verdict, remaining risks, and next action,
 - finding completeness matrix and verification capability with separate commit,
   push, and CI-wait evidence.
 
 ## Completion condition
 
-Complete only when the required Skills have produced normal review and independent-final-review evidence, all non-final repository changes and mandatory end-of-Issue or feedback work preceded the frozen reviewed implementation HEAD, no unresolved required finding or verdict-invalidating unexplored area remains, and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit or repository-writing Skill execution. No merge is performed.
+Complete only when the required Skills have produced normal review and independent-final-review evidence, every newly created reviewer went through `sub-agent-task-manager`, any required `Sol xhigh` or `Sol max` approval preceded reviewer spawn, reused reviewers preserved their original applied profile, all non-final repository changes and mandatory end-of-Issue or feedback work preceded the frozen reviewed implementation HEAD, no unresolved required finding or verdict-invalidating unexplored area remains, and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit or repository-writing Skill execution. No merge is performed.
 
 ## Cross-cutting rule
 

--- a/skills/review-enforcer/SKILL.md
+++ b/skills/review-enforcer/SKILL.md
@@ -23,26 +23,50 @@ Do not replace these Skills with `shared/` files or duplicate their semantics lo
 
 ## Reviewer dispatch contract
 
-Every newly created reviewer sub-agent must be dispatched through `sub-agent-task-manager`.
+Every newly created reviewer sub-agent must be dispatched through `sub-agent-task-manager` as one identity-bearing reviewer task.
 
-- `review-enforcer` owns reviewer identity, continuity, independence, review mode, and lifecycle state.
+- `review-enforcer` owns reviewer identity, continuity, independence, review mode, single-reviewer scope, report persistence mode, and lifecycle state.
 - `sub-agent-task-manager` owns per-task model, reasoning effort, fork policy, expensive-profile approval gating, runtime application, and dispatch-profile evidence.
+- Every reviewer task created by this Skill must set `decomposability: single`, `decomposition_policy: forbidden`, and `parallelism_mode: single_agent`.
+- Reviewer breadth never authorizes multi-agent decomposition. Large reviews remain one reviewer because normal-review continuity and the independent one-exhaustive-pass guarantee are identity-sensitive lifecycle contracts.
 - If `sub-agent-task-manager` produces an unapproved `Sol xhigh` or `Sol max` `proposed_profile`, return that proposal to the parent and stop before spawning the reviewer.
 - Do not bypass the proposal stop by directly spawning a reviewer from this Skill.
 - A reviewer that already exists is reused directly for continuity; reuse is not a new profile selection or new spawn.
 
 When an existing reviewer is reused, preserve its originally applied execution profile. Record `application_status: reused_existing_agent_profile`, the original applied profile, the reviewer identity, and the review mode being continued. Do not claim that a new default such as Terra `high` was applied to an already-running Sol reviewer.
 
+## Report persistence by review mode
+
+Use two distinct report modes.
+
+### Normal review and fix verification
+
+Use `report_persistence_mode: normal_persistence`.
+
+- `sub-agent-task-manager` may pre-create the normal-review report from the standard template.
+- the reviewer may fill child-owned report sections directly
+- parent-owned dispatch-profile fields are completed from actual spawn/runtime evidence
+- persist and commit these reports before the independent-final-review target is frozen
+
+### Independent final review and bounded independent closure
+
+Use `report_persistence_mode: deferred_attestation`.
+
+- reserve the exact independent-final-review report path before freeze through `report-output-manager`
+- reservation is metadata only; do not create, pre-populate, or edit that repository path before or during independent review
+- the independent reviewer returns structured review evidence to the parent instead of editing a report file
+- the parent retains reviewer output and dispatch-profile evidence outside the frozen repository content
+- only after a passing verdict may `report-writer` and `report-output-manager` materialize that evidence into the reserved path as the single report-attestation commit
+
+If the independent review finds required changes, keep its evidence as parent-owned lifecycle state, invalidate the terminal state, return through implementation and normal fix verification, and later reuse the same independent reviewer for bounded closure without creating the reserved report file. Persist only after that independent lifecycle reaches a passing verdict.
+
 ## Codex reviewer lifecycle
 
 ### Normal review cycle
 
-Use one dedicated reviewer sub-agent for initial review and fix verification while available. Create that reviewer through `sub-agent-task-manager`. Preserve finding identity, reviewed HEAD, selected criteria, held and unexplored items, fix context, reviewer identity, and the originally applied reviewer profile.
+Use one dedicated reviewer sub-agent for initial review and fix verification while available. Create that reviewer through `sub-agent-task-manager` with decomposition forbidden and normal persistence. Preserve finding identity, reviewed HEAD, selected criteria, held and unexplored items, fix context, reviewer identity, and the originally applied reviewer profile.
 
-Persist normal-review and fix-verification reports, synchronize tracking, and
-commit all resulting repository changes before selecting the
-independent-final-review target. Push and CI waiting remain separate,
-verification-route-owned states.
+Persist normal-review and fix-verification reports, synchronize tracking, and commit all resulting repository changes before selecting the independent-final-review target. Push and CI waiting remain separate, verification-route-owned states.
 
 ### Independent final review
 
@@ -50,13 +74,13 @@ After the normal cycle converges:
 
 - finish every implementation, design, workflow, configuration, tracking, feedback-ledger, normal handoff, and non-final report change,
 - finish the parent-owned end-of-Issue Skill-gap decision and execute any in-scope Skill update,
-- reserve the independent-final-review report path or paths,
-- commit those changes,
+- reserve the independent-final-review report path or paths without creating those files,
+- commit all other changes,
 - for `local_execution_available`, freeze the validated local committed HEAD without pre-review push; for `remote_ci_only`, complete authorized pre-review push and matching current-HEAD CI,
 - freeze that HEAD as `reviewed_implementation_head`,
-- ask `sub-agent-task-manager` to prepare a different fresh reviewer sub-agent.
+- ask `sub-agent-task-manager` to prepare one different fresh reviewer sub-agent with decomposition forbidden and deferred attestation.
 
-The independent reviewer must differ from the implementation agent and normal reviewer, must not have implemented fixes, and should use `fork_turns: "none"` unless a bounded exception is justified.
+The independent reviewer must differ from the implementation agent and normal reviewer, must not have implemented fixes, must remain a single reviewer for the entire independent lifecycle, and should use `fork_turns: "none"` unless a bounded exception is justified.
 
 If independent-final-review profile selection proposes `Sol xhigh` or `Sol max`, stop before reviewer creation and return the proposal to the user. Continue only after explicit current-task approval. If the user rejects the proposal, let `sub-agent-task-manager` recompute the profile with the rejected expensive profiles excluded.
 
@@ -64,29 +88,23 @@ If independent-final-review profile selection proposes `Sol xhigh` or `Sol max`,
 
 1. Invoke `work-context-manager` for the current committed HEAD and matching evidence.
 2. Run applicable Markdown and repository gates.
-3. Ask `sub-agent-task-manager` to select and apply the profile for a new normal reviewer and dispatch that reviewer to invoke `review-worker` in the selected mode. If an expensive Sol proposal is awaiting approval, stop before spawn and return the proposal to the parent.
-4. Invoke `report-writer` and persist through `report-output-manager`.
+3. Ask `sub-agent-task-manager` to select the profile for one new normal reviewer with `decomposability: single`, `decomposition_policy: forbidden`, `parallelism_mode: single_agent`, and `report_persistence_mode: normal_persistence`; dispatch that reviewer to invoke `review-worker` in the selected mode. If an expensive Sol proposal is awaiting approval, stop before spawn and return the proposal to the parent.
+4. Invoke `report-writer` and persist normal-review evidence through `report-output-manager`.
 5. Return required findings to the implementation flow.
 6. Reuse the normal reviewer for fix verification when available. Reuse the existing agent and its original applied profile; do not create a new profile or claim that the focused-fix default replaced the running reviewer's profile. Record `application_status: reused_existing_agent_profile`.
-7. Before requesting finding closure, require a finding-by-finding completeness
-   matrix covering every required action, production path, actual composition
-   fixture, and focused evidence. Do not dispatch closure review while any cell
-   is incomplete.
-8. After each fix, require route-appropriate validation, report and tracking
-   synchronization, and a review-target commit before another review round. On
-   `local_execution_available`, do not wait for CI in this loop; on
-   `remote_ci_only`, record matching current-HEAD CI evidence after authorized
-   push when it is required for formal verification.
+7. Before requesting finding closure, require a finding-by-finding completeness matrix covering every required action, production path, actual composition fixture, and focused evidence. Do not dispatch closure review while any cell is incomplete.
+8. After each fix, require route-appropriate validation, report and tracking synchronization, and a review-target commit before another normal-review round. On `local_execution_available`, do not wait for CI in this loop; on `remote_ci_only`, record matching current-HEAD CI evidence after authorized push when it is required for formal verification.
 9. After convergence, verify that the parent has completed the end-of-Issue Skill-gap decision, any in-scope `skill-authoring-wrapper` work, feedback classification and ledger synchronization, normal handoff persistence, reports, and tracking.
 10. If step 9 creates or discovers any repository change, require route-appropriate validation, commit, and another normal review or fix-verification round. Do not freeze the target yet.
-11. Only after the normal cycle converges again with all pre-freeze work included, ensure every non-final repository change is committed. On the local route, require the repository-defined full local gate before final push. Reserve the independent-final-review report path, and freeze the implementation HEAD.
-12. Ask `sub-agent-task-manager` to select the profile for a fresh independent final reviewer against that frozen implementation HEAD. If it returns an unapproved `Sol xhigh` or `Sol max` proposal, stop before spawn; after approval, dispatch the reviewer through `sub-agent-task-manager`.
-13. If the one exhaustive independent review finds required changes, invalidate the terminal state, return to implementation and normal fix verification, then reuse that same independent reviewer only for finding/CI-delta closure against the updated reviewed HEAD. Preserve the reviewer's original applied profile and record `application_status: reused_existing_agent_profile`; do not spawn another fresh exhaustive reviewer or add new review criteria.
-14. When the verdict passes, invoke `report-writer` and `report-output-manager` in report-attestation mode.
-15. Persist at most one report-attestation commit whose first parent is the reviewed implementation HEAD and whose changed paths are limited to the pre-reserved independent-final-review report path or paths.
-16. Validate the attestation diff, make the final authorized push, then invoke `git-pr-submitter` or the authorized equivalent to create or update the PR for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI. Do not wait for an unrequired `push` run.
-17. After the attestation commit, permit only operations that do not change Git HEAD: PR body or comment updates, review requests, external Issue operations, and inline or branch-external handoff transport.
-18. Do not call any repository-writing Skill after attestation and do not commit any later handoff, tracking, design, Skill, workflow, configuration, feedback, report, or implementation change.
+11. Only after the normal cycle converges again with all pre-freeze work included, ensure every non-final repository change is committed. On the local route, require the repository-defined full local gate before final push. Reserve the independent-final-review report path as metadata only, and freeze the implementation HEAD.
+12. Ask `sub-agent-task-manager` to select the profile for one fresh independent final reviewer with `decomposability: single`, `decomposition_policy: forbidden`, `parallelism_mode: single_agent`, and `report_persistence_mode: deferred_attestation`. If it returns an unapproved `Sol xhigh` or `Sol max` proposal, stop before spawn; after approval, dispatch that single reviewer through `sub-agent-task-manager` without creating the reserved report file.
+13. Retain the independent reviewer's structured findings, coverage, commands/evidence, verdict, risks, unexplored areas, and post-runtime dispatch-profile evidence as parent-owned lifecycle evidence.
+14. If the one exhaustive independent review finds required changes, invalidate the terminal state, return to implementation and normal fix verification, then reuse that same independent reviewer only for finding/CI-delta closure against the updated reviewed HEAD. Preserve the reviewer's original applied profile and record `application_status: reused_existing_agent_profile`; do not spawn another fresh exhaustive reviewer, decompose the review, add new review criteria, or create the reserved report file.
+15. When the independent lifecycle reaches a passing verdict, invoke `report-writer` and `report-output-manager` in report-attestation mode using the retained reviewer evidence and pre-reserved path.
+16. Persist at most one report-attestation commit whose first parent is the reviewed implementation HEAD and whose changed paths are limited to the pre-reserved independent-final-review report path or paths.
+17. Validate the attestation diff, make the final authorized push, then invoke `git-pr-submitter` or the authorized equivalent to create or update the PR for that exact HEAD. Wait once after publication for exact-head required `pull_request` CI. Do not wait for an unrequired `push` run.
+18. After the attestation commit, permit only operations that do not change Git HEAD: PR body or comment updates, review requests, external Issue operations, and inline or branch-external handoff transport.
+19. Do not call any repository-writing Skill after attestation and do not commit any later handoff, tracking, design, Skill, workflow, configuration, feedback, report, or implementation change.
 
 Any other post-review commit invalidates completion and requires normal fix verification followed by same-reviewer bounded finding/CI-delta closure.
 
@@ -94,17 +112,16 @@ Any other post-review commit invalidates completion and requires normal fix veri
 
 The independent-final-review target must not be frozen until all of the following are explicit and repository-stable:
 
-- implementation, validation, design, workflow, configuration, reports, and tracking,
+- implementation, validation, design, workflow, configuration, normal reports, and tracking,
 - normal review and fix-verification evidence,
 - end-of-Issue Skill-gap decision,
 - any selected in-scope Skill update,
 - feedback classification and any feedback ledger write,
 - repository-backed normal handoff,
-- current-HEAD validation evidence and verification-route disposition. For
-  `remote_ci_only`, matching current-HEAD CI may be formal evidence; for the
-  local route, do not require CI completion before attestation.
+- the independent-final-review report path reservation as metadata only, with no file created yet,
+- current-HEAD validation evidence and verification-route disposition. For `remote_ci_only`, matching current-HEAD CI may be formal evidence; for the local route, do not require CI completion before attestation.
 
-A newly discovered repository write after this gate invalidates the gate and returns the workflow to the normal cycle.
+A newly discovered repository write after this gate invalidates the gate and returns the workflow to the normal cycle. Creating or editing the reserved independent-final-review report before a passing verdict also invalidates the gate.
 
 ## Report-attestation gate
 
@@ -113,6 +130,7 @@ A report-attestation head is acceptable only when:
 - exactly one commit follows the reviewed implementation HEAD,
 - the commit's first parent is the reviewed implementation HEAD,
 - only pre-reserved independent-final-review report paths changed,
+- those paths did not exist or change during the frozen independent review itself,
 - the report names the reviewed implementation HEAD and identifies the commit as administrative attestation,
 - no executable, Skill, design, workflow, configuration, tracking, feedback, handoff, or product path changed,
 - no later repository commit exists.
@@ -121,8 +139,8 @@ The technical verdict remains attached to the reviewed implementation HEAD. The 
 
 ## Codex responsibilities
 
-- Parent owns reviewer identity, continuity, independence, report path reservation, pre-freeze gating, lifecycle gating, attestation validation, and integration.
-- `sub-agent-task-manager` owns every new reviewer spawn and its dispatch profile.
+- Parent owns reviewer identity, continuity, independence, single-reviewer enforcement, report path reservation, retained independent evidence, pre-freeze gating, lifecycle gating, attestation validation, and integration.
+- `sub-agent-task-manager` owns every new reviewer spawn and its dispatch profile, but must honor the caller's no-decomposition and report-persistence constraints.
 - Parent review cannot replace reviewer sub-agent work.
 - Do not cancel a reviewer merely because it is slow.
 - Reviewers do not implement findings.
@@ -137,20 +155,20 @@ Return:
 
 - normal review and fix-verification evidence,
 - pre-freeze gate evidence,
-- independent-final-review evidence,
+- independent-final-review evidence retained outside the frozen repository until attestation,
 - reviewed implementation HEAD,
 - report-attestation head or explicit absence,
 - attestation allowlist validation,
 - reviewer identity and independence evidence,
 - reviewer dispatch-profile evidence, including any expensive-profile proposal and approval evidence,
 - reviewer continuity evidence, including `reused_existing_agent_profile` when applicable,
+- single-reviewer/decomposition-forbidden evidence for every review dispatch,
 - full findings, coverage, held and unexplored items, validation assessment, verdict, remaining risks, and next action,
-- finding completeness matrix and verification capability with separate commit,
-  push, and CI-wait evidence.
+- finding completeness matrix and verification capability with separate commit, push, and CI-wait evidence.
 
 ## Completion condition
 
-Complete only when the required Skills have produced normal review and independent-final-review evidence, every newly created reviewer went through `sub-agent-task-manager`, any required `Sol xhigh` or `Sol max` approval preceded reviewer spawn, reused reviewers preserved their original applied profile, all non-final repository changes and mandatory end-of-Issue or feedback work preceded the frozen reviewed implementation HEAD, no unresolved required finding or verdict-invalidating unexplored area remains, and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit or repository-writing Skill execution. No merge is performed.
+Complete only when the required Skills have produced normal review and independent-final-review evidence, every newly created reviewer went through `sub-agent-task-manager` as a single non-decomposable reviewer, any required `Sol xhigh` or `Sol max` approval preceded reviewer spawn, reused reviewers preserved their original applied profile, the independent reviewer did not write the reserved report path before passing, all non-final repository changes and mandatory end-of-Issue or feedback work preceded the frozen reviewed implementation HEAD, no unresolved required finding or verdict-invalidating unexplored area remains, and either no report commit was required or exactly one validated report-attestation head exists with no later repository commit or repository-writing Skill execution. No merge is performed.
 
 ## Cross-cutting rule
 

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -11,7 +11,7 @@ Standardize how work is handed to a sub-agent.
 
 Make every sub-agent task bounded, auditable, proportionately resourced, and report-backed.
 
-This Skill owns per-task model-tier, reasoning-effort, and fork-policy selection. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions.
+This Skill owns per-task model-tier, reasoning-effort, and fork-policy selection for newly dispatched sub-agents. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions. Existing reviewer continuity is preserved by `review-enforcer` and is not treated as a new spawn.
 
 ## Execution owner
 
@@ -39,14 +39,17 @@ When a caller already supplied a complete delegation assessment, reuse it. Other
 
 Run this skill whenever:
 
-- a skill requires sub-agent execution
-- `codex-delegation-executor` chooses a `sub-agent`
-- independent review or verification is required
+- a skill requires a new sub-agent execution
+- `codex-delegation-executor` chooses a new `sub-agent`
+- `review-enforcer` needs a new normal, replacement, or independent reviewer
+- independent verification is required through a new sub-agent
 - a bounded implementation or investigation task is handed off
+
+Do not create a new reviewer merely because an existing reviewer moves from initial review to fix verification or bounded closure. `review-enforcer` owns that reuse and preserves the original applied profile.
 
 ## Required flow
 
-1. define the exact task type and why a `sub-agent` is being used
+1. define the exact task type and why a new `sub-agent` is being used
 2. define the scope, non-goals, expected outputs, and write ownership
 3. classify the task signals required by [references/agent-profile-selection.md](references/agent-profile-selection.md)
 4. select and record one ordinary `dispatch_profile`, return independently separable work to `codex-delegation-executor`, or create an approval-gated `proposed_profile`
@@ -58,7 +61,7 @@ Run this skill whenever:
 10. create the report file before dispatch using the standard template
 11. tell the `sub-agent` to read the specified skill files before executing
 12. tell the `sub-agent` to read that exact report file first and fill only the intended blank sections or placeholder values
-13. require commands run, changed files, outcome, unresolved risks, and dispatch-profile evidence in the report
+13. require commands run, changed files, outcome, unresolved risks, and every field in the fixed `Dispatch profile` section to be completed in the report
 14. dispatch with the applied model and reasoning effort as actual tool-call arguments and the selected fork policy
 15. do not treat the delegated task as complete until the report exists, the runtime application status is recorded, and the parent has reviewed the result
 
@@ -95,11 +98,13 @@ An explicit current-task instruction from the user that directly requests `Sol x
 
 This gate applies to all task kinds, including independent final review and release audit, and has priority over repository policy and automatic selection.
 
-For review work, use these defaults:
+For newly created review agents, use these defaults:
 
 - initial normal review: Sol with `high`
-- focused fix verification: Terra with `high`
+- focused fix verification when continuity reuse is unavailable: Terra with `high`
 - independent final review or release audit: propose Sol with `xhigh`, then stop for explicit user approval before dispatch
+
+When `review-enforcer` reuses an existing normal or independent reviewer, do not apply these new-agent defaults. Preserve the original applied profile and record `application_status: reused_existing_agent_profile` in the review evidence.
 
 For investigation, do not use Luna for open-ended or root-cause work. A deterministic evidence-collection task may use Luna, but a failure or conflicting evidence must be reclassified before retrying.
 
@@ -107,7 +112,7 @@ Record `proposed`, `requested`, and `applied` distinctly when the approval gate 
 
 ## Required prompt content
 
-Every sub-agent request must include:
+Every new sub-agent request must include:
 
 - task purpose
 - exact scope
@@ -120,6 +125,7 @@ Every sub-agent request must include:
 - report path
 - instruction to read the pre-created report file first and preserve its heading order, spacing, and existing filled text
 - instruction to fill only blank sections or placeholder values instead of rewriting the full report
+- instruction to complete the fixed `Dispatch profile` placeholders without adding, removing, or reordering report sections
 - required final output shape
 
 The selected model and reasoning effort belong only in actual spawn parameters. Do not rely on model names written in the prompt to configure execution. The prompt may state task-local cost or quality constraints, but it must not claim an unapplied runtime profile.
@@ -157,6 +163,7 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 - The report must be created before the parent workflow treats a dispatched task as complete.
 - An approval-gated proposal may be recorded before a child report exists because no child has been dispatched yet; record it in the parent-owned lifecycle evidence.
 - The parent should pre-populate the standard headings and placeholders so the `sub-agent` edits a fixed structure instead of rewriting the document.
+- The standard template includes a fixed `Dispatch profile` section. Do not require profile evidence outside that fixed structure.
 - If the `sub-agent` cannot write the report directly, the parent must write it immediately from the returned evidence.
 - Do not ask a sub-agent for ad hoc investigation, review, or implementation without a report path.
 - For review tasks, the built-in review result must be materialized into the report file before the task is considered complete.
@@ -166,7 +173,7 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 - Report text should be written in Japanese unless the user explicitly requests another language.
 - The `sub-agent` must preserve the existing report format: no heading renames, no section reordering, no blank-line cleanup, and no whole-file replacement.
 - Existing non-empty parent text in the report is immutable unless the parent explicitly marks it as editable.
-- Record all profile-selection inputs, proposal and approval evidence when relevant, requested and applied profile, selection source, reasons, constraints, fork policy, application status, and any escalation or fallback.
+- Record all profile-selection inputs, proposal and approval evidence when relevant, requested and applied profile, selection source, reasons, constraints, fork policy, application status, and any escalation or fallback in the fixed `Dispatch profile` section.
 
 ## Standard report sections
 
@@ -177,11 +184,25 @@ Use these sections in order:
 - `## sub-agentを使う理由`
 - `## 対象範囲`
 - `## 対象外`
+- `## Dispatch profile`
 - `## 実行コマンド`
 - `## 対象ファイル`
 - `## 指摘事項`
 - `## 結果`
 - `## リスク`
+
+The fixed `Dispatch profile` section contains placeholders for:
+
+- selection inputs
+- selection source
+- proposed profile
+- approval status / evidence
+- requested profile
+- applied profile
+- application status
+- reviewer continuity
+- fork policy
+- reasons / constraints
 
 ## Minimum report contents
 
@@ -197,6 +218,7 @@ Include:
 - unresolved risks or follow-up items
 - dispatch-profile evidence and runtime application status
 - when applicable, `Sol xhigh` / `Sol max` proposal and explicit approval evidence
+- when applicable, reviewer continuity evidence and `reused_existing_agent_profile`
 
 ## Outputs
 
@@ -223,7 +245,7 @@ This skill is complete for a dispatched task only when:
 - any required `Sol xhigh` or `Sol max` approval was obtained before dispatch
 - the requested profile has either been applied or recorded as an explicit inherited, fallback, or capability-gap state
 - the report file exists in the expected location
-- the report contains the dispatch-profile evidence
+- the report contains the fixed `Dispatch profile` evidence
 - the parent has reviewed the resulting report and underlying evidence
 
 An approval-gated task is intentionally incomplete while awaiting user approval.

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -31,8 +31,9 @@ Before running this skill, identify:
 - task kind, work class, uncertainty, change radius, criticality, repetition, decomposability, and context need
 - explicit user or repository model, reasoning, budget, availability, or fork constraints
 - whether `codex-delegation-executor` considered multi-agent decomposition and its disposition
+- user-approval evidence when `Sol xhigh` or `Sol max` is under consideration
 
-When a caller already supplied a complete delegation assessment, reuse it. Otherwise derive the missing selection inputs from the bounded task and record that derivation. Do not require routine user confirmation of an automatically selected implementation model.
+When a caller already supplied a complete delegation assessment, reuse it. Otherwise derive the missing selection inputs from the bounded task and record that derivation. Do not require routine user confirmation of automatically selected profiles below the expensive-profile approval gate.
 
 ## Run this skill
 
@@ -48,16 +49,18 @@ Run this skill whenever:
 1. define the exact task type and why a `sub-agent` is being used
 2. define the scope, non-goals, expected outputs, and write ownership
 3. classify the task signals required by [references/agent-profile-selection.md](references/agent-profile-selection.md)
-4. select and record one `dispatch_profile`, or return independently separable work to `codex-delegation-executor` before dispatch
-5. read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md) and resolve the requested profile into an applied runtime profile
-6. identify which skill files the `sub-agent` must read
-7. call `report-output-manager` and decide the report path before dispatch
-8. create the report file before dispatch using the standard template
-9. tell the `sub-agent` to read the specified skill files before executing
-10. tell the `sub-agent` to read that exact report file first and fill only the intended blank sections or placeholder values
-11. require commands run, changed files, outcome, unresolved risks, and dispatch-profile evidence in the report
-12. dispatch with the applied model and reasoning effort as actual tool-call arguments and the selected fork policy
-13. do not treat the delegated task as complete until the report exists, the runtime application status is recorded, and the parent has reviewed the result
+4. select and record one ordinary `dispatch_profile`, return independently separable work to `codex-delegation-executor`, or create an approval-gated `proposed_profile`
+5. if the proposed profile is `Sol xhigh` or `Sol max`, present the proposal and cost notice to the user and stop before dispatch unless explicit current-task approval already exists
+6. after approval, promote the approved proposal to `requested`; after rejection, recompute with `Sol xhigh` and `Sol max` excluded
+7. read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md) and resolve the approved requested profile into an applied runtime profile
+8. identify which skill files the `sub-agent` must read
+9. call `report-output-manager` and decide the report path before dispatch
+10. create the report file before dispatch using the standard template
+11. tell the `sub-agent` to read the specified skill files before executing
+12. tell the `sub-agent` to read that exact report file first and fill only the intended blank sections or placeholder values
+13. require commands run, changed files, outcome, unresolved risks, and dispatch-profile evidence in the report
+14. dispatch with the applied model and reasoning effort as actual tool-call arguments and the selected fork policy
+15. do not treat the delegated task as complete until the report exists, the runtime application status is recorded, and the parent has reviewed the result
 
 Read the report template from `report-output-manager` when creating the file:
 
@@ -75,15 +78,32 @@ Select the model tier and reasoning effort independently.
 - choose the highest floor required by task kind, uncertainty, change radius, and criticality
 - preserve explicit user and repository overrides according to the precedence in the reference
 
-For review work, apply these minimum defaults unless a higher floor is required:
+### Expensive Sol approval gate
+
+`Sol xhigh` and `Sol max` are not automatic dispatch profiles.
+
+When either becomes the calculated profile:
+
+- keep it in `proposed_profile`, not `requested`
+- explain why `Sol high` is insufficient
+- tell the user that the higher reasoning effort increases execution cost
+- ask for explicit approval to use the proposed profile
+- stop the workflow before spawning that agent
+- do not treat repository policy, a prior unrelated approval, silence, or inferred preference as approval
+
+An explicit current-task instruction from the user that directly requests `Sol xhigh` or `Sol max` satisfies the gate. If the user rejects the proposal, recompute a non-gated profile; normally the upper automatic fallback is `Sol high`.
+
+This gate applies to all task kinds, including independent final review and release audit, and has priority over repository policy and automatic selection.
+
+For review work, use these defaults:
 
 - initial normal review: Sol with `high`
 - focused fix verification: Terra with `high`
-- independent final review or release audit: Sol with `xhigh`
+- independent final review or release audit: propose Sol with `xhigh`, then stop for explicit user approval before dispatch
 
 For investigation, do not use Luna for open-ended or root-cause work. A deterministic evidence-collection task may use Luna, but a failure or conflicting evidence must be reclassified before retrying.
 
-Record both `requested` and `applied` profiles. A full-history fork inherits the parent profile; runtime rejection or fallback is a capability state, not evidence that the requested override was applied.
+Record `proposed`, `requested`, and `applied` distinctly when the approval gate is relevant. A full-history fork inherits the parent profile; runtime rejection or fallback is a capability state, not evidence that the requested override was applied.
 
 ## Required prompt content
 
@@ -132,9 +152,10 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 
 ## Report rules
 
-- Every sub-agent task must produce a file under `reports/`.
+- Every dispatched sub-agent task must produce a file under `reports/`.
 - The parent agent should create the report file before dispatch whenever feasible.
-- The report must be created before the parent workflow treats the task as complete.
+- The report must be created before the parent workflow treats a dispatched task as complete.
+- An approval-gated proposal may be recorded before a child report exists because no child has been dispatched yet; record it in the parent-owned lifecycle evidence.
 - The parent should pre-populate the standard headings and placeholders so the `sub-agent` edits a fixed structure instead of rewriting the document.
 - If the `sub-agent` cannot write the report directly, the parent must write it immediately from the returned evidence.
 - Do not ask a sub-agent for ad hoc investigation, review, or implementation without a report path.
@@ -145,7 +166,7 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 - Report text should be written in Japanese unless the user explicitly requests another language.
 - The `sub-agent` must preserve the existing report format: no heading renames, no section reordering, no blank-line cleanup, and no whole-file replacement.
 - Existing non-empty parent text in the report is immutable unless the parent explicitly marks it as editable.
-- Record all profile-selection inputs, requested and applied profile, selection source, reasons, constraints, fork policy, application status, and any escalation or fallback.
+- Record all profile-selection inputs, proposal and approval evidence when relevant, requested and applied profile, selection source, reasons, constraints, fork policy, application status, and any escalation or fallback.
 
 ## Standard report sections
 
@@ -175,10 +196,11 @@ Include:
 - outcome
 - unresolved risks or follow-up items
 - dispatch-profile evidence and runtime application status
+- when applicable, `Sol xhigh` / `Sol max` proposal and explicit approval evidence
 
 ## Outputs
 
-After this skill runs, there should be:
+After this skill runs for a dispatched task, there should be:
 
 - a dispatched sub-agent task with explicit scope
 - a pre-created report path under `reports/`
@@ -186,22 +208,34 @@ After this skill runs, there should be:
 - a requested and actually applied model, reasoning effort, and fork policy
 - report-backed evidence for the delegated work
 
+When the expensive Sol approval gate is pending, the output is instead:
+
+- a recorded `proposed_profile`
+- cost and justification notice
+- `application_status: awaiting_user_approval`
+- no dispatch using that profile
+
 ## Completion condition
 
-This skill is complete only when:
+This skill is complete for a dispatched task only when:
 
 - the sub-agent task has been dispatched with the required prompt content
+- any required `Sol xhigh` or `Sol max` approval was obtained before dispatch
 - the requested profile has either been applied or recorded as an explicit inherited, fallback, or capability-gap state
 - the report file exists in the expected location
 - the report contains the dispatch-profile evidence
 - the parent has reviewed the resulting report and underlying evidence
+
+An approval-gated task is intentionally incomplete while awaiting user approval.
 
 ## Rules
 
 - Keep sub-agent tasks small and concrete.
 - Prefer one bounded request over one broad speculative request.
 - Reuse existing reports before dispatching duplicate work.
-- Use `execution-cost-stabilizer` before `max`, multi-agent decomposition, wasteful reruns, or excessive parallelism.
+- Use `execution-cost-stabilizer` before proposing `max`, multi-agent decomposition, wasteful reruns, or excessive parallelism.
+- Never dispatch `Sol xhigh` or `Sol max` without explicit current-task user approval.
+- Do not silently downgrade an approval-gated proposal merely to avoid asking the user; present the proposal and stop first. After rejection, recompute the profile.
 - Do not make a sub-agent run `codex exec`, nested Codex, or equivalent agent-spawning workflows inside the delegated task.
 - Do not let a sub-agent re-run `development-orchestrator` or other parent-owned workflow entry skills just because they exist in the repo; the sub-agent should execute only the delegated task and the explicitly named supporting skills.
 - Do not leave report structure up to the `sub-agent`.
@@ -210,11 +244,11 @@ This skill is complete only when:
 - For review tasks, prefer direct report editing by the reviewer and use parent-side transcription only as fallback.
 - Do not treat a model or reasoning mention in `message` as an override. Pass the applied values in the actual `spawn_agent` call.
 - Do not combine a model or reasoning override with omitted `fork_turns` or `fork_turns: "all"`; full-history forks inherit the parent execution profile.
-- Do not silently downgrade an explicit user or repository profile override.
+- Do not silently downgrade an explicit user or repository profile override, except that an unapproved repository request for `Sol xhigh` or `Sol max` remains a proposal until the user approves it.
 - Do not keep a failed deterministic task on Luna after the work has become diagnosis or judgment.
 - If runtime rejects a hidden override argument, keep fallback execution parent-owned as defined by the spawn reference. Do not ask the delegated sub-agent to run the fallback.
 - If independently separable work would justify multi-agent execution, return it to `codex-delegation-executor` before dispatch rather than overloading one sub-agent.
 
 ## Cross-cutting rule
 
-If recurring sub-agent dispatch failures, profile misclassification, or report omissions appear, call `feedback-points-manager`.
+If recurring sub-agent dispatch failures, profile misclassification, approval-gate bypasses, or report omissions appear, call `feedback-points-manager`.

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -11,7 +11,7 @@ Standardize how work is handed to a sub-agent.
 
 Make every sub-agent task bounded, auditable, proportionately resourced, and report-backed.
 
-This Skill owns per-task model-tier, reasoning-effort, and fork-policy selection for newly dispatched sub-agents. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions. Existing reviewer continuity is preserved by `review-enforcer` and is not treated as a new spawn.
+This Skill owns per-task model-tier, reasoning-effort, and fork-policy selection for newly dispatched sub-agents. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions unless the caller explicitly locks a task to one agent. Existing reviewer continuity is preserved by `review-enforcer` and is not treated as a new spawn.
 
 ## Execution owner
 
@@ -31,9 +31,13 @@ Before running this skill, identify:
 - task kind, work class, uncertainty, change radius, criticality, repetition, decomposability, and context need
 - explicit user or repository model, reasoning, budget, availability, or fork constraints
 - whether `codex-delegation-executor` considered multi-agent decomposition and its disposition
+- whether the caller explicitly forbids decomposition and requires one agent
+- report persistence mode: `normal_persistence` or `deferred_attestation`
 - user-approval evidence when `Sol xhigh` or `Sol max` is under consideration
 
 When a caller already supplied a complete delegation assessment, reuse it. Otherwise derive the missing selection inputs from the bounded task and record that derivation. Do not require routine user confirmation of automatically selected profiles below the expensive-profile approval gate.
+
+If the caller owns an identity-sensitive lifecycle and explicitly sets `decomposition_policy: forbidden`, preserve `decomposability: single` and do not return that task for multi-agent decomposition.
 
 ## Run this skill
 
@@ -50,22 +54,26 @@ Do not create a new reviewer merely because an existing reviewer moves from init
 ## Required flow
 
 1. define the exact task type and why a new `sub-agent` is being used
-2. define the scope, non-goals, expected outputs, and write ownership
+2. define the scope, non-goals, expected outputs, write ownership, decomposition policy, and report persistence mode
 3. classify the task signals required by [references/agent-profile-selection.md](references/agent-profile-selection.md)
-4. select and record one ordinary `dispatch_profile`, return independently separable work to `codex-delegation-executor`, or create an approval-gated `proposed_profile`
+4. select and record one ordinary `dispatch_profile`, return independently separable work to `codex-delegation-executor` only when decomposition is allowed, or create an approval-gated `proposed_profile`
 5. if the proposed profile is `Sol xhigh` or `Sol max`, present the proposal and cost notice to the user and stop before dispatch unless explicit current-task approval already exists
 6. after approval, promote the approved proposal to `requested`; after rejection, recompute with `Sol xhigh` and `Sol max` excluded
-7. read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md) and resolve the approved requested profile into an applied runtime profile
+7. read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md) and prepare the runtime call plan from `requested`, model availability, and fork constraints; do not populate `applied` before runtime evidence exists
 8. identify which skill files the `sub-agent` must read
-9. call `report-output-manager` and decide the report path before dispatch
-10. create the report file before dispatch using the standard template
+9. call `report-output-manager` and determine report handling:
+   - for `normal_persistence`, reserve the path and create the standard report file before dispatch
+   - for `deferred_attestation`, reserve the exact path only; do not create, pre-populate, or edit the repository report file before or during review
+10. for `normal_persistence`, pre-populate the fixed report structure and parent-owned `Dispatch profile` fields before dispatch
 11. tell the `sub-agent` to read the specified skill files before executing
-12. tell the `sub-agent` to read that exact report file first and fill only the intended blank sections or placeholder values
-13. require commands run, changed files, outcome, unresolved risks, and every field in the fixed `Dispatch profile` section to be completed in the report
-14. dispatch with the applied model and reasoning effort as actual tool-call arguments and the selected fork policy
-15. do not treat the delegated task as complete until the report exists, the runtime application status is recorded, and the parent has reviewed the result
+12. give the child the report instructions for the selected persistence mode
+13. dispatch using the `requested` model and reasoning effort as actual tool-call arguments when an override is permitted; when full-history inheritance is required, omit the incompatible override as defined by the spawn reference
+14. after the spawn call or fallback attempt, record `applied` and `application_status` from actual runtime evidence, inheritance, rejection, or fallback; never infer `applied` from `requested`
+15. for `normal_persistence`, update the parent-owned `Dispatch profile` fields with the post-call runtime evidence and require the child or parent to complete the remaining report sections
+16. for `deferred_attestation`, retain the reviewer output and dispatch-profile evidence as parent-owned lifecycle evidence without writing the reserved report path; only the caller's passing-verdict attestation flow may persist it later
+17. do not treat the delegated task as complete until the applicable report/evidence contract, runtime application status, and parent adjudication are satisfied
 
-Read the report template from `report-output-manager` when creating the file:
+Read the report template from `report-output-manager` when `normal_persistence` applies:
 
 - [../report-output-manager/references/sub-agent-report-template.md](../report-output-manager/references/sub-agent-report-template.md)
 
@@ -80,6 +88,7 @@ Select the model tier and reasoning effort independently.
 - treat multi-agent or article-described `Ultra` execution as a decomposition strategy owned by `codex-delegation-executor`, never as a `reasoning_effort` value
 - choose the highest floor required by task kind, uncertainty, change radius, and criticality
 - preserve explicit user and repository overrides according to the precedence in the reference
+- honor a caller-owned `decomposition_policy: forbidden`; such a task stays one agent even when its review scope is broad
 
 ### Expensive Sol approval gate
 
@@ -108,7 +117,7 @@ When `review-enforcer` reuses an existing normal or independent reviewer, do not
 
 For investigation, do not use Luna for open-ended or root-cause work. A deterministic evidence-collection task may use Luna, but a failure or conflicting evidence must be reclassified before retrying.
 
-Record `proposed`, `requested`, and `applied` distinctly when the approval gate is relevant. A full-history fork inherits the parent profile; runtime rejection or fallback is a capability state, not evidence that the requested override was applied.
+Record `proposed`, `requested`, and `applied` distinctly when the approval gate is relevant. `requested` is known before spawn; `applied` is a post-runtime fact. A full-history fork inherits the parent profile; runtime rejection or fallback is a capability state, not evidence that the requested override was applied.
 
 ## Required prompt content
 
@@ -120,15 +129,33 @@ Every new sub-agent request must include:
 - explicit instruction not to run `codex exec`, nested Codex, or equivalent agent-spawning inside the sub-agent task
 - explicit instruction not to re-enter `development-orchestrator` or any other parent-owned workflow unless the parent explicitly named that workflow as part of the delegated task
 - an explicit fork policy
+- explicit decomposition policy when the caller requires a single agent
 - skill names and file paths that must be read first
 - validation commands or evidence expectations
-- report path
-- instruction to read the pre-created report file first and preserve its heading order, spacing, and existing filled text
-- instruction to fill only blank sections or placeholder values instead of rewriting the full report
-- instruction to complete the fixed `Dispatch profile` placeholders without adding, removing, or reordering report sections
+- report persistence mode
 - required final output shape
 
-The selected model and reasoning effort belong only in actual spawn parameters. Do not rely on model names written in the prompt to configure execution. The prompt may state task-local cost or quality constraints, but it must not claim an unapplied runtime profile.
+The requested model and reasoning effort belong only in actual spawn parameters. Do not rely on model names written in the prompt to configure execution. The prompt may state task-local cost or quality constraints, but it must not claim an unapplied runtime profile.
+
+### Normal-persistence prompt additions
+
+For `normal_persistence`, also include:
+
+- report path
+- instruction to read the pre-created report file first and preserve its heading order, spacing, and existing filled text
+- instruction to fill only child-owned blank sections or placeholder values instead of rewriting the full report
+- instruction not to modify parent-owned `Dispatch profile` values, especially `requested`, `applied`, `application status`, approval, and continuity evidence
+
+The parent owns the complete `Dispatch profile` section because the child cannot observe hidden spawn arguments or runtime application evidence.
+
+### Deferred-attestation prompt additions
+
+For `deferred_attestation`, also include:
+
+- the reserved report path as metadata only
+- explicit instruction that the reserved repository report file does not yet exist and must not be created or edited by the reviewer
+- instruction to return structured findings, coverage, commands/evidence, verdict, risks, and unexplored areas to the parent
+- instruction that the parent will retain this output until the caller's report-attestation flow decides whether it may be persisted
 
 For review tasks also include:
 
@@ -137,16 +164,16 @@ For review tasks also include:
 - instruction to return findings first, ordered by severity
 - instruction to include file/line references when available
 - instruction to say explicitly when no findings were found
-- instruction to treat the report template as immutable structure and fill only blank sections or placeholder values
 - instruction to distinguish blocking normal-path problems, user-confirmation-required capability gaps, and non-blocking concerns that should only be recorded and held
 - instruction to inspect the relevant workspace directly when surrounding code context is needed, instead of relying only on a parent-prepared diff summary
-- explicit permission and requirement to write those findings into the pre-created report file without changing the report format
+
+For normal-persistence review tasks, require direct editing of the child-owned report sections. For deferred-attestation independent review, prohibit repository report editing and require structured parent-returned evidence instead.
 
 For investigation tasks also include:
 
 - instruction to inspect the relevant workspace directly when the answer depends on surrounding code or configuration context
 - instruction not to stop at the parent-prepared excerpt when additional repository files are needed to confirm the result
-- instruction to record the checked files and concrete evidence in the report
+- instruction to record the checked files and concrete evidence in the report or returned structured evidence, according to persistence mode
 
 For coding tasks also include:
 
@@ -158,26 +185,26 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 
 ## Report rules
 
-- Every dispatched sub-agent task must produce a file under `reports/`.
-- The parent agent should create the report file before dispatch whenever feasible.
-- The report must be created before the parent workflow treats a dispatched task as complete.
+- Every dispatched ordinary sub-agent task must produce a file under `reports/` using `normal_persistence`.
+- An independent-final reviewer using `deferred_attestation` is the intentional exception: reserve the report path before freeze, but do not create or edit that repository file until the caller has a passing verdict and enters report-attestation mode.
+- The parent agent should create the normal-persistence report file before dispatch whenever feasible.
 - An approval-gated proposal may be recorded before a child report exists because no child has been dispatched yet; record it in the parent-owned lifecycle evidence.
-- The parent should pre-populate the standard headings and placeholders so the `sub-agent` edits a fixed structure instead of rewriting the document.
-- The standard template includes a fixed `Dispatch profile` section. Do not require profile evidence outside that fixed structure.
-- If the `sub-agent` cannot write the report directly, the parent must write it immediately from the returned evidence.
-- Do not ask a sub-agent for ad hoc investigation, review, or implementation without a report path.
-- For review tasks, the built-in review result must be materialized into the report file before the task is considered complete.
-- For review tasks, direct report editing by the reviewer is the default path; parent-side transcription is fallback only when direct editing is not possible.
-- For review tasks, a concern that does not break the intended normal path yet should still be written to the report, but may be held instead of blocking release immediately.
+- The parent should pre-populate the standard headings and parent-owned `Dispatch profile` fields so the `sub-agent` edits a fixed structure instead of rewriting the document.
+- The standard template includes a fixed `Dispatch profile` section, but that section is parent-owned. The child must not attest to hidden spawn arguments or runtime application state.
+- If a normal-persistence `sub-agent` cannot write its child-owned report sections directly, the parent must write them immediately from the returned evidence.
+- Do not ask an ordinary sub-agent for ad hoc investigation, review, or implementation without a report path.
+- For normal review and fix verification, the built-in review result must be materialized into the report file before the task is considered complete.
+- For deferred-attestation independent final review, retain the built-in result as parent-owned evidence and do not materialize it into the reserved repository path until the passing-verdict attestation step.
+- For normal review tasks, direct report editing by the reviewer is the default path; parent-side transcription is fallback only when direct editing is not possible.
+- For review tasks, a concern that does not break the intended normal path yet should still be recorded, but may be held instead of blocking release immediately.
 - For review tasks, do not stop or replace an in-flight reviewer just because waiting took too long; keep waiting until completion unless the user explicitly says to stop.
 - Report text should be written in Japanese unless the user explicitly requests another language.
-- The `sub-agent` must preserve the existing report format: no heading renames, no section reordering, no blank-line cleanup, and no whole-file replacement.
-- Existing non-empty parent text in the report is immutable unless the parent explicitly marks it as editable.
-- Record all profile-selection inputs, proposal and approval evidence when relevant, requested and applied profile, selection source, reasons, constraints, fork policy, application status, and any escalation or fallback in the fixed `Dispatch profile` section.
+- A normal-persistence `sub-agent` must preserve the existing report format: no heading renames, no section reordering, no blank-line cleanup, and no whole-file replacement.
+- Existing non-empty parent text and all parent-owned `Dispatch profile` values are immutable to the child unless the parent explicitly marks them as editable.
 
 ## Standard report sections
 
-Use these sections in order:
+For `normal_persistence`, use these sections in order:
 
 - `# Sub-agent実行レポート`
 - `## タスク`
@@ -191,7 +218,7 @@ Use these sections in order:
 - `## 結果`
 - `## リスク`
 
-The fixed `Dispatch profile` section contains placeholders for:
+The fixed `Dispatch profile` section is parent-owned and contains:
 
 - selection inputs
 - selection source
@@ -204,9 +231,9 @@ The fixed `Dispatch profile` section contains placeholders for:
 - fork policy
 - reasons / constraints
 
-## Minimum report contents
+## Minimum evidence contents
 
-Include:
+For every dispatched task, retain:
 
 - task identifier or purpose
 - why a `sub-agent` was used
@@ -214,21 +241,30 @@ Include:
 - commands run
 - files changed or checked
 - findings summary or explicit `no findings`
-- outcome
+- outcome or verdict
 - unresolved risks or follow-up items
-- dispatch-profile evidence and runtime application status
+- dispatch-profile requested and post-runtime applied evidence
 - when applicable, `Sol xhigh` / `Sol max` proposal and explicit approval evidence
 - when applicable, reviewer continuity evidence and `reused_existing_agent_profile`
 
+For deferred attestation, these remain parent-owned lifecycle evidence until persistence is permitted.
+
 ## Outputs
 
-After this skill runs for a dispatched task, there should be:
+After this skill runs for a normal-persistence dispatched task, there should be:
 
 - a dispatched sub-agent task with explicit scope
 - a pre-created report path under `reports/`
-- a recorded delegation assessment and selected `dispatch_profile`
-- a requested and actually applied model, reasoning effort, and fork policy
+- a recorded delegation assessment and requested `dispatch_profile`
+- post-runtime `applied` and `application_status` evidence
 - report-backed evidence for the delegated work
+
+For a deferred-attestation independent reviewer, there should be:
+
+- one dispatched reviewer with explicit scope and reserved report path metadata
+- no repository report file created or edited by the reviewer
+- requested and post-runtime applied dispatch-profile evidence retained by the parent
+- structured review evidence retained by the parent for later attestation or fix-loop handling
 
 When the expensive Sol approval gate is pending, the output is instead:
 
@@ -239,14 +275,16 @@ When the expensive Sol approval gate is pending, the output is instead:
 
 ## Completion condition
 
-This skill is complete for a dispatched task only when:
+This skill is complete for a normal-persistence dispatched task only when:
 
 - the sub-agent task has been dispatched with the required prompt content
 - any required `Sol xhigh` or `Sol max` approval was obtained before dispatch
-- the requested profile has either been applied or recorded as an explicit inherited, fallback, or capability-gap state
+- post-runtime `applied` or an explicit inherited, fallback, or capability-gap state is recorded
 - the report file exists in the expected location
-- the report contains the fixed `Dispatch profile` evidence
+- the parent-owned `Dispatch profile` evidence and child-owned task evidence are complete
 - the parent has reviewed the resulting report and underlying evidence
+
+For a deferred-attestation independent reviewer, this Skill's dispatch work is complete when the reviewer returns, post-runtime profile evidence is recorded, the structured review evidence is retained by the parent, and the reserved path remains unwritten. Repository report persistence is completed later only through the caller's report-attestation flow after a passing verdict.
 
 An approval-gated task is intentionally incomplete while awaiting user approval.
 
@@ -255,6 +293,7 @@ An approval-gated task is intentionally incomplete while awaiting user approval.
 - Keep sub-agent tasks small and concrete.
 - Prefer one bounded request over one broad speculative request.
 - Reuse existing reports before dispatching duplicate work.
+- Honor `decomposition_policy: forbidden`; do not return caller-locked identity-sensitive tasks to multi-agent decomposition.
 - Use `execution-cost-stabilizer` before proposing `max`, multi-agent decomposition, wasteful reruns, or excessive parallelism.
 - Never dispatch `Sol xhigh` or `Sol max` without explicit current-task user approval.
 - Do not silently downgrade an approval-gated proposal merely to avoid asking the user; present the proposal and stop first. After rejection, recompute the profile.
@@ -263,14 +302,14 @@ An approval-gated task is intentionally incomplete while awaiting user approval.
 - Do not leave report structure up to the `sub-agent`.
 - For review and investigation tasks, prefer letting the `sub-agent` read the relevant workspace directly instead of over-constraining it to parent-curated excerpts.
 - For review tasks, prefer the model's native review behavior over inventing a custom review rubric in the prompt.
-- For review tasks, prefer direct report editing by the reviewer and use parent-side transcription only as fallback.
-- Do not treat a model or reasoning mention in `message` as an override. Pass the applied values in the actual `spawn_agent` call.
+- Do not treat a model or reasoning mention in `message` as an override. Pass the `requested` values in the actual `spawn_agent` call, not post-call `applied` values.
 - Do not combine a model or reasoning override with omitted `fork_turns` or `fork_turns: "all"`; full-history forks inherit the parent execution profile.
 - Do not silently downgrade an explicit user or repository profile override, except that an unapproved repository request for `Sol xhigh` or `Sol max` remains a proposal until the user approves it.
 - Do not keep a failed deterministic task on Luna after the work has become diagnosis or judgment.
 - If runtime rejects a hidden override argument, keep fallback execution parent-owned as defined by the spawn reference. Do not ask the delegated sub-agent to run the fallback.
-- If independently separable work would justify multi-agent execution, return it to `codex-delegation-executor` before dispatch rather than overloading one sub-agent.
+- If independently separable work would justify multi-agent execution and decomposition is allowed, return it to `codex-delegation-executor` before dispatch rather than overloading one sub-agent.
+- Never create or edit an independent-final reserved report path before the caller enters passing-verdict report-attestation mode.
 
 ## Cross-cutting rule
 
-If recurring sub-agent dispatch failures, profile misclassification, approval-gate bypasses, or report omissions appear, call `feedback-points-manager`.
+If recurring sub-agent dispatch failures, profile misclassification, approval-gate bypasses, report omissions, or attestation-boundary violations appear, call `feedback-points-manager`.

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -11,7 +11,7 @@ Standardize how work is handed to a sub-agent.
 
 Make every sub-agent task bounded, auditable, proportionately resourced, and report-backed.
 
-This Skill owns per-task model-tier, reasoning-effort, and fork-policy selection for newly dispatched sub-agents. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions unless the caller explicitly locks a task to one agent. Existing reviewer continuity is preserved by `review-enforcer` and is not treated as a new spawn.
+This Skill owns per-task model-tier, reasoning-effort, fork-policy selection, role/default-role call planning, and runtime-profile evidence for newly dispatched sub-agents. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions unless the caller explicitly forbids decomposition. Existing reviewer continuity is preserved by `review-enforcer` and is not treated as a new spawn.
 
 ## Execution owner
 
@@ -28,16 +28,18 @@ Before running this skill, identify:
 - relevant skill files the `sub-agent` must read
 - whether the `sub-agent` should inspect the repository directly beyond the parent-prepared diff or summary
 - write boundaries and validation expectations
-- task kind, work class, uncertainty, change radius, criticality, repetition, decomposability, and context need
-- explicit user or repository model, reasoning, budget, availability, or fork constraints
+- task kind, work class, uncertainty, change radius, criticality, repetition, observed decomposability, and context need
+- `decomposition_policy: allowed | forbidden` and its caller-owned reason
+- explicit user or repository model, reasoning, budget, availability, fork, or agent-role constraints
+- explicit `agent_type` when one is required, otherwise the effective default-role context
+- authoritative role/default-role configuration evidence when that role can change model or reasoning
 - whether `codex-delegation-executor` considered multi-agent decomposition and its disposition
-- whether the caller explicitly forbids decomposition and requires one agent
 - report persistence mode: `normal_persistence` or `deferred_attestation`
 - user-approval evidence when `Sol xhigh` or `Sol max` is under consideration
 
 When a caller already supplied a complete delegation assessment, reuse it. Otherwise derive the missing selection inputs from the bounded task and record that derivation. Do not require routine user confirmation of automatically selected profiles below the expensive-profile approval gate.
 
-If the caller owns an identity-sensitive lifecycle and explicitly sets `decomposition_policy: forbidden`, preserve `decomposability: single` and do not return that task for multi-agent decomposition.
+`decomposability` is an observed task signal. `decomposition_policy` is an execution constraint. If the caller forbids decomposition, preserve the observed signal and record `decomposition_disposition: prohibited_by_caller_policy`; do not rewrite the signal to `single`.
 
 ## Run this skill
 
@@ -49,63 +51,65 @@ Run this skill whenever:
 - independent verification is required through a new sub-agent
 - a bounded implementation or investigation task is handed off
 
-Do not create a new reviewer merely because an existing reviewer moves from initial review to fix verification or bounded closure. `review-enforcer` owns that reuse and preserves the original applied profile.
+Do not create a new reviewer merely because an existing reviewer moves from initial review to fix verification or bounded closure. `review-enforcer` owns that reuse and preserves the original profile/observability evidence.
 
 ## Required flow
 
 1. define the exact task type and why a new `sub-agent` is being used
-2. define the scope, non-goals, expected outputs, write ownership, decomposition policy, and report persistence mode
-3. classify the task signals required by [references/agent-profile-selection.md](references/agent-profile-selection.md)
+2. define scope, non-goals, expected outputs, write ownership, decomposition policy, report persistence mode, and applicable explicit/default agent role
+3. classify truthful task signals required by [references/agent-profile-selection.md](references/agent-profile-selection.md), including observed `decomposability` separately from `decomposition_policy`
 4. select and record one ordinary `dispatch_profile`, return independently separable work to `codex-delegation-executor` only when decomposition is allowed, or create an approval-gated `proposed_profile`
 5. if the proposed profile is `Sol xhigh` or `Sol max`, present the proposal and cost notice to the user and stop before dispatch unless explicit current-task approval already exists
 6. after approval, promote the approved proposal to `requested`; after rejection, recompute with `Sol xhigh` and `Sol max` excluded
-7. read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md) and prepare the runtime call plan from `requested`, model availability, and fork constraints; do not populate `applied` before runtime evidence exists
-8. identify which skill files the `sub-agent` must read
-9. call `report-output-manager` and determine report handling:
-   - for `normal_persistence`, reserve the path and create the standard report file before dispatch
-   - for `deferred_attestation`, reserve the exact path only; do not create, pre-populate, or edit the repository report file before or during review
-10. for `normal_persistence`, pre-populate the fixed report structure and parent-owned `Dispatch profile` fields before dispatch
-11. tell the `sub-agent` to read the specified skill files before executing
-12. give the child the report instructions for the selected persistence mode
-13. dispatch using the `requested` model and reasoning effort as actual tool-call arguments when an override is permitted; when full-history inheritance is required, omit the incompatible override as defined by the spawn reference
-14. after the spawn call or fallback attempt, record `applied` and `application_status` from actual runtime evidence, inheritance, rejection, or fallback; never infer `applied` from `requested`
-15. for `normal_persistence`, update the parent-owned `Dispatch profile` fields with the post-call runtime evidence and require the child or parent to complete the remaining report sections
-16. for `deferred_attestation`, retain the reviewer output and dispatch-profile evidence as parent-owned lifecycle evidence without writing the reserved report path; only the caller's passing-verdict attestation flow may persist it later
-17. do not treat the delegated task as complete until the applicable report/evidence contract, runtime application status, and parent adjudication are satisfied
+7. read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md) and prepare the runtime call plan from `requested`, model availability, fork constraints, and explicit/default agent-role configuration
+8. derive `role_plan` and `planned_runtime_profile`; if the role changes or locks model/reasoning, return the plan through the selector and re-run floor/approval checks before spawn
+9. if role/default-role profile impact cannot be inspected well enough to guarantee the expensive-profile gate, record a role-profile capability gap and stop before dispatch
+10. keep `applied: null` while planning; identify which skill files the `sub-agent` must read
+11. call `report-output-manager` in the correct phase:
+    - for `normal_persistence`, use normal persistence, reserve the path, and create the standard report file before dispatch
+    - for `deferred_attestation`, use the independent-final reservation phase only; reserve the exact path as metadata, do not invoke `report-writer`, and do not create/pre-populate/edit the repository report file
+12. for `normal_persistence`, pre-populate the fixed report structure and parent-owned `Dispatch profile` fields available before spawn
+13. tell the `sub-agent` to read the specified skill files before executing and give it the report instructions for the selected persistence mode
+14. dispatch using the `requested` model/reasoning values and explicit `agent_type` when applicable; when using the runtime default role, omit `agent_type` but preserve that default role in `role_plan`; when full-history inheritance is required, follow the spawn reference
+15. after spawn/fallback, inspect parent-visible runtime evidence; record exact `applied` only when a trustworthy final profile snapshot or equivalent exact proof is observable
+16. if spawn succeeds but final model/reasoning is hidden, keep `applied: null`, record `application_status: spawn_succeeded_profile_unverified`, and preserve `profile_observability: final_profile_hidden`
+17. for `normal_persistence`, update parent-owned `Dispatch profile` fields with post-call evidence and require the child or parent to complete remaining report sections
+18. for `deferred_attestation`, retain reviewer output and dispatch-profile evidence as parent-owned lifecycle evidence without writing the reserved report path; only the caller's passing-verdict attestation flow may persist it later
+19. do not treat the delegated task as complete until the applicable report/evidence contract, runtime application/observability status, and parent adjudication are satisfied
 
-Read the report template from `report-output-manager` when `normal_persistence` applies:
+Read the report template from `report-output-manager` only when `normal_persistence` applies:
 
 - [../report-output-manager/references/sub-agent-report-template.md](../report-output-manager/references/sub-agent-report-template.md)
 
 ## Profile-selection contract
 
-Select the model tier and reasoning effort independently.
+Select model tier and reasoning effort independently.
 
 - use Luna only for low-uncertainty, local, ordinary-criticality, deterministic work
 - use Terra for ordinary bounded technical work
 - use Sol for judgment-heavy, ambiguous, high-criticality, cross-system, design, difficult debugging, and review work
-- use `max` only for one exceptionally difficult, non-decomposable problem
+- use `max` only for one exceptionally difficult, intrinsically non-decomposable problem; caller policy forbidding decomposition does not satisfy that condition
 - treat multi-agent or article-described `Ultra` execution as a decomposition strategy owned by `codex-delegation-executor`, never as a `reasoning_effort` value
 - choose the highest floor required by task kind, uncertainty, change radius, and criticality
 - preserve explicit user and repository overrides according to the precedence in the reference
-- honor a caller-owned `decomposition_policy: forbidden`; such a task stays one agent even when its review scope is broad
+- honor `decomposition_policy: forbidden` without falsifying observed `decomposability`
 
 ### Expensive Sol approval gate
 
 `Sol xhigh` and `Sol max` are not automatic dispatch profiles.
 
-When either becomes the calculated profile:
+When either becomes the calculated initial or role-adjusted profile:
 
 - keep it in `proposed_profile`, not `requested`
 - explain why `Sol high` is insufficient
 - tell the user that the higher reasoning effort increases execution cost
-- ask for explicit approval to use the proposed profile
-- stop the workflow before spawning that agent
-- do not treat repository policy, a prior unrelated approval, silence, or inferred preference as approval
+- ask for explicit current-task approval
+- stop before spawning that agent
+- do not treat repository policy, prior unrelated approval, silence, or inferred preference as approval
 
 An explicit current-task instruction from the user that directly requests `Sol xhigh` or `Sol max` satisfies the gate. If the user rejects the proposal, recompute a non-gated profile; normally the upper automatic fallback is `Sol high`.
 
-This gate applies to all task kinds, including independent final review and release audit, and has priority over repository policy and automatic selection.
+The same gate must be re-run when role/default-role planning raises a cheaper requested profile to Sol `xhigh` or Sol `max`.
 
 For newly created review agents, use these defaults:
 
@@ -113,11 +117,11 @@ For newly created review agents, use these defaults:
 - focused fix verification when continuity reuse is unavailable: Terra with `high`
 - independent final review or release audit: propose Sol with `xhigh`, then stop for explicit user approval before dispatch
 
-When `review-enforcer` reuses an existing normal or independent reviewer, do not apply these new-agent defaults. Preserve the original applied profile and record `application_status: reused_existing_agent_profile` in the review evidence.
+When `review-enforcer` reuses an existing normal or independent reviewer, do not apply these new-agent defaults. Preserve the original profile evidence and its observability state; record `application_status: reused_existing_agent_profile`.
 
 For investigation, do not use Luna for open-ended or root-cause work. A deterministic evidence-collection task may use Luna, but a failure or conflicting evidence must be reclassified before retrying.
 
-Record `proposed`, `requested`, and `applied` distinctly when the approval gate is relevant. `requested` is known before spawn; `applied` is a post-runtime fact. A full-history fork inherits the parent profile; runtime rejection or fallback is a capability state, not evidence that the requested override was applied.
+`requested` and `planned_runtime_profile` are pre-spawn evidence. `applied` is a post-runtime fact and may remain unknown when the runtime hides final model/reasoning metadata.
 
 ## Required prompt content
 
@@ -128,79 +132,75 @@ Every new sub-agent request must include:
 - explicit non-goals
 - explicit instruction not to run `codex exec`, nested Codex, or equivalent agent-spawning inside the sub-agent task
 - explicit instruction not to re-enter `development-orchestrator` or any other parent-owned workflow unless the parent explicitly named that workflow as part of the delegated task
-- an explicit fork policy
-- explicit decomposition policy when the caller requires a single agent
+- explicit fork policy
+- decomposition policy when the caller constrains execution
 - skill names and file paths that must be read first
 - validation commands or evidence expectations
 - report persistence mode
 - required final output shape
 
-The requested model and reasoning effort belong only in actual spawn parameters. Do not rely on model names written in the prompt to configure execution. The prompt may state task-local cost or quality constraints, but it must not claim an unapplied runtime profile.
+The requested model/reasoning and agent role belong in actual spawn planning/tool arguments, not merely the message. Do not tell the child it is running an exact final profile when the parent cannot observe that fact.
 
 ### Normal-persistence prompt additions
 
 For `normal_persistence`, also include:
 
 - report path
-- instruction to read the pre-created report file first and preserve its heading order, spacing, and existing filled text
-- instruction to fill only child-owned blank sections or placeholder values instead of rewriting the full report
-- instruction not to modify parent-owned `Dispatch profile` values, especially `requested`, `applied`, `application status`, approval, and continuity evidence
+- instruction to read the pre-created report file first and preserve heading order, spacing, and existing filled text
+- instruction to fill only child-owned blank sections/placeholders instead of rewriting the full report
+- instruction not to modify parent-owned `Dispatch profile` values
 
-The parent owns the complete `Dispatch profile` section because the child cannot observe hidden spawn arguments or runtime application evidence.
+The parent owns the complete `Dispatch profile` section because the child cannot observe hidden spawn arguments, role application, or final runtime profile state.
 
 ### Deferred-attestation prompt additions
 
 For `deferred_attestation`, also include:
 
-- the reserved report path as metadata only
+- reserved report path as metadata only
 - explicit instruction that the reserved repository report file does not yet exist and must not be created or edited by the reviewer
 - instruction to return structured findings, coverage, commands/evidence, verdict, risks, and unexplored areas to the parent
-- instruction that the parent will retain this output until the caller's report-attestation flow decides whether it may be persisted
+- instruction that the parent will retain this output until passing-verdict attestation decides whether it may be persisted
 
 For review tasks also include:
 
-- the review mode and criticality signals used by the profile selector
-- explicit instruction to perform a code review using the built-in review behavior
+- review mode and criticality signals used by the profile selector
+- explicit instruction to perform a code review using built-in review behavior
 - instruction to return findings first, ordered by severity
 - instruction to include file/line references when available
 - instruction to say explicitly when no findings were found
 - instruction to distinguish blocking normal-path problems, user-confirmation-required capability gaps, and non-blocking concerns that should only be recorded and held
-- instruction to inspect the relevant workspace directly when surrounding code context is needed, instead of relying only on a parent-prepared diff summary
+- instruction to inspect the relevant workspace directly when surrounding context is needed
 
-For normal-persistence review tasks, require direct editing of the child-owned report sections. For deferred-attestation independent review, prohibit repository report editing and require structured parent-returned evidence instead.
+For normal-persistence review tasks, require direct editing of child-owned report sections. For deferred-attestation independent review, prohibit repository report editing and require structured parent-returned evidence instead.
 
 For investigation tasks also include:
 
-- instruction to inspect the relevant workspace directly when the answer depends on surrounding code or configuration context
-- instruction not to stop at the parent-prepared excerpt when additional repository files are needed to confirm the result
-- instruction to record the checked files and concrete evidence in the report or returned structured evidence, according to persistence mode
+- instruction to inspect relevant workspace context directly
+- instruction not to stop at a parent-prepared excerpt when more repository evidence is needed
+- instruction to record checked files and concrete evidence in the report or returned structured evidence, according to persistence mode
 
 For coding tasks also include:
 
-- owned files or modules
+- owned files/modules
 - instruction not to revert unrelated changes
-- instruction to list changed files in the final response
+- instruction to list changed files in final output
 
-When a relevant skill exists, do not paraphrase it loosely as the only guidance. Tell the `sub-agent` to read the actual `SKILL.md` path and then restate only the most critical task-local constraints.
+When a relevant skill exists, tell the `sub-agent` to read the actual `SKILL.md` path; do not rely only on paraphrased guidance.
 
 ## Report rules
 
 - Every dispatched ordinary sub-agent task must produce a file under `reports/` using `normal_persistence`.
-- An independent-final reviewer using `deferred_attestation` is the intentional exception: reserve the report path before freeze, but do not create or edit that repository file until the caller has a passing verdict and enters report-attestation mode.
-- The parent agent should create the normal-persistence report file before dispatch whenever feasible.
-- An approval-gated proposal may be recorded before a child report exists because no child has been dispatched yet; record it in the parent-owned lifecycle evidence.
-- The parent should pre-populate the standard headings and parent-owned `Dispatch profile` fields so the `sub-agent` edits a fixed structure instead of rewriting the document.
-- The standard template includes a fixed `Dispatch profile` section, but that section is parent-owned. The child must not attest to hidden spawn arguments or runtime application state.
-- If a normal-persistence `sub-agent` cannot write its child-owned report sections directly, the parent must write them immediately from the returned evidence.
-- Do not ask an ordinary sub-agent for ad hoc investigation, review, or implementation without a report path.
-- For normal review and fix verification, the built-in review result must be materialized into the report file before the task is considered complete.
-- For deferred-attestation independent final review, retain the built-in result as parent-owned evidence and do not materialize it into the reserved repository path until the passing-verdict attestation step.
-- For normal review tasks, direct report editing by the reviewer is the default path; parent-side transcription is fallback only when direct editing is not possible.
-- For review tasks, a concern that does not break the intended normal path yet should still be recorded, but may be held instead of blocking release immediately.
-- For review tasks, do not stop or replace an in-flight reviewer just because waiting took too long; keep waiting until completion unless the user explicitly says to stop.
-- Report text should be written in Japanese unless the user explicitly requests another language.
-- A normal-persistence `sub-agent` must preserve the existing report format: no heading renames, no section reordering, no blank-line cleanup, and no whole-file replacement.
-- Existing non-empty parent text and all parent-owned `Dispatch profile` values are immutable to the child unless the parent explicitly marks them as editable.
+- An independent-final reviewer using `deferred_attestation` is the intentional exception: reserve the path before freeze, but do not create/edit the repository file until passing-verdict attestation.
+- The parent should create the normal-persistence report file before dispatch whenever feasible.
+- An approval-gated proposal or pre-dispatch capability gap may be recorded before a child report exists because no child was dispatched.
+- The parent should pre-populate standard headings and parent-owned `Dispatch profile` fields.
+- The fixed `Dispatch profile` section is parent-owned. The child must not attest to hidden spawn arguments, role application, or final runtime profile.
+- If a normal-persistence child cannot write child-owned sections directly, the parent must write them immediately from returned evidence.
+- For normal review/fix verification, built-in review results must be materialized before the task is complete.
+- For deferred-attestation independent final review, retain the result as parent-owned evidence and do not materialize it until passing-verdict attestation.
+- Do not stop/replace an in-flight reviewer merely because it is slow unless the user explicitly says to stop.
+- Report text should be Japanese unless the user requests another language.
+- Normal-persistence children must preserve report structure and existing parent text.
 
 ## Standard report sections
 
@@ -218,34 +218,39 @@ For `normal_persistence`, use these sections in order:
 - `## 結果`
 - `## リスク`
 
-The fixed `Dispatch profile` section is parent-owned and contains:
+The fixed parent-owned `Dispatch profile` section contains:
 
-- selection inputs
+- selection inputs, including observed decomposability and separate decomposition policy/disposition
 - selection source
 - proposed profile
-- approval status / evidence
+- approval status/evidence
 - requested profile
-- applied profile
+- explicit/default agent role plan and role-config evidence
+- planned runtime profile
+- applied profile, only when exactly observed
 - application status
+- runtime profile observability
 - reviewer continuity
 - fork policy
-- reasons / constraints
+- reasons/constraints
 
 ## Minimum evidence contents
 
 For every dispatched task, retain:
 
-- task identifier or purpose
-- why a `sub-agent` was used
+- task identifier/purpose
+- why a sub-agent was used
 - scope handled
 - commands run
-- files changed or checked
+- files changed/checked
 - findings summary or explicit `no findings`
-- outcome or verdict
-- unresolved risks or follow-up items
-- dispatch-profile requested and post-runtime applied evidence
-- when applicable, `Sol xhigh` / `Sol max` proposal and explicit approval evidence
-- when applicable, reviewer continuity evidence and `reused_existing_agent_profile`
+- outcome/verdict
+- unresolved risks/follow-up
+- truthful decomposability plus decomposition policy/disposition
+- requested and role-adjusted planning evidence
+- exact applied profile when observable, otherwise explicit unverified state
+- when applicable, Sol `xhigh` / Sol `max` proposal and approval evidence
+- when applicable, reviewer continuity evidence
 
 For deferred attestation, these remain parent-owned lifecycle evidence until persistence is permitted.
 
@@ -255,61 +260,64 @@ After this skill runs for a normal-persistence dispatched task, there should be:
 
 - a dispatched sub-agent task with explicit scope
 - a pre-created report path under `reports/`
-- a recorded delegation assessment and requested `dispatch_profile`
-- post-runtime `applied` and `application_status` evidence
-- report-backed evidence for the delegated work
+- recorded delegation assessment, requested profile, role plan, and planned runtime profile
+- post-runtime exact applied evidence or explicit unverified/inherited/fallback/capability-gap state
+- report-backed task evidence
 
 For a deferred-attestation independent reviewer, there should be:
 
-- one dispatched reviewer with explicit scope and reserved report path metadata
-- no repository report file created or edited by the reviewer
-- requested and post-runtime applied dispatch-profile evidence retained by the parent
-- structured review evidence retained by the parent for later attestation or fix-loop handling
+- one dispatched reviewer with explicit scope and reserved report-path metadata
+- no repository report file created/edited by the reviewer
+- requested/role-plan/runtime-observability evidence retained by the parent
+- structured review evidence retained by the parent for later attestation/fix-loop handling
 
-When the expensive Sol approval gate is pending, the output is instead:
+When the expensive Sol approval gate is pending, output instead includes:
 
-- a recorded `proposed_profile`
-- cost and justification notice
+- recorded `proposed_profile`
+- cost/justification notice
 - `application_status: awaiting_user_approval`
 - no dispatch using that profile
 
+When role/default-role impact cannot be resolved safely before dispatch, output instead includes:
+
+- `application_status: capability_gap`
+- role/default-role identity and missing evidence
+- no dispatch
+
 ## Completion condition
 
-This skill is complete for a normal-persistence dispatched task only when:
+A normal-persistence dispatched task completes only when:
 
-- the sub-agent task has been dispatched with the required prompt content
-- any required `Sol xhigh` or `Sol max` approval was obtained before dispatch
-- post-runtime `applied` or an explicit inherited, fallback, or capability-gap state is recorded
-- the report file exists in the expected location
-- the parent-owned `Dispatch profile` evidence and child-owned task evidence are complete
-- the parent has reviewed the resulting report and underlying evidence
+- required prompt content was used
+- any required initial or role-adjusted expensive-profile approval preceded dispatch
+- post-runtime exact applied evidence **or** an explicit unverified/inherited/fallback/capability-gap state is recorded
+- report file exists in expected location
+- parent-owned dispatch evidence and child-owned task evidence are complete
+- parent reviewed the result/evidence
 
-For a deferred-attestation independent reviewer, this Skill's dispatch work is complete when the reviewer returns, post-runtime profile evidence is recorded, the structured review evidence is retained by the parent, and the reserved path remains unwritten. Repository report persistence is completed later only through the caller's report-attestation flow after a passing verdict.
+For a deferred-attestation independent reviewer, dispatch work completes when the reviewer returns, runtime profile observability state is recorded, structured review evidence is retained by the parent, and the reserved path remains unwritten. Repository report persistence completes later only through passing-verdict report attestation.
 
-An approval-gated task is intentionally incomplete while awaiting user approval.
+An approval-gated or pre-dispatch role-capability-gap task is intentionally incomplete.
 
 ## Rules
 
 - Keep sub-agent tasks small and concrete.
 - Prefer one bounded request over one broad speculative request.
 - Reuse existing reports before dispatching duplicate work.
-- Honor `decomposition_policy: forbidden`; do not return caller-locked identity-sensitive tasks to multi-agent decomposition.
+- Honor `decomposition_policy: forbidden` without rewriting observed `decomposability`.
+- Never use a decomposition prohibition as evidence that a problem is intrinsically non-decomposable for `max` selection.
 - Use `execution-cost-stabilizer` before proposing `max`, multi-agent decomposition, wasteful reruns, or excessive parallelism.
-- Never dispatch `Sol xhigh` or `Sol max` without explicit current-task user approval.
-- Do not silently downgrade an approval-gated proposal merely to avoid asking the user; present the proposal and stop first. After rejection, recompute the profile.
-- Do not make a sub-agent run `codex exec`, nested Codex, or equivalent agent-spawning workflows inside the delegated task.
-- Do not let a sub-agent re-run `development-orchestrator` or other parent-owned workflow entry skills just because they exist in the repo; the sub-agent should execute only the delegated task and the explicitly named supporting skills.
-- Do not leave report structure up to the `sub-agent`.
-- For review and investigation tasks, prefer letting the `sub-agent` read the relevant workspace directly instead of over-constraining it to parent-curated excerpts.
-- For review tasks, prefer the model's native review behavior over inventing a custom review rubric in the prompt.
-- Do not treat a model or reasoning mention in `message` as an override. Pass the `requested` values in the actual `spawn_agent` call, not post-call `applied` values.
-- Do not combine a model or reasoning override with omitted `fork_turns` or `fork_turns: "all"`; full-history forks inherit the parent execution profile.
-- Do not silently downgrade an explicit user or repository profile override, except that an unapproved repository request for `Sol xhigh` or `Sol max` remains a proposal until the user approves it.
-- Do not keep a failed deterministic task on Luna after the work has become diagnosis or judgment.
-- If runtime rejects a hidden override argument, keep fallback execution parent-owned as defined by the spawn reference. Do not ask the delegated sub-agent to run the fallback.
-- If independently separable work would justify multi-agent execution and decomposition is allowed, return it to `codex-delegation-executor` before dispatch rather than overloading one sub-agent.
-- Never create or edit an independent-final reserved report path before the caller enters passing-verdict report-attestation mode.
+- Never dispatch Sol `xhigh` or Sol `max` without explicit current-task user approval, including when an agent role/default role raises the planned runtime profile to those efforts.
+- If role/default-role impact on model/reasoning is unknown, stop before dispatch rather than assuming the requested profile survives role application.
+- Do not make a sub-agent run nested Codex or parent-owned orchestration workflows.
+- Do not leave report structure up to the child.
+- Do not treat a model/reasoning mention in `message` as an override.
+- Pass pre-spawn `requested` values to spawn; never use post-runtime `applied` as call input.
+- Do not claim exact `applied` merely because spawn succeeded. When final profile metadata is hidden, record `spawn_succeeded_profile_unverified` with `applied: null`.
+- Full-history behavior, role application, rejection, and fallback must follow the spawn reference.
+- If independently separable work would justify multi-agent execution and decomposition is allowed, return it to `codex-delegation-executor`; if decomposition is forbidden, preserve the decomposability observation and record the suppression.
+- Never create/edit an independent-final reserved report path before passing-verdict attestation.
 
 ## Cross-cutting rule
 
-If recurring sub-agent dispatch failures, profile misclassification, approval-gate bypasses, report omissions, or attestation-boundary violations appear, call `feedback-points-manager`.
+If recurring sub-agent dispatch failures, profile misclassification, approval-gate bypasses, role-profile uncertainty, report omissions, or attestation-boundary violations appear, call `feedback-points-manager`.

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -11,7 +11,7 @@ Standardize how work is handed to a sub-agent.
 
 Make every sub-agent task bounded, auditable, proportionately resourced, and report-backed.
 
-This Skill owns per-task model-tier, reasoning-effort, fork-policy selection, role/default-role call planning, and runtime-profile evidence for newly dispatched sub-agents. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions unless the caller explicitly forbids decomposition. Existing reviewer continuity is preserved by `review-enforcer` and is not treated as a new spawn.
+This Skill owns per-task model-tier, reasoning-effort, fork-policy selection, role/default-role call planning, and runtime-profile evidence for newly dispatched sub-agents. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions unless the caller explicitly forbids decomposition. Existing reviewer continuity and independent-final report-path reservation are owned by `review-enforcer` and are not treated as new spawn-side decisions.
 
 ## Execution owner
 
@@ -35,11 +35,14 @@ Before running this skill, identify:
 - authoritative role/default-role configuration evidence when that role can change model or reasoning
 - whether `codex-delegation-executor` considered multi-agent decomposition and its disposition
 - report persistence mode: `normal_persistence` or `deferred_attestation`
+- for `deferred_attestation`, `pre_reserved_report_path`, `reservation_owner`, `reservation_identity`, and evidence that the reservation was created before the reviewed implementation HEAD was frozen without creating/editing the repository file
 - user-approval evidence when `Sol xhigh` or `Sol max` is under consideration
 
 When a caller already supplied a complete delegation assessment, reuse it. Otherwise derive the missing selection inputs from the bounded task and record that derivation. Do not require routine user confirmation of automatically selected profiles below the expensive-profile approval gate.
 
 `decomposability` is an observed task signal. `decomposition_policy` is an execution constraint. If the caller forbids decomposition, preserve the observed signal and record `decomposition_disposition: prohibited_by_caller_policy`; do not rewrite the signal to `single`.
+
+For independent-final `deferred_attestation`, `review-enforcer` is the reservation owner. This Skill must receive and reuse its pre-freeze reservation. Missing, ambiguous, post-freeze, or already-materialized reservation evidence is a lifecycle blocker; do not create a second reservation to compensate.
 
 ## Run this skill
 
@@ -65,17 +68,17 @@ Do not create a new reviewer merely because an existing reviewer moves from init
 8. derive `role_plan` and `planned_runtime_profile`; if the role changes or locks model/reasoning, return the plan through the selector and re-run floor/approval checks before spawn
 9. if role/default-role profile impact cannot be inspected well enough to guarantee the expensive-profile gate, record a role-profile capability gap and stop before dispatch
 10. keep `applied: null` while planning; identify which skill files the `sub-agent` must read
-11. call `report-output-manager` in the correct phase:
-    - for `normal_persistence`, use normal persistence, reserve the path, and create the standard report file before dispatch
-    - for `deferred_attestation`, use the independent-final reservation phase only; reserve the exact path as metadata, do not invoke `report-writer`, and do not create/pre-populate/edit the repository report file
+11. resolve report handling without creating duplicate reservations:
+    - for `normal_persistence`, call `report-output-manager` normal-persistence phase, reserve the path, and create the standard report file before dispatch
+    - for independent-final `deferred_attestation`, do **not** call reservation-only phase here; validate and inherit the exact `pre_reserved_report_path` / `reservation_identity` supplied by `review-enforcer`, verify `reservation_owner: review-enforcer`, verify the path was reserved pre-freeze as metadata only, and verify the repository file still does not exist or has not changed
 12. for `normal_persistence`, pre-populate the fixed report structure and parent-owned `Dispatch profile` fields available before spawn
 13. tell the `sub-agent` to read the specified skill files before executing and give it the report instructions for the selected persistence mode
 14. dispatch using the `requested` model/reasoning values and explicit `agent_type` when applicable; when using the runtime default role, omit `agent_type` but preserve that default role in `role_plan`; when full-history inheritance is required, follow the spawn reference
 15. after spawn/fallback, inspect parent-visible runtime evidence; record exact `applied` only when a trustworthy final profile snapshot or equivalent exact proof is observable
 16. if spawn succeeds but final model/reasoning is hidden, keep `applied: null`, record `application_status: spawn_succeeded_profile_unverified`, and preserve `profile_observability: final_profile_hidden`
 17. for `normal_persistence`, update parent-owned `Dispatch profile` fields with post-call evidence and require the child or parent to complete remaining report sections
-18. for `deferred_attestation`, retain reviewer output and dispatch-profile evidence as parent-owned lifecycle evidence without writing the reserved report path; only the caller's passing-verdict attestation flow may persist it later
-19. do not treat the delegated task as complete until the applicable report/evidence contract, runtime application/observability status, and parent adjudication are satisfied
+18. for `deferred_attestation`, retain reviewer output, inherited reservation identity, and dispatch-profile evidence as parent-owned lifecycle evidence without writing the reserved report path; only `review-enforcer`'s passing-verdict attestation flow may persist it later
+19. do not treat the delegated task as complete until the applicable report/evidence contract, runtime application/observability status, reservation identity, and parent adjudication are satisfied
 
 Read the report template from `report-output-manager` only when `normal_persistence` applies:
 
@@ -156,10 +159,10 @@ The parent owns the complete `Dispatch profile` section because the child cannot
 
 For `deferred_attestation`, also include:
 
-- reserved report path as metadata only
+- the inherited `pre_reserved_report_path`, `reservation_owner`, and `reservation_identity` as metadata only
 - explicit instruction that the reserved repository report file does not yet exist and must not be created or edited by the reviewer
 - instruction to return structured findings, coverage, commands/evidence, verdict, risks, and unexplored areas to the parent
-- instruction that the parent will retain this output until passing-verdict attestation decides whether it may be persisted
+- instruction that the parent will retain this output until `review-enforcer`'s passing-verdict attestation decides whether it may be persisted
 
 For review tasks also include:
 
@@ -190,14 +193,14 @@ When a relevant skill exists, tell the `sub-agent` to read the actual `SKILL.md`
 ## Report rules
 
 - Every dispatched ordinary sub-agent task must produce a file under `reports/` using `normal_persistence`.
-- An independent-final reviewer using `deferred_attestation` is the intentional exception: reserve the path before freeze, but do not create/edit the repository file until passing-verdict attestation.
+- An independent-final reviewer using `deferred_attestation` is the intentional exception: `review-enforcer` reserves the path before freeze; this Skill reuses that exact reservation and does not create/edit/re-reserve the repository file until passing-verdict attestation.
 - The parent should create the normal-persistence report file before dispatch whenever feasible.
 - An approval-gated proposal or pre-dispatch capability gap may be recorded before a child report exists because no child was dispatched.
 - The parent should pre-populate standard headings and parent-owned `Dispatch profile` fields.
 - The fixed `Dispatch profile` section is parent-owned. The child must not attest to hidden spawn arguments, role application, or final runtime profile.
 - If a normal-persistence child cannot write child-owned sections directly, the parent must write them immediately from returned evidence.
 - For normal review/fix verification, built-in review results must be materialized before the task is complete.
-- For deferred-attestation independent final review, retain the result as parent-owned evidence and do not materialize it until passing-verdict attestation.
+- For deferred-attestation independent final review, retain the result and reservation identity as parent-owned evidence and do not materialize it until passing-verdict attestation.
 - Do not stop/replace an in-flight reviewer merely because it is slow unless the user explicitly says to stop.
 - Report text should be Japanese unless the user requests another language.
 - Normal-persistence children must preserve report structure and existing parent text.
@@ -249,6 +252,7 @@ For every dispatched task, retain:
 - truthful decomposability plus decomposition policy/disposition
 - requested and role-adjusted planning evidence
 - exact applied profile when observable, otherwise explicit unverified state
+- report persistence mode and reservation identity when deferred
 - when applicable, Sol `xhigh` / Sol `max` proposal and approval evidence
 - when applicable, reviewer continuity evidence
 
@@ -266,7 +270,8 @@ After this skill runs for a normal-persistence dispatched task, there should be:
 
 For a deferred-attestation independent reviewer, there should be:
 
-- one dispatched reviewer with explicit scope and reserved report-path metadata
+- one dispatched reviewer with explicit scope
+- one inherited pre-freeze report reservation owned by `review-enforcer`; no second reservation
 - no repository report file created/edited by the reviewer
 - requested/role-plan/runtime-observability evidence retained by the parent
 - structured review evidence retained by the parent for later attestation/fix-loop handling
@@ -295,7 +300,7 @@ A normal-persistence dispatched task completes only when:
 - parent-owned dispatch evidence and child-owned task evidence are complete
 - parent reviewed the result/evidence
 
-For a deferred-attestation independent reviewer, dispatch work completes when the reviewer returns, runtime profile observability state is recorded, structured review evidence is retained by the parent, and the reserved path remains unwritten. Repository report persistence completes later only through passing-verdict report attestation.
+For a deferred-attestation independent reviewer, dispatch work completes when the inherited pre-freeze reservation identity is validated, no duplicate reservation was created, the reviewer returns, runtime profile observability state is recorded, structured review evidence is retained by the parent, and the reserved path remains unwritten. Repository report persistence completes later only through `review-enforcer`'s passing-verdict report attestation.
 
 An approval-gated or pre-dispatch role-capability-gap task is intentionally incomplete.
 
@@ -317,7 +322,8 @@ An approval-gated or pre-dispatch role-capability-gap task is intentionally inco
 - Full-history behavior, role application, rejection, and fallback must follow the spawn reference.
 - If independently separable work would justify multi-agent execution and decomposition is allowed, return it to `codex-delegation-executor`; if decomposition is forbidden, preserve the decomposability observation and record the suppression.
 - Never create/edit an independent-final reserved report path before passing-verdict attestation.
+- Never create a second deferred-attestation reservation when `review-enforcer` already supplied the pre-freeze reservation; ambiguity is a blocker, not a reason to re-reserve.
 
 ## Cross-cutting rule
 
-If recurring sub-agent dispatch failures, profile misclassification, approval-gate bypasses, role-profile uncertainty, report omissions, or attestation-boundary violations appear, call `feedback-points-manager`.
+If recurring sub-agent dispatch failures, profile misclassification, approval-gate bypasses, role-profile uncertainty, report omissions, duplicate reservations, or attestation-boundary violations appear, call `feedback-points-manager`.

--- a/skills/sub-agent-task-manager/SKILL.md
+++ b/skills/sub-agent-task-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sub-agent-task-manager
-description: Create and dispatch bounded sub-agent tasks with explicit scope, ownership, and mandatory report output. Use whenever investigation, implementation, review, verification, or evidence work is handed to a sub-agent.
+description: Create and dispatch bounded sub-agent tasks with explicit scope, adaptive model and reasoning selection, ownership, and mandatory report output. Use whenever investigation, implementation, review, verification, or evidence work is handed to a sub-agent.
 ---
 
 # Sub-Agent Task Manager
@@ -9,7 +9,9 @@ Standardize how work is handed to a sub-agent.
 
 ## Goal
 
-Make every sub-agent task bounded, auditable, and report-backed.
+Make every sub-agent task bounded, auditable, proportionately resourced, and report-backed.
+
+This Skill owns per-task model-tier, reasoning-effort, and fork-policy selection. It does not decide whether the parent should delegate or how independent workstreams should be decomposed; `codex-delegation-executor` owns those decisions.
 
 ## Execution owner
 
@@ -26,8 +28,11 @@ Before running this skill, identify:
 - relevant skill files the `sub-agent` must read
 - whether the `sub-agent` should inspect the repository directly beyond the parent-prepared diff or summary
 - write boundaries and validation expectations
-- dispatch model, reasoning effort, and fork policy
-- confirmation source for an implementation `sub-agent` model when implementation work is delegated
+- task kind, work class, uncertainty, change radius, criticality, repetition, decomposability, and context need
+- explicit user or repository model, reasoning, budget, availability, or fork constraints
+- whether `codex-delegation-executor` considered multi-agent decomposition and its disposition
+
+When a caller already supplied a complete delegation assessment, reuse it. Otherwise derive the missing selection inputs from the bounded task and record that derivation. Do not require routine user confirmation of an automatically selected implementation model.
 
 ## Run this skill
 
@@ -41,21 +46,44 @@ Run this skill whenever:
 ## Required flow
 
 1. define the exact task type and why a `sub-agent` is being used
-2. define the scope, non-goals, and expected outputs
-3. receive the caller-selected dispatch model, reasoning effort, and fork policy before drafting the request; for implementation work, require the `development-orchestrator` user-confirmed model
-4. when selecting or applying a model or reasoning override, read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md)
-5. identify which skill files the `sub-agent` must read
-6. define write ownership and file boundaries when edits are allowed
+2. define the scope, non-goals, expected outputs, and write ownership
+3. classify the task signals required by [references/agent-profile-selection.md](references/agent-profile-selection.md)
+4. select and record one `dispatch_profile`, or return independently separable work to `codex-delegation-executor` before dispatch
+5. read [references/spawn-agent-model-overrides.md](references/spawn-agent-model-overrides.md) and resolve the requested profile into an applied runtime profile
+6. identify which skill files the `sub-agent` must read
 7. call `report-output-manager` and decide the report path before dispatch
 8. create the report file before dispatch using the standard template
 9. tell the `sub-agent` to read the specified skill files before executing
 10. tell the `sub-agent` to read that exact report file first and fill only the intended blank sections or placeholder values
-11. require commands run, changed files, outcome, and unresolved risks in the report
-12. do not treat the delegated task as complete until the report exists and has been reviewed
+11. require commands run, changed files, outcome, unresolved risks, and dispatch-profile evidence in the report
+12. dispatch with the applied model and reasoning effort as actual tool-call arguments and the selected fork policy
+13. do not treat the delegated task as complete until the report exists, the runtime application status is recorded, and the parent has reviewed the result
 
-Read the template from `report-output-manager` when creating the file:
+Read the report template from `report-output-manager` when creating the file:
 
 - [../report-output-manager/references/sub-agent-report-template.md](../report-output-manager/references/sub-agent-report-template.md)
+
+## Profile-selection contract
+
+Select the model tier and reasoning effort independently.
+
+- use Luna only for low-uncertainty, local, ordinary-criticality, deterministic work
+- use Terra for ordinary bounded technical work
+- use Sol for judgment-heavy, ambiguous, high-criticality, cross-system, design, difficult debugging, and review work
+- use `max` only for one exceptionally difficult, non-decomposable problem
+- treat multi-agent or article-described `Ultra` execution as a decomposition strategy owned by `codex-delegation-executor`, never as a `reasoning_effort` value
+- choose the highest floor required by task kind, uncertainty, change radius, and criticality
+- preserve explicit user and repository overrides according to the precedence in the reference
+
+For review work, apply these minimum defaults unless a higher floor is required:
+
+- initial normal review: Sol with `high`
+- focused fix verification: Terra with `high`
+- independent final review or release audit: Sol with `xhigh`
+
+For investigation, do not use Luna for open-ended or root-cause work. A deterministic evidence-collection task may use Luna, but a failure or conflicting evidence must be reclassified before retrying.
+
+Record both `requested` and `applied` profiles. A full-history fork inherits the parent profile; runtime rejection or fallback is a capability state, not evidence that the requested override was applied.
 
 ## Required prompt content
 
@@ -66,8 +94,7 @@ Every sub-agent request must include:
 - explicit non-goals
 - explicit instruction not to run `codex exec`, nested Codex, or equivalent agent-spawning inside the sub-agent task
 - explicit instruction not to re-enter `development-orchestrator` or any other parent-owned workflow unless the parent explicitly named that workflow as part of the delegated task
-- the selected model and reasoning effort only as tool-call parameters, never as a prompt-only request
-- an explicit fork policy; a fresh override spawn must set `fork_turns: "none"`
+- an explicit fork policy
 - skill names and file paths that must be read first
 - validation commands or evidence expectations
 - report path
@@ -75,9 +102,11 @@ Every sub-agent request must include:
 - instruction to fill only blank sections or placeholder values instead of rewriting the full report
 - required final output shape
 
+The selected model and reasoning effort belong only in actual spawn parameters. Do not rely on model names written in the prompt to configure execution. The prompt may state task-local cost or quality constraints, but it must not claim an unapplied runtime profile.
+
 For review tasks also include:
 
-- the reviewer profile selected by `review-enforcer`: the parent agent's current model and `high` reasoning effort unless the user overrides the effort; apply it through actual spawn arguments rather than prompt text
+- the review mode and criticality signals used by the profile selector
 - explicit instruction to perform a code review using the built-in review behavior
 - instruction to return findings first, ordered by severity
 - instruction to include file/line references when available
@@ -106,8 +135,8 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 - Every sub-agent task must produce a file under `reports/`.
 - The parent agent should create the report file before dispatch whenever feasible.
 - The report must be created before the parent workflow treats the task as complete.
-- The parent agent should pre-populate the standard headings and placeholders so the `sub-agent` edits a fixed structure instead of rewriting the document.
-- If the `sub-agent` cannot write the report directly, the parent agent must write it immediately from the returned evidence.
+- The parent should pre-populate the standard headings and placeholders so the `sub-agent` edits a fixed structure instead of rewriting the document.
+- If the `sub-agent` cannot write the report directly, the parent must write it immediately from the returned evidence.
 - Do not ask a sub-agent for ad hoc investigation, review, or implementation without a report path.
 - For review tasks, the built-in review result must be materialized into the report file before the task is considered complete.
 - For review tasks, direct report editing by the reviewer is the default path; parent-side transcription is fallback only when direct editing is not possible.
@@ -116,6 +145,7 @@ When a relevant skill exists, do not paraphrase it loosely as the only guidance.
 - Report text should be written in Japanese unless the user explicitly requests another language.
 - The `sub-agent` must preserve the existing report format: no heading renames, no section reordering, no blank-line cleanup, and no whole-file replacement.
 - Existing non-empty parent text in the report is immutable unless the parent explicitly marks it as editable.
+- Record all profile-selection inputs, requested and applied profile, selection source, reasons, constraints, fork policy, application status, and any escalation or fallback.
 
 ## Standard report sections
 
@@ -144,6 +174,7 @@ Include:
 - findings summary or explicit `no findings`
 - outcome
 - unresolved risks or follow-up items
+- dispatch-profile evidence and runtime application status
 
 ## Outputs
 
@@ -151,7 +182,8 @@ After this skill runs, there should be:
 
 - a dispatched sub-agent task with explicit scope
 - a pre-created report path under `reports/`
-- a dispatch configuration applied through the actual spawn call
+- a recorded delegation assessment and selected `dispatch_profile`
+- a requested and actually applied model, reasoning effort, and fork policy
 - report-backed evidence for the delegated work
 
 ## Completion condition
@@ -159,26 +191,30 @@ After this skill runs, there should be:
 This skill is complete only when:
 
 - the sub-agent task has been dispatched with the required prompt content
+- the requested profile has either been applied or recorded as an explicit inherited, fallback, or capability-gap state
 - the report file exists in the expected location
-- the parent has reviewed the resulting report
+- the report contains the dispatch-profile evidence
+- the parent has reviewed the resulting report and underlying evidence
 
 ## Rules
 
 - Keep sub-agent tasks small and concrete.
 - Prefer one bounded request over one broad speculative request.
 - Reuse existing reports before dispatching duplicate work.
-- Use `execution-cost-stabilizer` if the delegation plan risks wasteful reruns or excessive parallelism.
+- Use `execution-cost-stabilizer` before `max`, multi-agent decomposition, wasteful reruns, or excessive parallelism.
 - Do not make a sub-agent run `codex exec`, nested Codex, or equivalent agent-spawning workflows inside the delegated task.
 - Do not let a sub-agent re-run `development-orchestrator` or other parent-owned workflow entry skills just because they exist in the repo; the sub-agent should execute only the delegated task and the explicitly named supporting skills.
 - Do not leave report structure up to the `sub-agent`.
-- For investigation and review tasks, prefer letting the `sub-agent` read the relevant workspace directly instead of over-constraining it to parent-curated excerpts.
+- For review and investigation tasks, prefer letting the `sub-agent` read the relevant workspace directly instead of over-constraining it to parent-curated excerpts.
 - For review tasks, prefer the model's native review behavior over inventing a custom review rubric in the prompt.
-- When a task depends on an existing skill, prefer making the `sub-agent` read that skill over duplicating its workflow in the prompt.
-- Do not treat a model or reasoning mention in `message` as an override. Pass the selected values in the `spawn_agent` call itself.
-- Do not infer an implementation sub-agent model. Apply only the user-confirmed model supplied by `development-orchestrator` through `codex-delegation-executor`.
-- Do not combine a model or reasoning override with omitted `fork_turns` or `fork_turns: "all"`; those full-history forks inherit the parent execution profile. Use `fork_turns: "none"` for a fresh specialist, or an explicit positive partial fork only when the needed context is bounded.
-- If the runtime rejects a hidden override argument, keep fallback execution parent-owned: use `codex exec --model <model> -c model_reasoning_effort="<effort>"`. Do not ask the delegated sub-agent to run it.
+- For review tasks, prefer direct report editing by the reviewer and use parent-side transcription only as fallback.
+- Do not treat a model or reasoning mention in `message` as an override. Pass the applied values in the actual `spawn_agent` call.
+- Do not combine a model or reasoning override with omitted `fork_turns` or `fork_turns: "all"`; full-history forks inherit the parent execution profile.
+- Do not silently downgrade an explicit user or repository profile override.
+- Do not keep a failed deterministic task on Luna after the work has become diagnosis or judgment.
+- If runtime rejects a hidden override argument, keep fallback execution parent-owned as defined by the spawn reference. Do not ask the delegated sub-agent to run the fallback.
+- If independently separable work would justify multi-agent execution, return it to `codex-delegation-executor` before dispatch rather than overloading one sub-agent.
 
 ## Cross-cutting rule
 
-If recurring sub-agent dispatch failures or report omissions appear, call `feedback-points-manager`.
+If recurring sub-agent dispatch failures, profile misclassification, or report omissions appear, call `feedback-points-manager`.

--- a/skills/sub-agent-task-manager/references/agent-profile-selection.md
+++ b/skills/sub-agent-task-manager/references/agent-profile-selection.md
@@ -20,6 +20,26 @@ Use only reasoning effort values supported by the selected runtime model. For th
 
 Do not use pricing as the primary selector. Use task nature, uncertainty, change radius, and criticality first, then choose the least expensive profile that satisfies the resulting floor.
 
+## Mandatory user-approval gate for expensive Sol profiles
+
+`Sol xhigh` and `Sol max` are approval-gated profiles. They are never selected or dispatched automatically.
+
+When automatic classification, repository policy, escalation, or another Skill concludes that either profile is appropriate:
+
+1. classify it only as a `proposed_profile`
+2. explain why `Sol high` is insufficient and what benefit the higher effort is expected to provide
+3. state that `Sol xhigh` or `Sol max` has higher execution cost
+4. present the proposed profile to the user
+5. stop the dispatch flow before creating or invoking the sub-agent with that profile
+6. wait for explicit user approval
+7. only after approval, promote the proposal to `requested` and continue runtime application
+
+An explicit user instruction in the current task that directly requests `Sol xhigh` or `Sol max` counts as approval. A repository policy, previous approval for another task, inferred preference, or silence does not count.
+
+If the user rejects the proposal, recompute the profile with `Sol xhigh` and `Sol max` excluded. Normally the highest automatic fallback is `Sol high`, but classification must still be recomputed rather than silently copying the rejected proposal.
+
+This gate has higher precedence than repository policy and automatic selection. It also applies to review and release-audit tasks.
+
 ## Selection inputs
 
 Record these signals before choosing a profile:
@@ -33,6 +53,7 @@ Record these signals before choosing a profile:
 - `decomposability`: `single`, `sequential_dependencies`, or `independent_workstreams`
 - `context_need`: `fresh`, `bounded_history`, or `full_history`
 - explicit user or repository model, effort, budget, and availability constraints
+- approval state when `Sol xhigh` or `Sol max` is proposed
 
 `criticality: high` includes security, authorization, privacy, destructive data handling, schema or data migration, concurrency, compatibility, public API, release, deployment, and other changes where an incorrect result has a large or difficult-to-reverse impact.
 
@@ -84,7 +105,7 @@ Do not downgrade a Sol-floor task merely because the expected edit is small. Cha
 
 ## Task defaults
 
-Use these defaults after applying the floors above:
+Use these defaults after applying the floors above. A value marked `proposal` is not dispatchable until the user approves it.
 
 | Task | Default profile | Escalation |
 | --- | --- | --- |
@@ -92,11 +113,11 @@ Use these defaults after applying the floors above:
 | deterministic build or test execution | Luna `medium` | Reclassify failure diagnosis as investigation |
 | ordinary bounded implementation | Terra `medium` | Terra `high` for cross-module or multi-factor work |
 | localized debugging with a concrete hypothesis | Terra `high` | Sol `high` when the hypothesis fails or layers interact |
-| design or requirement interpretation | Sol `high` | Sol `max` only for one exceptionally hard, inseparable decision |
-| open-ended or cross-layer investigation | Sol `high` | Sol `max` for one exceptionally hard, inseparable root cause |
-| initial normal review | Sol `high` | Sol `xhigh` for high-criticality scope |
+| design or requirement interpretation | Sol `high` | propose Sol `max`; stop for user approval |
+| open-ended or cross-layer investigation | Sol `high` | propose Sol `max`; stop for user approval |
+| initial normal review | Sol `high` | propose Sol `xhigh`; stop for user approval |
 | focused fix verification | Terra `high` | Sol `high` when the original finding or changed scope is high-criticality |
-| independent final review or release audit | Sol `xhigh` | Sol `max` only when one inseparable proof obligation dominates |
+| independent final review or release audit | propose Sol `xhigh` | stop for user approval; propose Sol `max` only for one inseparable proof obligation |
 
 Do not use `none` by default for delegated development work. It may be used only for an explicitly deterministic operation that requires no technical judgment and has a complete mechanical validator.
 
@@ -107,14 +128,14 @@ Choose reasoning effort independently from model tier:
 - `low`: exact, low-risk transformations with explicit expected output
 - `medium`: ordinary bounded implementation or deterministic evidence work
 - `high`: multiple interacting conditions, careful debugging, design, or review
-- `xhigh`: exhaustive or high-stakes review and audit with a bounded scope
-- `max`: one exceptionally difficult, non-decomposable problem where deeper reasoning is more useful than splitting the task
+- `xhigh`: exhaustive or high-stakes review and audit with a bounded scope; when paired with Sol, user approval is mandatory
+- `max`: one exceptionally difficult, non-decomposable problem where deeper reasoning is more useful than splitting the task; when paired with Sol, user approval is mandatory
 
-Do not use `max` as a generic quality setting. Before selecting it, call `execution-cost-stabilizer` and record why Terra or Sol at `high` or `xhigh` is insufficient.
+Do not use `max` as a generic quality setting. Before proposing it, call `execution-cost-stabilizer` and record why Sol `high` or an independently decomposed plan is insufficient.
 
 ## Multi-agent decision
 
-Return the task to `codex-delegation-executor` for decomposition instead of selecting a single `max` task when all of the following hold:
+Return the task to `codex-delegation-executor` for decomposition instead of proposing a single `max` task when all of the following hold:
 
 - there are at least two independently executable workstreams
 - each workstream can have explicit scope, non-goals, evidence, and report ownership
@@ -128,18 +149,23 @@ Each decomposed task receives its own profile. Do not assign one shared profile 
 
 Apply precedence in this order:
 
-1. explicit user instruction
-2. authoritative repository policy
-3. runtime capability and model availability
-4. automatic selection rules in this reference
+1. explicit current-task user instruction, including explicit approval for `Sol xhigh` or `Sol max`
+2. mandatory user-approval gate for an unapproved `Sol xhigh` or `Sol max` proposal
+3. authoritative repository policy
+4. runtime capability and model availability
+5. automatic selection rules in this reference
 
 An override may pin the model, effort, or both. Continue to classify the task and record when the override is below the automatically calculated floor. Do not silently replace an explicit override. Report the mismatch and follow the governing authority.
 
-Separate the requested profile from the applied profile:
+A repository policy that requests `Sol xhigh` or `Sol max` creates a proposal but cannot satisfy the approval gate.
+
+## Dispatch profile schema
+
+For ordinary profiles:
 
 ```yaml
 dispatch_profile:
-  schema_version: 1
+  schema_version: 2
   selection_source: automatic | user_override | repository_policy
   task_kind: review
   signals:
@@ -153,23 +179,49 @@ dispatch_profile:
   requested:
     model_tier: sol
     model: gpt-5.6-sol
-    reasoning_effort: xhigh
+    reasoning_effort: high
     fork_turns: none
     parallelism_mode: single_agent
   applied:
     model: gpt-5.6-sol
-    reasoning_effort: xhigh
+    reasoning_effort: high
     fork_turns: none
   application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
-  reasons:
-    - independent final review
-    - high-criticality cross-module scope
+  approval:
+    required: false
+    status: not_required
+  reasons: []
   constraints: []
-  escalation_triggers:
-    - evidence conflict expands the review scope
+  escalation_triggers: []
 ```
 
-When the selected model or effort is unavailable or rejected, follow [spawn-agent-model-overrides.md](spawn-agent-model-overrides.md). Never claim the requested profile was applied without actual runtime evidence.
+For approval-gated profiles, keep the candidate out of `requested` until approval:
+
+```yaml
+dispatch_profile:
+  schema_version: 2
+  selection_source: automatic | repository_policy
+  proposed_profile:
+    model_tier: sol
+    model: gpt-5.6-sol
+    reasoning_effort: xhigh | max
+    fork_turns: none
+    parallelism_mode: single_agent
+  requested: null
+  applied: null
+  application_status: awaiting_user_approval
+  approval:
+    required: true
+    status: pending | approved | rejected
+    approved_by: null
+    approval_evidence: null
+  reasons:
+    - why Sol high is insufficient
+  cost_notice:
+    - higher reasoning effort increases execution cost
+```
+
+After explicit approval, copy the approved proposal into `requested`, record approval evidence, and only then follow [spawn-agent-model-overrides.md](spawn-agent-model-overrides.md). Never claim the requested profile was applied without actual runtime evidence.
 
 ## Fork policy
 
@@ -187,6 +239,7 @@ Recompute the profile when new evidence changes uncertainty, change radius, crit
 - A task that becomes cleanly separable returns to `codex-delegation-executor` for decomposition.
 - Raise reasoning effort when the problem is unchanged but needs more careful analysis.
 - Raise model tier when the nature of the problem changes or the current model lacks the required judgment capability.
+- If escalation reaches Sol `xhigh` or Sol `max`, convert it to a proposal and stop for user approval instead of dispatching.
 
 Avoid blind retry loops. Record the reason for every profile escalation or fallback and reuse existing evidence.
 
@@ -201,6 +254,9 @@ Every dispatched task report must record:
 - runtime rejection or fallback, if any
 - reclassification or escalation, if any
 - whether multi-agent decomposition was considered and why it was or was not used
+- for `Sol xhigh` or `Sol max`, the proposal, cost notice, approval status, and explicit approval evidence
+
+A proposal that is still awaiting approval is a stopped workflow state, not a dispatched task.
 
 ## References
 

--- a/skills/sub-agent-task-manager/references/agent-profile-selection.md
+++ b/skills/sub-agent-task-manager/references/agent-profile-selection.md
@@ -2,7 +2,7 @@
 
 Use this reference before dispatching every bounded `sub-agent` task.
 
-The selector chooses a model tier, reasoning effort, and fork policy separately. It also decides whether the work should remain one bounded task or return to `codex-delegation-executor` for multi-agent decomposition.
+The selector chooses a model tier, reasoning effort, and fork policy separately. It may return decomposable work to `codex-delegation-executor` only when the caller permits decomposition. Identity-sensitive reviewer tasks from `review-enforcer` are caller-locked to one agent and must remain `decomposability: single`.
 
 ## Current model family
 
@@ -16,7 +16,7 @@ Use the following runtime model IDs when they are available:
 
 Use only reasoning effort values supported by the selected runtime model. For the GPT-5.6 family, the normalized values are `none`, `low`, `medium`, `high`, `xhigh`, and `max`.
 
-`Ultra` is not a `reasoning_effort` value. Treat it as a multi-agent execution strategy for independently separable workstreams. `codex-delegation-executor` owns that decomposition decision; this reference selects the profile for each resulting bounded task.
+`Ultra` is not a `reasoning_effort` value. Treat it as a multi-agent execution strategy for independently separable workstreams. `codex-delegation-executor` owns that decomposition decision when decomposition is allowed; this reference selects the profile for each resulting bounded task.
 
 Do not use pricing as the primary selector. Use task nature, uncertainty, change radius, and criticality first, then choose the least expensive profile that satisfies the resulting floor.
 
@@ -51,12 +51,15 @@ Record these signals before choosing a profile:
 - `criticality`: `ordinary` or `high`
 - `repetition`: `single` or `high_volume`
 - `decomposability`: `single`, `sequential_dependencies`, or `independent_workstreams`
+- `decomposition_policy`: `allowed` or `forbidden`
 - `context_need`: `fresh`, `bounded_history`, or `full_history`
 - explicit user or repository model, effort, budget, and availability constraints
 - approval state when `Sol xhigh` or `Sol max` is proposed
 - existing agent identity and its applied profile when the caller requests continuity reuse
 
 `criticality: high` includes security, authorization, privacy, destructive data handling, schema or data migration, concurrency, compatibility, public API, release, deployment, and other changes where an incorrect result has a large or difficult-to-reverse impact.
+
+When `decomposition_policy: forbidden`, preserve `decomposability: single` even if the scope contains several review areas. This is required for `review-enforcer` reviewer identity and one-pass lifecycle guarantees.
 
 ## Model-tier rules
 
@@ -151,13 +154,15 @@ Do not use `max` as a generic quality setting. Before proposing it, call `execut
 
 ## Multi-agent decision
 
-Return the task to `codex-delegation-executor` for decomposition instead of proposing a single `max` task when all of the following hold:
+Return the task to `codex-delegation-executor` for decomposition only when `decomposition_policy: allowed` and all of the following hold:
 
 - there are at least two independently executable workstreams
 - each workstream can have explicit scope, non-goals, evidence, and report ownership
 - write ownership does not overlap, or the tasks are read-only
 - a parent synthesis step is defined
 - parallel execution provides material value after applying `execution-cost-stabilizer`
+
+Do not return a caller-locked task for decomposition. In particular, every reviewer task from `review-enforcer` has `decomposition_policy: forbidden` and remains one reviewer regardless of review breadth.
 
 Each decomposed task receives its own profile. Do not assign one shared profile merely because the tasks run together.
 
@@ -168,9 +173,10 @@ Apply precedence in this order:
 1. explicit current-task user instruction, including explicit approval for `Sol xhigh` or `Sol max`
 2. mandatory user-approval gate for an unapproved `Sol xhigh` or `Sol max` proposal
 3. reviewer continuity reuse of an existing agent and its actually applied profile
-4. authoritative repository policy
-5. runtime capability and model availability
-6. automatic selection rules in this reference
+4. caller-owned decomposition prohibition
+5. authoritative repository policy
+6. runtime capability and model availability
+7. automatic selection rules in this reference
 
 An override may pin the model, effort, or both. Continue to classify the task and record when the override is below the automatically calculated floor. Do not silently replace an explicit override. Report the mismatch and follow the governing authority.
 
@@ -178,11 +184,11 @@ A repository policy that requests `Sol xhigh` or `Sol max` creates a proposal bu
 
 ## Dispatch profile schema
 
-For ordinary newly dispatched profiles:
+For an ordinary newly dispatched profile before the spawn call:
 
 ```yaml
 dispatch_profile:
-  schema_version: 2
+  schema_version: 3
   selection_source: automatic | user_override | repository_policy
   task_kind: review
   signals:
@@ -192,6 +198,7 @@ dispatch_profile:
     criticality: high
     repetition: single
     decomposability: single
+    decomposition_policy: forbidden
     context_need: fresh
   requested:
     model_tier: sol
@@ -199,11 +206,8 @@ dispatch_profile:
     reasoning_effort: high
     fork_turns: none
     parallelism_mode: single_agent
-  applied:
-    model: gpt-5.6-sol
-    reasoning_effort: high
-    fork_turns: none
-  application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+  applied: null
+  application_status: pending_runtime_result
   approval:
     required: false
     status: not_required
@@ -212,11 +216,25 @@ dispatch_profile:
   escalation_triggers: []
 ```
 
+`requested` is the pre-spawn instruction. `applied` is not known yet.
+
+After the call, fill `applied` and replace `pending_runtime_result` using actual runtime evidence:
+
+```yaml
+applied:
+  model: <actual model or inherited parent model>
+  reasoning_effort: <actual effort or inherited parent effort>
+  fork_turns: <actual fork policy>
+application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+```
+
+Never copy `requested` into `applied` merely because the call was attempted.
+
 For approval-gated profiles, keep the candidate out of `requested` until approval:
 
 ```yaml
 dispatch_profile:
-  schema_version: 2
+  schema_version: 3
   selection_source: automatic | repository_policy
   proposed_profile:
     model_tier: sol
@@ -242,7 +260,7 @@ For continuity reuse:
 
 ```yaml
 dispatch_profile:
-  schema_version: 2
+  schema_version: 3
   selection_source: continuity_reuse
   task_kind: review
   requested: null
@@ -266,7 +284,7 @@ After explicit approval, copy the approved proposal into `requested`, record app
 
 - Use `fork_turns: "none"` for a fresh specialist when applying a model or reasoning override.
 - Use an explicit positive partial fork only when the required history is bounded and identified.
-- A full-history fork inherits the parent execution profile. Record `application_status: inherited_parent_profile` and do not claim that a different requested model was applied.
+- A full-history fork inherits the parent execution profile. Preserve the requested specialization as unapplied evidence and record `application_status: inherited_parent_profile` only from the actual inheritance path.
 - Prefer fresh context plus explicit task-local inputs over a full-history fork when specialization matters.
 - Continuity reuse keeps the existing agent context and is not represented as a new fork operation.
 
@@ -276,7 +294,7 @@ Recompute the profile when new evidence changes uncertainty, change radius, crit
 
 - A failed deterministic verification becomes investigation; do not keep retrying it as Luna work.
 - A localized implementation that exposes architectural ambiguity becomes Sol work.
-- A task that becomes cleanly separable returns to `codex-delegation-executor` for decomposition.
+- A task that becomes cleanly separable returns to `codex-delegation-executor` only when decomposition is allowed.
 - Raise reasoning effort when the problem is unchanged but needs more careful analysis.
 - Raise model tier when the nature of the problem changes or the current model lacks the required judgment capability.
 - If escalation reaches Sol `xhigh` or Sol `max`, convert it to a proposal and stop for user approval instead of dispatching.
@@ -286,15 +304,16 @@ Avoid blind retry loops. Record the reason for every profile escalation or fallb
 
 ## Evidence requirement
 
-Every dispatched task report must record:
+Every dispatched task lifecycle must record:
 
 - all selection inputs
-- requested and applied profile
+- requested profile before spawn
+- applied profile only after runtime evidence exists
 - selection source and rationale
 - fork policy
-- runtime rejection or fallback, if any
+- runtime rejection, inheritance, or fallback, if any
 - reclassification or escalation, if any
-- whether multi-agent decomposition was considered and why it was or was not used
+- whether multi-agent decomposition was allowed, considered, and used
 - for `Sol xhigh` or `Sol max`, the proposal, cost notice, approval status, and explicit approval evidence
 - for reviewer continuity, existing reviewer identity, original applied profile evidence, continued mode, and `application_status: reused_existing_agent_profile`
 

--- a/skills/sub-agent-task-manager/references/agent-profile-selection.md
+++ b/skills/sub-agent-task-manager/references/agent-profile-selection.md
@@ -1,0 +1,211 @@
+# Agent profile selection
+
+Use this reference before dispatching every bounded `sub-agent` task.
+
+The selector chooses a model tier, reasoning effort, and fork policy separately. It also decides whether the work should remain one bounded task or return to `codex-delegation-executor` for multi-agent decomposition.
+
+## Current model family
+
+Use the following runtime model IDs when they are available:
+
+| Tier | Runtime model | Intended use |
+| --- | --- | --- |
+| Luna | `gpt-5.6-luna` | deterministic, repetitive, cost-sensitive, high-volume work |
+| Terra | `gpt-5.6-terra` | ordinary implementation and bounded technical work |
+| Sol | `gpt-5.6-sol` | ambiguous, high-risk, cross-system, design, debugging, and review work |
+
+Use only reasoning effort values supported by the selected runtime model. For the GPT-5.6 family, the normalized values are `none`, `low`, `medium`, `high`, `xhigh`, and `max`.
+
+`Ultra` is not a `reasoning_effort` value. Treat it as a multi-agent execution strategy for independently separable workstreams. `codex-delegation-executor` owns that decomposition decision; this reference selects the profile for each resulting bounded task.
+
+Do not use pricing as the primary selector. Use task nature, uncertainty, change radius, and criticality first, then choose the least expensive profile that satisfies the resulting floor.
+
+## Selection inputs
+
+Record these signals before choosing a profile:
+
+- `task_kind`: implementation, design, investigation, review, verification, environment verification, intake verification, standards work, or other
+- `work_class`: `mechanical`, `bounded_technical`, or `judgment_heavy`
+- `uncertainty`: `low`, `medium`, or `high`
+- `change_radius`: `local`, `cross_module`, or `cross_system`
+- `criticality`: `ordinary` or `high`
+- `repetition`: `single` or `high_volume`
+- `decomposability`: `single`, `sequential_dependencies`, or `independent_workstreams`
+- `context_need`: `fresh`, `bounded_history`, or `full_history`
+- explicit user or repository model, effort, budget, and availability constraints
+
+`criticality: high` includes security, authorization, privacy, destructive data handling, schema or data migration, concurrency, compatibility, public API, release, deployment, and other changes where an incorrect result has a large or difficult-to-reverse impact.
+
+## Model-tier rules
+
+Choose the highest floor required by any applicable rule.
+
+### Luna floor
+
+Use Luna only when all of the following are true:
+
+- the expected behavior and procedure are already decided
+- uncertainty is low
+- the change or evidence scope is local
+- criticality is ordinary
+- the task is mechanical, repetitive, or high-volume
+- success can be checked with explicit deterministic evidence
+
+Examples include exact formatting, generated-file updates, repetitive metadata edits, known-command execution, extraction, classification, and bounded evidence collection.
+
+Do not use Luna for open-ended investigation, root-cause analysis, architecture, requirement interpretation, independent review, or failure diagnosis.
+
+### Terra floor
+
+Use Terra for ordinary bounded technical work, including:
+
+- implementation from accepted requirements with a bounded change radius
+- focused verification whose commands and expected evidence are known
+- localized investigation with a concrete hypothesis
+- focused fix verification against already identified findings
+- cross-module work whose behavior is still well specified and whose risk is ordinary
+
+Raise Terra from `medium` to `high` when the task spans modules, has several interacting conditions, or needs careful regression reasoning but does not require Sol.
+
+### Sol floor
+
+Use Sol when any of the following applies:
+
+- requirements or architecture must be decided
+- uncertainty is high or the task is judgment-heavy
+- root cause is unknown or spans layers
+- change radius is cross-system
+- criticality is high
+- the task is an initial review, independent final review, release audit, security review, or compatibility review
+- evidence conflicts and must be adjudicated
+- the task requires synthesizing several technical domains
+
+Do not downgrade a Sol-floor task merely because the expected edit is small. Change radius, uncertainty, and consequence take precedence over line count.
+
+## Task defaults
+
+Use these defaults after applying the floors above:
+
+| Task | Default profile | Escalation |
+| --- | --- | --- |
+| exact repetitive transformation | Luna `low` | Luna `medium` when validation interpretation is needed |
+| deterministic build or test execution | Luna `medium` | Reclassify failure diagnosis as investigation |
+| ordinary bounded implementation | Terra `medium` | Terra `high` for cross-module or multi-factor work |
+| localized debugging with a concrete hypothesis | Terra `high` | Sol `high` when the hypothesis fails or layers interact |
+| design or requirement interpretation | Sol `high` | Sol `max` only for one exceptionally hard, inseparable decision |
+| open-ended or cross-layer investigation | Sol `high` | Sol `max` for one exceptionally hard, inseparable root cause |
+| initial normal review | Sol `high` | Sol `xhigh` for high-criticality scope |
+| focused fix verification | Terra `high` | Sol `high` when the original finding or changed scope is high-criticality |
+| independent final review or release audit | Sol `xhigh` | Sol `max` only when one inseparable proof obligation dominates |
+
+Do not use `none` by default for delegated development work. It may be used only for an explicitly deterministic operation that requires no technical judgment and has a complete mechanical validator.
+
+## Reasoning-effort rules
+
+Choose reasoning effort independently from model tier:
+
+- `low`: exact, low-risk transformations with explicit expected output
+- `medium`: ordinary bounded implementation or deterministic evidence work
+- `high`: multiple interacting conditions, careful debugging, design, or review
+- `xhigh`: exhaustive or high-stakes review and audit with a bounded scope
+- `max`: one exceptionally difficult, non-decomposable problem where deeper reasoning is more useful than splitting the task
+
+Do not use `max` as a generic quality setting. Before selecting it, call `execution-cost-stabilizer` and record why Terra or Sol at `high` or `xhigh` is insufficient.
+
+## Multi-agent decision
+
+Return the task to `codex-delegation-executor` for decomposition instead of selecting a single `max` task when all of the following hold:
+
+- there are at least two independently executable workstreams
+- each workstream can have explicit scope, non-goals, evidence, and report ownership
+- write ownership does not overlap, or the tasks are read-only
+- a parent synthesis step is defined
+- parallel execution provides material value after applying `execution-cost-stabilizer`
+
+Each decomposed task receives its own profile. Do not assign one shared profile merely because the tasks run together.
+
+## Override and availability precedence
+
+Apply precedence in this order:
+
+1. explicit user instruction
+2. authoritative repository policy
+3. runtime capability and model availability
+4. automatic selection rules in this reference
+
+An override may pin the model, effort, or both. Continue to classify the task and record when the override is below the automatically calculated floor. Do not silently replace an explicit override. Report the mismatch and follow the governing authority.
+
+Separate the requested profile from the applied profile:
+
+```yaml
+dispatch_profile:
+  schema_version: 1
+  selection_source: automatic | user_override | repository_policy
+  task_kind: review
+  signals:
+    work_class: judgment_heavy
+    uncertainty: high
+    change_radius: cross_module
+    criticality: high
+    repetition: single
+    decomposability: single
+    context_need: fresh
+  requested:
+    model_tier: sol
+    model: gpt-5.6-sol
+    reasoning_effort: xhigh
+    fork_turns: none
+    parallelism_mode: single_agent
+  applied:
+    model: gpt-5.6-sol
+    reasoning_effort: xhigh
+    fork_turns: none
+  application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+  reasons:
+    - independent final review
+    - high-criticality cross-module scope
+  constraints: []
+  escalation_triggers:
+    - evidence conflict expands the review scope
+```
+
+When the selected model or effort is unavailable or rejected, follow [spawn-agent-model-overrides.md](spawn-agent-model-overrides.md). Never claim the requested profile was applied without actual runtime evidence.
+
+## Fork policy
+
+- Use `fork_turns: "none"` for a fresh specialist when applying a model or reasoning override.
+- Use an explicit positive partial fork only when the required history is bounded and identified.
+- A full-history fork inherits the parent execution profile. Record `application_status: inherited_parent_profile` and do not claim that a different requested model was applied.
+- Prefer fresh context plus explicit task-local inputs over a full-history fork when specialization matters.
+
+## Reclassification and escalation
+
+Recompute the profile when new evidence changes uncertainty, change radius, criticality, or task kind.
+
+- A failed deterministic verification becomes investigation; do not keep retrying it as Luna work.
+- A localized implementation that exposes architectural ambiguity becomes Sol work.
+- A task that becomes cleanly separable returns to `codex-delegation-executor` for decomposition.
+- Raise reasoning effort when the problem is unchanged but needs more careful analysis.
+- Raise model tier when the nature of the problem changes or the current model lacks the required judgment capability.
+
+Avoid blind retry loops. Record the reason for every profile escalation or fallback and reuse existing evidence.
+
+## Evidence requirement
+
+Every dispatched task report must record:
+
+- all selection inputs
+- requested and applied profile
+- selection source and rationale
+- fork policy
+- runtime rejection or fallback, if any
+- reclassification or escalation, if any
+- whether multi-agent decomposition was considered and why it was or was not used
+
+## References
+
+- [Adaptive agent assignment design](../../../design/adaptive-agent-assignment-design.md)
+- [Execution Cost Stabilizer](../../execution-cost-stabilizer/SKILL.md)
+- [OpenAI model catalog](https://developers.openai.com/api/docs/models)
+- [OpenAI latest-model guidance](https://developers.openai.com/api/docs/guides/latest-model)
+- [参考記事: 役割分担で回すGPT-5.6 Luna / Terra / Sol](https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb)

--- a/skills/sub-agent-task-manager/references/agent-profile-selection.md
+++ b/skills/sub-agent-task-manager/references/agent-profile-selection.md
@@ -54,6 +54,7 @@ Record these signals before choosing a profile:
 - `context_need`: `fresh`, `bounded_history`, or `full_history`
 - explicit user or repository model, effort, budget, and availability constraints
 - approval state when `Sol xhigh` or `Sol max` is proposed
+- existing agent identity and its applied profile when the caller requests continuity reuse
 
 `criticality: high` includes security, authorization, privacy, destructive data handling, schema or data migration, concurrency, compatibility, public API, release, deployment, and other changes where an incorrect result has a large or difficult-to-reverse impact.
 
@@ -83,7 +84,7 @@ Use Terra for ordinary bounded technical work, including:
 - implementation from accepted requirements with a bounded change radius
 - focused verification whose commands and expected evidence are known
 - localized investigation with a concrete hypothesis
-- focused fix verification against already identified findings
+- a newly created reviewer dedicated only to focused fix verification when continuity reuse is unavailable
 - cross-module work whose behavior is still well specified and whose risk is ordinary
 
 Raise Terra from `medium` to `high` when the task spans modules, has several interacting conditions, or needs careful regression reasoning but does not require Sol.
@@ -105,7 +106,7 @@ Do not downgrade a Sol-floor task merely because the expected edit is small. Cha
 
 ## Task defaults
 
-Use these defaults after applying the floors above. A value marked `proposal` is not dispatchable until the user approves it.
+Use these defaults after applying the floors above. A value marked `proposal` is not dispatchable until the user approves it. Defaults apply only when a new sub-agent is being created; continuity reuse preserves the existing agent profile instead of reselecting a default.
 
 | Task | Default profile | Escalation |
 | --- | --- | --- |
@@ -116,10 +117,25 @@ Use these defaults after applying the floors above. A value marked `proposal` is
 | design or requirement interpretation | Sol `high` | propose Sol `max`; stop for user approval |
 | open-ended or cross-layer investigation | Sol `high` | propose Sol `max`; stop for user approval |
 | initial normal review | Sol `high` | propose Sol `xhigh`; stop for user approval |
-| focused fix verification | Terra `high` | Sol `high` when the original finding or changed scope is high-criticality |
+| focused fix verification, new reviewer only | Terra `high` | Sol `high` when the original finding or changed scope is high-criticality |
 | independent final review or release audit | propose Sol `xhigh` | stop for user approval; propose Sol `max` only for one inseparable proof obligation |
 
 Do not use `none` by default for delegated development work. It may be used only for an explicitly deterministic operation that requires no technical judgment and has a complete mechanical validator.
+
+## Reviewer continuity rule
+
+When `review-enforcer` requests reuse of an already-running normal reviewer or independent reviewer, continuity takes precedence over the task default table.
+
+- do not spawn a replacement merely to apply the focused fix-verification default
+- do not reselect Terra `high`, Sol `high`, `xhigh`, or `max` for the existing agent
+- preserve the model, reasoning effort, and fork context that were actually applied when that reviewer was created
+- record `application_status: reused_existing_agent_profile`
+- record the reviewer identity and the original applied profile as continuity evidence
+- record the continued review mode, such as `fix_verification` or `finding_ci_delta_closure`
+
+Reusing an already-approved `Sol xhigh` or `Sol max` reviewer in the same review lifecycle does not create a new expensive-profile selection. The original approval evidence remains attached to that reviewer. A new reviewer, a replacement reviewer, or a new task lifecycle must pass profile selection and any applicable approval gate again.
+
+If the original applied profile is unknown, do not invent it. Record the evidence gap and let `review-enforcer` decide whether continuity can be trusted or a replacement reviewer must be created through the normal selection path.
 
 ## Reasoning-effort rules
 
@@ -151,9 +167,10 @@ Apply precedence in this order:
 
 1. explicit current-task user instruction, including explicit approval for `Sol xhigh` or `Sol max`
 2. mandatory user-approval gate for an unapproved `Sol xhigh` or `Sol max` proposal
-3. authoritative repository policy
-4. runtime capability and model availability
-5. automatic selection rules in this reference
+3. reviewer continuity reuse of an existing agent and its actually applied profile
+4. authoritative repository policy
+5. runtime capability and model availability
+6. automatic selection rules in this reference
 
 An override may pin the model, effort, or both. Continue to classify the task and record when the override is below the automatically calculated floor. Do not silently replace an explicit override. Report the mismatch and follow the governing authority.
 
@@ -161,7 +178,7 @@ A repository policy that requests `Sol xhigh` or `Sol max` creates a proposal bu
 
 ## Dispatch profile schema
 
-For ordinary profiles:
+For ordinary newly dispatched profiles:
 
 ```yaml
 dispatch_profile:
@@ -221,6 +238,28 @@ dispatch_profile:
     - higher reasoning effort increases execution cost
 ```
 
+For continuity reuse:
+
+```yaml
+dispatch_profile:
+  schema_version: 2
+  selection_source: continuity_reuse
+  task_kind: review
+  requested: null
+  applied:
+    model: <original applied model>
+    reasoning_effort: <original applied effort>
+    fork_turns: <original fork policy>
+  application_status: reused_existing_agent_profile
+  continuity:
+    reviewer_identity: <existing reviewer>
+    continued_mode: fix_verification | finding_ci_delta_closure
+    original_profile_evidence: <report or spawn evidence>
+  approval:
+    required: false
+    status: inherited_from_original_dispatch | not_required
+```
+
 After explicit approval, copy the approved proposal into `requested`, record approval evidence, and only then follow [spawn-agent-model-overrides.md](spawn-agent-model-overrides.md). Never claim the requested profile was applied without actual runtime evidence.
 
 ## Fork policy
@@ -229,10 +268,11 @@ After explicit approval, copy the approved proposal into `requested`, record app
 - Use an explicit positive partial fork only when the required history is bounded and identified.
 - A full-history fork inherits the parent execution profile. Record `application_status: inherited_parent_profile` and do not claim that a different requested model was applied.
 - Prefer fresh context plus explicit task-local inputs over a full-history fork when specialization matters.
+- Continuity reuse keeps the existing agent context and is not represented as a new fork operation.
 
 ## Reclassification and escalation
 
-Recompute the profile when new evidence changes uncertainty, change radius, criticality, or task kind.
+Recompute the profile when new evidence changes uncertainty, change radius, criticality, or task kind and a new agent would be dispatched.
 
 - A failed deterministic verification becomes investigation; do not keep retrying it as Luna work.
 - A localized implementation that exposes architectural ambiguity becomes Sol work.
@@ -240,6 +280,7 @@ Recompute the profile when new evidence changes uncertainty, change radius, crit
 - Raise reasoning effort when the problem is unchanged but needs more careful analysis.
 - Raise model tier when the nature of the problem changes or the current model lacks the required judgment capability.
 - If escalation reaches Sol `xhigh` or Sol `max`, convert it to a proposal and stop for user approval instead of dispatching.
+- Do not recompute the profile merely because an existing reviewer moved from initial review to fix verification or bounded closure.
 
 Avoid blind retry loops. Record the reason for every profile escalation or fallback and reuse existing evidence.
 
@@ -255,6 +296,7 @@ Every dispatched task report must record:
 - reclassification or escalation, if any
 - whether multi-agent decomposition was considered and why it was or was not used
 - for `Sol xhigh` or `Sol max`, the proposal, cost notice, approval status, and explicit approval evidence
+- for reviewer continuity, existing reviewer identity, original applied profile evidence, continued mode, and `application_status: reused_existing_agent_profile`
 
 A proposal that is still awaiting approval is a stopped workflow state, not a dispatched task.
 

--- a/skills/sub-agent-task-manager/references/agent-profile-selection.md
+++ b/skills/sub-agent-task-manager/references/agent-profile-selection.md
@@ -2,7 +2,7 @@
 
 Use this reference before dispatching every bounded `sub-agent` task.
 
-The selector chooses a model tier, reasoning effort, and fork policy separately. It may return decomposable work to `codex-delegation-executor` only when the caller permits decomposition. Identity-sensitive reviewer tasks from `review-enforcer` are caller-locked to one agent and must remain `decomposability: single`.
+The selector chooses a model tier, reasoning effort, and fork policy separately. It records task decomposability as an observed signal and execution decomposition policy as a separate caller constraint. It may return decomposable work to `codex-delegation-executor` only when decomposition is allowed.
 
 ## Current model family
 
@@ -18,27 +18,27 @@ Use only reasoning effort values supported by the selected runtime model. For th
 
 `Ultra` is not a `reasoning_effort` value. Treat it as a multi-agent execution strategy for independently separable workstreams. `codex-delegation-executor` owns that decomposition decision when decomposition is allowed; this reference selects the profile for each resulting bounded task.
 
-Do not use pricing as the primary selector. Use task nature, uncertainty, change radius, and criticality first, then choose the least expensive profile that satisfies the resulting floor.
+Do not use pricing as the primary selector. Use task nature, uncertainty, change radius, criticality, and observed decomposability first, then choose the least expensive profile that satisfies the resulting floor and caller constraints.
 
 ## Mandatory user-approval gate for expensive Sol profiles
 
 `Sol xhigh` and `Sol max` are approval-gated profiles. They are never selected or dispatched automatically.
 
-When automatic classification, repository policy, escalation, or another Skill concludes that either profile is appropriate:
+When automatic classification, repository policy, escalation, agent-role planning, or another Skill concludes that either profile is appropriate:
 
 1. classify it only as a `proposed_profile`
 2. explain why `Sol high` is insufficient and what benefit the higher effort is expected to provide
 3. state that `Sol xhigh` or `Sol max` has higher execution cost
 4. present the proposed profile to the user
 5. stop the dispatch flow before creating or invoking the sub-agent with that profile
-6. wait for explicit user approval
+6. wait for explicit current-task user approval
 7. only after approval, promote the proposal to `requested` and continue runtime application
 
 An explicit user instruction in the current task that directly requests `Sol xhigh` or `Sol max` counts as approval. A repository policy, previous approval for another task, inferred preference, or silence does not count.
 
 If the user rejects the proposal, recompute the profile with `Sol xhigh` and `Sol max` excluded. Normally the highest automatic fallback is `Sol high`, but classification must still be recomputed rather than silently copying the rejected proposal.
 
-This gate has higher precedence than repository policy and automatic selection. It also applies to review and release-audit tasks.
+This gate has higher precedence than repository policy and automatic selection. It also applies to role/default-role profile changes, review, and release-audit tasks.
 
 ## Selection inputs
 
@@ -53,13 +53,31 @@ Record these signals before choosing a profile:
 - `decomposability`: `single`, `sequential_dependencies`, or `independent_workstreams`
 - `decomposition_policy`: `allowed` or `forbidden`
 - `context_need`: `fresh`, `bounded_history`, or `full_history`
-- explicit user or repository model, effort, budget, and availability constraints
+- explicit user or repository model, effort, budget, availability, fork, or agent-role constraints
+- applicable explicit/default agent-role configuration evidence when runtime roles can change model or reasoning
 - approval state when `Sol xhigh` or `Sol max` is proposed
-- existing agent identity and its applied profile when the caller requests continuity reuse
+- existing agent identity and original applied-profile evidence when the caller requests continuity reuse
 
 `criticality: high` includes security, authorization, privacy, destructive data handling, schema or data migration, concurrency, compatibility, public API, release, deployment, and other changes where an incorrect result has a large or difficult-to-reverse impact.
 
-When `decomposition_policy: forbidden`, preserve `decomposability: single` even if the scope contains several review areas. This is required for `review-enforcer` reviewer identity and one-pass lifecycle guarantees.
+## Decomposability versus decomposition policy
+
+`decomposability` is an observation about the work. `decomposition_policy` is an execution constraint. Never rewrite the observed signal merely to satisfy the policy.
+
+Examples:
+
+- A large review can truthfully be `decomposability: independent_workstreams` while `decomposition_policy: forbidden` because reviewer identity and one-pass lifecycle semantics require one reviewer.
+- A migration with strictly ordered steps can be `decomposability: sequential_dependencies` regardless of whether the caller allows parallel decomposition.
+- A genuinely inseparable proof obligation is `decomposability: single`.
+
+When decomposition is forbidden:
+
+- preserve the observed `decomposability`
+- set `decomposition_disposition: prohibited_by_caller_policy`
+- execute with one agent as required
+- do not use the policy prohibition as evidence that the underlying problem is intrinsically non-decomposable
+
+This distinction matters for `max`: a caller policy that forbids splitting does not make an `independent_workstreams` problem qualify as a non-decomposable `max` problem.
 
 ## Model-tier rules
 
@@ -117,11 +135,11 @@ Use these defaults after applying the floors above. A value marked `proposal` is
 | deterministic build or test execution | Luna `medium` | Reclassify failure diagnosis as investigation |
 | ordinary bounded implementation | Terra `medium` | Terra `high` for cross-module or multi-factor work |
 | localized debugging with a concrete hypothesis | Terra `high` | Sol `high` when the hypothesis fails or layers interact |
-| design or requirement interpretation | Sol `high` | propose Sol `max`; stop for user approval |
-| open-ended or cross-layer investigation | Sol `high` | propose Sol `max`; stop for user approval |
+| design or requirement interpretation | Sol `high` | propose Sol `max` only for an intrinsically inseparable problem |
+| open-ended or cross-layer investigation | Sol `high` | propose Sol `max` only for an intrinsically inseparable root cause |
 | initial normal review | Sol `high` | propose Sol `xhigh`; stop for user approval |
 | focused fix verification, new reviewer only | Terra `high` | Sol `high` when the original finding or changed scope is high-criticality |
-| independent final review or release audit | propose Sol `xhigh` | stop for user approval; propose Sol `max` only for one inseparable proof obligation |
+| independent final review or release audit | propose Sol `xhigh` | stop for user approval; propose Sol `max` only for one intrinsically inseparable proof obligation |
 
 Do not use `none` by default for delegated development work. It may be used only for an explicitly deterministic operation that requires no technical judgment and has a complete mechanical validator.
 
@@ -131,14 +149,13 @@ When `review-enforcer` requests reuse of an already-running normal reviewer or i
 
 - do not spawn a replacement merely to apply the focused fix-verification default
 - do not reselect Terra `high`, Sol `high`, `xhigh`, or `max` for the existing agent
-- preserve the model, reasoning effort, and fork context that were actually applied when that reviewer was created
-- record `application_status: reused_existing_agent_profile`
-- record the reviewer identity and the original applied profile as continuity evidence
+- preserve the model, reasoning effort, and fork context that were actually established when that reviewer was created
+- if exact original model/reasoning evidence was unavailable, preserve that uncertainty rather than inventing an exact profile
+- record `application_status: reused_existing_agent_profile` only together with the original observability state
+- record the reviewer identity and the original applied/unverified profile evidence as continuity evidence
 - record the continued review mode, such as `fix_verification` or `finding_ci_delta_closure`
 
 Reusing an already-approved `Sol xhigh` or `Sol max` reviewer in the same review lifecycle does not create a new expensive-profile selection. The original approval evidence remains attached to that reviewer. A new reviewer, a replacement reviewer, or a new task lifecycle must pass profile selection and any applicable approval gate again.
-
-If the original applied profile is unknown, do not invent it. Record the evidence gap and let `review-enforcer` decide whether continuity can be trusted or a replacement reviewer must be created through the normal selection path.
 
 ## Reasoning-effort rules
 
@@ -148,9 +165,11 @@ Choose reasoning effort independently from model tier:
 - `medium`: ordinary bounded implementation or deterministic evidence work
 - `high`: multiple interacting conditions, careful debugging, design, or review
 - `xhigh`: exhaustive or high-stakes review and audit with a bounded scope; when paired with Sol, user approval is mandatory
-- `max`: one exceptionally difficult, non-decomposable problem where deeper reasoning is more useful than splitting the task; when paired with Sol, user approval is mandatory
+- `max`: one exceptionally difficult, intrinsically non-decomposable problem where deeper reasoning is more useful than splitting the task; when paired with Sol, user approval is mandatory
 
-Do not use `max` as a generic quality setting. Before proposing it, call `execution-cost-stabilizer` and record why Sol `high` or an independently decomposed plan is insufficient.
+Do not use `max` as a generic quality setting. Before proposing it, call `execution-cost-stabilizer` and record why Sol `high`, Sol `xhigh`, or an independently decomposed plan is insufficient.
+
+`decomposition_policy: forbidden` never satisfies the intrinsic non-decomposability requirement. If `decomposability: independent_workstreams`, do not justify `max` merely because the caller requires single-agent execution.
 
 ## Multi-agent decision
 
@@ -162,33 +181,60 @@ Return the task to `codex-delegation-executor` for decomposition only when `deco
 - a parent synthesis step is defined
 - parallel execution provides material value after applying `execution-cost-stabilizer`
 
-Do not return a caller-locked task for decomposition. In particular, every reviewer task from `review-enforcer` has `decomposition_policy: forbidden` and remains one reviewer regardless of review breadth.
+When decomposition is forbidden but observed decomposability is `independent_workstreams`, record that decomposition was considered but suppressed by caller policy. Do not falsify the observed signal.
 
 Each decomposed task receives its own profile. Do not assign one shared profile merely because the tasks run together.
+
+## Agent-role/default-role re-evaluation
+
+Current Codex MultiAgent V2 applies requested model/reasoning overrides before applying the explicit or default agent role. A role can therefore replace or lock model/reasoning after the selector creates `requested`.
+
+Before spawn, require the runtime call planner to record:
+
+```yaml
+role_plan:
+  explicit_agent_type: <role or null>
+  effective_role: <role name>
+  role_config_evidence: <path/source or null>
+  profile_effect: unchanged | changed | locked | unknown
+planned_runtime_profile:
+  model: <known planned model or null>
+  reasoning_effort: <known planned effort or null>
+```
+
+Rules:
+
+- If the role/default role changes model tier or reasoning effort, re-evaluate floors and the expensive Sol approval gate against `planned_runtime_profile` before spawn.
+- If the role/default role would produce Sol `xhigh` or Sol `max`, stop for current-task user approval even when the original `requested` profile was cheaper.
+- If the role forces a profile below the required floor, record a policy/capability mismatch rather than silently accepting it.
+- If applicable role configuration cannot be inspected well enough to determine whether it changes model/reasoning, stop before spawn with a role-profile capability gap. This is required to prevent an unobservable role from bypassing the expensive-profile gate.
+- `planned_runtime_profile` is planning evidence, not `applied` evidence.
+
+After spawn, exact `applied` may be recorded only when the parent can observe a trustworthy final runtime/config snapshot. If the call succeeds but final model/reasoning metadata is hidden, keep `applied: null` and use `application_status: spawn_succeeded_profile_unverified`.
 
 ## Override and availability precedence
 
 Apply precedence in this order:
 
 1. explicit current-task user instruction, including explicit approval for `Sol xhigh` or `Sol max`
-2. mandatory user-approval gate for an unapproved `Sol xhigh` or `Sol max` proposal
-3. reviewer continuity reuse of an existing agent and its actually applied profile
-4. caller-owned decomposition prohibition
+2. mandatory user-approval gate for an unapproved initial or role-adjusted Sol `xhigh` / Sol `max` proposal
+3. reviewer continuity reuse of an existing agent and its original observability state
+4. caller-owned decomposition policy
 5. authoritative repository policy
-6. runtime capability and model availability
+6. runtime role/default-role constraints and model availability
 7. automatic selection rules in this reference
 
 An override may pin the model, effort, or both. Continue to classify the task and record when the override is below the automatically calculated floor. Do not silently replace an explicit override. Report the mismatch and follow the governing authority.
 
-A repository policy that requests `Sol xhigh` or `Sol max` creates a proposal but cannot satisfy the approval gate.
+A repository policy that requests Sol `xhigh` or Sol `max` creates a proposal but cannot satisfy the approval gate.
 
 ## Dispatch profile schema
 
-For an ordinary newly dispatched profile before the spawn call:
+For an ordinary newly dispatched profile before role/runtime planning:
 
 ```yaml
 dispatch_profile:
-  schema_version: 3
+  schema_version: 4
   selection_source: automatic | user_override | repository_policy
   task_kind: review
   signals:
@@ -197,8 +243,9 @@ dispatch_profile:
     change_radius: cross_module
     criticality: high
     repetition: single
-    decomposability: single
+    decomposability: independent_workstreams
     decomposition_policy: forbidden
+    decomposition_disposition: prohibited_by_caller_policy
     context_need: fresh
   requested:
     model_tier: sol
@@ -206,8 +253,17 @@ dispatch_profile:
     reasoning_effort: high
     fork_turns: none
     parallelism_mode: single_agent
+  role_plan:
+    explicit_agent_type: null
+    effective_role: default
+    role_config_evidence: <source>
+    profile_effect: unchanged
+  planned_runtime_profile:
+    model: gpt-5.6-sol
+    reasoning_effort: high
   applied: null
   application_status: pending_runtime_result
+  profile_observability: pending
   approval:
     required: false
     status: not_required
@@ -216,26 +272,35 @@ dispatch_profile:
   escalation_triggers: []
 ```
 
-`requested` is the pre-spawn instruction. `applied` is not known yet.
+`requested` and `planned_runtime_profile` are pre-spawn evidence. `applied` is not known yet.
 
-After the call, fill `applied` and replace `pending_runtime_result` using actual runtime evidence:
+When a trustworthy final snapshot is parent-visible:
 
 ```yaml
 applied:
-  model: <actual model or inherited parent model>
-  reasoning_effort: <actual effort or inherited parent effort>
-  fork_turns: <actual fork policy>
-application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+  model: <observed final model>
+  reasoning_effort: <observed final effort>
+  fork_turns: <established fork policy>
+application_status: applied_verified
+profile_observability: verified_final_snapshot
 ```
 
-Never copy `requested` into `applied` merely because the call was attempted.
+When spawn succeeds but final model/reasoning cannot be observed:
+
+```yaml
+applied: null
+application_status: spawn_succeeded_profile_unverified
+profile_observability: final_profile_hidden
+```
+
+Never copy `requested` or `planned_runtime_profile` into `applied` merely because the call succeeded.
 
 For approval-gated profiles, keep the candidate out of `requested` until approval:
 
 ```yaml
 dispatch_profile:
-  schema_version: 3
-  selection_source: automatic | repository_policy
+  schema_version: 4
+  selection_source: automatic | repository_policy | role_adjustment
   proposed_profile:
     model_tier: sol
     model: gpt-5.6-sol
@@ -260,15 +325,13 @@ For continuity reuse:
 
 ```yaml
 dispatch_profile:
-  schema_version: 3
+  schema_version: 4
   selection_source: continuity_reuse
   task_kind: review
   requested: null
-  applied:
-    model: <original applied model>
-    reasoning_effort: <original applied effort>
-    fork_turns: <original fork policy>
+  applied: <original exact profile or null when originally unverified>
   application_status: reused_existing_agent_profile
+  profile_observability: <original observability state>
   continuity:
     reviewer_identity: <existing reviewer>
     continued_mode: fix_verification | finding_ci_delta_closure
@@ -278,51 +341,58 @@ dispatch_profile:
     status: inherited_from_original_dispatch | not_required
 ```
 
-After explicit approval, copy the approved proposal into `requested`, record approval evidence, and only then follow [spawn-agent-model-overrides.md](spawn-agent-model-overrides.md). Never claim the requested profile was applied without actual runtime evidence.
+After explicit approval, copy the approved proposal into `requested`, record approval evidence, then run role/default-role planning and follow [spawn-agent-model-overrides.md](spawn-agent-model-overrides.md). A later role adjustment can require a second approval check if it raises the planned profile to Sol `xhigh` or Sol `max`.
 
 ## Fork policy
 
 - Use `fork_turns: "none"` for a fresh specialist when applying a model or reasoning override.
 - Use an explicit positive partial fork only when the required history is bounded and identified.
-- A full-history fork inherits the parent execution profile. Preserve the requested specialization as unapplied evidence and record `application_status: inherited_parent_profile` only from the actual inheritance path.
+- A full-history fork follows the runtime inheritance/role path. Preserve requested specialization as unapplied evidence until final profile observability is established.
 - Prefer fresh context plus explicit task-local inputs over a full-history fork when specialization matters.
 - Continuity reuse keeps the existing agent context and is not represented as a new fork operation.
 
 ## Reclassification and escalation
 
-Recompute the profile when new evidence changes uncertainty, change radius, criticality, or task kind and a new agent would be dispatched.
+Recompute the profile when new evidence changes uncertainty, change radius, criticality, task kind, or known role-adjusted runtime plan and a new agent would be dispatched.
 
 - A failed deterministic verification becomes investigation; do not keep retrying it as Luna work.
 - A localized implementation that exposes architectural ambiguity becomes Sol work.
 - A task that becomes cleanly separable returns to `codex-delegation-executor` only when decomposition is allowed.
 - Raise reasoning effort when the problem is unchanged but needs more careful analysis.
 - Raise model tier when the nature of the problem changes or the current model lacks the required judgment capability.
-- If escalation reaches Sol `xhigh` or Sol `max`, convert it to a proposal and stop for user approval instead of dispatching.
+- If escalation or role planning reaches Sol `xhigh` or Sol `max`, convert it to a proposal and stop for user approval instead of dispatching.
 - Do not recompute the profile merely because an existing reviewer moved from initial review to fix verification or bounded closure.
 
-Avoid blind retry loops. Record the reason for every profile escalation or fallback and reuse existing evidence.
+Avoid blind retry loops. Record the reason for every profile escalation, role adjustment, observability gap, or fallback and reuse existing evidence.
 
 ## Evidence requirement
 
 Every dispatched task lifecycle must record:
 
-- all selection inputs
+- all selection inputs, including truthful `decomposability` and separate `decomposition_policy`
+- decomposition disposition when policy suppresses an otherwise possible split
 - requested profile before spawn
-- applied profile only after runtime evidence exists
+- explicit/default agent-role plan and role-config evidence
+- planned runtime profile after known role constraints
+- whether role planning caused floor or approval re-evaluation
+- applied profile only when exact final runtime evidence exists
+- runtime profile observability state
 - selection source and rationale
 - fork policy
-- runtime rejection, inheritance, or fallback, if any
+- runtime rejection, inheritance, role adjustment, or fallback, if any
 - reclassification or escalation, if any
-- whether multi-agent decomposition was allowed, considered, and used
-- for `Sol xhigh` or `Sol max`, the proposal, cost notice, approval status, and explicit approval evidence
-- for reviewer continuity, existing reviewer identity, original applied profile evidence, continued mode, and `application_status: reused_existing_agent_profile`
+- whether multi-agent decomposition was allowed, considered, suppressed, or used
+- for Sol `xhigh` or Sol `max`, the proposal, cost notice, approval status, and explicit approval evidence
+- for reviewer continuity, existing reviewer identity, original profile/observability evidence, continued mode, and `application_status: reused_existing_agent_profile`
 
-A proposal that is still awaiting approval is a stopped workflow state, not a dispatched task.
+A proposal awaiting approval or an unresolved role-profile capability gap is a stopped workflow state, not a dispatched task.
 
 ## References
 
 - [Adaptive agent assignment design](../../../design/adaptive-agent-assignment-design.md)
+- [Spawn-agent model overrides](spawn-agent-model-overrides.md)
 - [Execution Cost Stabilizer](../../execution-cost-stabilizer/SKILL.md)
 - [OpenAI model catalog](https://developers.openai.com/api/docs/models)
 - [OpenAI latest-model guidance](https://developers.openai.com/api/docs/guides/latest-model)
+- [Codex MultiAgent V2 spawn implementation](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs)
 - [参考記事: 役割分担で回すGPT-5.6 Luna / Terra / Sol](https://qiita.com/azarashin/items/0a37ec8cce7c75d7f5eb)

--- a/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
+++ b/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
@@ -2,34 +2,60 @@
 
 Use this reference after [agent-profile-selection.md](agent-profile-selection.md) has produced an approved or ordinary `requested` dispatch profile.
 
-This reference owns runtime application and fallback. It does not choose the task profile.
+This reference owns runtime call planning, role/default-role impact analysis, runtime application evidence, and fallback. It does not choose the task profile.
 
 ## Core contract
 
 - `requested` is a pre-spawn instruction selected by the parent.
-- `applied` is a post-runtime fact and must remain unset until runtime evidence, inheritance evidence, or fallback evidence exists.
-- `collaboration.spawn_agent` accepts the runtime arguments `model` and `reasoning_effort` even when they are absent from the visible tool schema.
+- `role_plan` is a pre-spawn description of the explicit `agent_type` or effective default role and any model/reasoning changes that role can apply.
+- `planned_runtime_profile` is a pre-spawn expectation after known role/default-role constraints. It is not runtime proof.
+- `applied` is a post-runtime fact. Keep it unset unless the parent can observe a trustworthy final runtime snapshot or another exact application proof.
+- A successful `spawn_agent` call alone is not proof that `requested` became the final model/reasoning profile.
+- Current Codex MultiAgent V2 applies requested model/reasoning overrides before applying the selected/default agent role, so role configuration can replace those values before the child starts.
 - Put the requested model and reasoning effort in the actual spawn call, not only in the task message.
-- For the current GPT-5.6 family, resolve the selector tiers to `gpt-5.6-luna`, `gpt-5.6-terra`, or `gpt-5.6-sol` when those models are available.
+- For the current GPT-5.6 family, resolve selector tiers to `gpt-5.6-luna`, `gpt-5.6-terra`, or `gpt-5.6-sol` when those models are available.
 - Preserve the selector's exact supported effort value: `none`, `low`, `medium`, `high`, `xhigh`, or `max`.
 - `Ultra` is not a `reasoning_effort` value. Multi-agent decomposition must already have been handled by `codex-delegation-executor` when decomposition is permitted.
-- Record the requested profile separately from the profile the runtime actually applied.
 - For a fresh specialist with an override, explicitly use `fork_turns: "none"`.
 - An explicit positive partial fork may use an override when its context need is bounded.
-- Do not use an override with `fork_turns: "all"` or omitted `fork_turns`: full-history forks inherit the parent model and reasoning profile.
+- Do not use an override with `fork_turns: "all"` or omitted `fork_turns`: full-history forks use the runtime's inheritance path.
+
+## Role/default-role planning
+
+Treat agent role configuration as part of the call plan, not as an opaque post-call detail.
+
+Before dispatch:
+
+1. identify explicit `agent_type` when one will be passed
+2. otherwise identify the effective default role that the current runtime will apply
+3. inspect the authoritative role configuration when it is available
+4. record whether the role leaves model/reasoning unchanged, changes them, locks them, or is unknown
+5. derive `planned_runtime_profile` only from known role/config evidence
+6. return the role-adjusted plan through [agent-profile-selection.md](agent-profile-selection.md) when it changes the model tier or reasoning effort
+
+The expensive Sol approval gate applies to the role-adjusted plan as well as the original selector output. If a role/default role would produce Sol `xhigh` or Sol `max`, create or update the proposal and stop before spawn until the current-task user explicitly approves it.
+
+If the applicable role/default-role configuration cannot be inspected well enough to determine whether it can change model or reasoning effort, the parent cannot guarantee the expensive-profile gate. Record a role-profile capability gap and stop before dispatch rather than assuming the requested profile will survive role application.
+
+A role that forces a profile below the required automatic floor is also a capability/policy mismatch. Do not silently claim the lower role profile satisfies the task.
 
 ## Required application sequence
 
 Use this order without collapsing the steps:
 
-1. finish profile selection and any required user approval
-2. record `requested`
-3. resolve call constraints such as model availability and fork compatibility without writing `applied`
-4. invoke `collaboration.spawn_agent` with the requested override when permitted, or use the required inheritance path
-5. inspect the call result or error
-6. only then record `applied` and `application_status`
-7. if the call rejects the override, record the rejection before considering a parent-owned fallback
-8. if fallback runs, record the fallback's actual profile as `applied`
+1. finish task classification and initial profile selection
+2. obtain any required user approval for the initial profile
+3. identify the explicit/default agent role and inspect its profile effect
+4. derive the role-adjusted `planned_runtime_profile`
+5. re-run floor and expensive-profile approval checks when the role changes or locks model/reasoning
+6. record `requested`, `role_plan`, and `planned_runtime_profile`; keep `applied: null`
+7. resolve remaining call constraints such as model availability and fork compatibility without writing `applied`
+8. invoke `collaboration.spawn_agent` with the requested override and explicit role when applicable, or use the required inheritance path
+9. inspect the returned tool evidence and any parent-observable final runtime/config snapshot
+10. only when exact final profile evidence exists, record it in `applied`
+11. if the spawn succeeds but final model/reasoning is not observable, keep `applied: null` and record `application_status: spawn_succeeded_profile_unverified`
+12. if the call rejects the override, record the rejection before considering a parent-owned fallback
+13. if fallback runs, record its profile as exact `applied` only when the fallback execution provides exact configuration evidence
 
 Never use an `applied` value as the input to the spawn call that is supposed to establish that value.
 
@@ -40,47 +66,79 @@ await collaboration.spawn_agent({
   task_name: "bounded_task",
   message: "Task-local instructions only.",
   fork_turns: "none",
+  agent_type: "<explicit role when selected>",
   model: "<dispatch_profile.requested.model>",
   reasoning_effort: "<dispatch_profile.requested.reasoning_effort>",
 });
 ```
 
+Omit `agent_type` only when the call intentionally uses the runtime default role. An omitted role is not equivalent to "no role"; account for the effective default role in `role_plan`.
+
 Keep the task request focused on work, scope, evidence, and report rules. A model name written only in `message` does not configure the spawned agent.
 
-Before the call, the evidence shape is:
+## Pre-spawn evidence shape
+
+Before the call:
 
 ```yaml
 requested:
   model: <selected model>
   reasoning_effort: <selected effort>
   fork_turns: <selected fork policy>
+role_plan:
+  explicit_agent_type: <role or null>
+  effective_role: <role name>
+  role_config_evidence: <path/source or null>
+  profile_effect: unchanged | changed | locked | unknown
+planned_runtime_profile:
+  model: <known planned model or null>
+  reasoning_effort: <known planned effort or null>
 applied: null
 application_status: pending_runtime_result
+profile_observability: pending
 ```
 
-After the call, replace the pending state using actual evidence:
+`planned_runtime_profile` is planning evidence only. Never rename it to `applied` before runtime proof.
+
+## Post-spawn evidence
+
+When a trustworthy parent-visible final snapshot exists:
 
 ```yaml
 applied:
-  model: <actual model or parent-inherited model>
-  reasoning_effort: <actual effort or parent-inherited effort>
-  fork_turns: <actual fork policy>
-application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+  model: <observed final model>
+  reasoning_effort: <observed final effort>
+  fork_turns: <observed/established fork policy>
+application_status: applied_verified
+profile_observability: verified_final_snapshot
 ```
 
-Do not copy requested values into `applied` without runtime evidence.
+When the tool call succeeds but the parent-visible output exposes only task identity/nickname or otherwise omits the final model/reasoning snapshot:
+
+```yaml
+applied: null
+application_status: spawn_succeeded_profile_unverified
+profile_observability: final_profile_hidden
+observed_runtime_evidence:
+  spawn_succeeded: true
+  task_identity: <returned task identity>
+```
+
+Do not copy `requested` or `planned_runtime_profile` into `applied` merely because spawn succeeded.
 
 ## Full-history constraint
 
-An agent cannot combine a different execution profile with a full-history fork under the current contract.
+A full-history spawn can have different role behavior from a fresh/partial spawn. Treat the actual runtime path as authoritative.
 
 When full history is mandatory:
 
 1. preserve the selected specialization in `requested` as unapplied evidence
-2. omit the incompatible override from the actual full-history spawn and inherit the parent profile
-3. after the runtime path is established, record the inherited parent model and effort in `applied`
-4. record `application_status: inherited_parent_profile`
-5. state which context requirement prevented fresh or partial-fork specialization
+2. determine whether an explicit role will still be applied on that full-history path
+3. omit incompatible model/reasoning overrides when the runtime requires inheritance
+4. keep `applied` unset until exact final inheritance/role evidence is parent-observable
+5. record `application_status: inherited_parent_profile` only when the final inherited profile is actually established
+6. otherwise use `spawn_succeeded_profile_unverified` or a capability-gap state as appropriate
+7. state which context requirement prevented fresh or partial-fork specialization
 
 Prefer a fresh task-local prompt or bounded positive partial fork when specialization is more important than complete conversational history.
 
@@ -88,7 +146,7 @@ Prefer a fresh task-local prompt or bounded positive partial fork when specializ
 
 The visible schema and backend acceptance can differ. Treat rejection as a capability state, not as successful application.
 
-1. record the rejected requested model, effort, fork policy, and error
+1. record the rejected requested model, effort, role, fork policy, and error
 2. do not populate `applied` with the rejected request
 3. do not silently downgrade an explicit user or repository override
 4. when policy permits fallback, the parent may run the work through:
@@ -98,21 +156,29 @@ codex exec --model <model> -c model_reasoning_effort="<effort>"
 ```
 
 5. keep that fallback parent-owned; a sub-agent must never run nested Codex
-6. after the fallback actually starts with known settings, record its actual profile and `application_status: fallback_applied`
-7. when no compliant fallback exists, keep `applied` unset or explicitly unavailable, record `application_status: capability_gap`, and return the blocker
+6. record `fallback_applied` only when exact fallback configuration evidence exists
+7. when fallback starts but exact effective model/reasoning still cannot be observed, use an explicit unverified fallback state instead of inventing `applied`
+8. when no compliant fallback exists, keep `applied` unset and record `application_status: capability_gap`
 
 If the selected model is unavailable but the runtime exposes another model in the same or a higher selector tier, the parent may resolve the requested runtime identifier before spawn only when no explicit identifier was pinned. Record the resolution as a constraint and preserve the requested tier. This call-planning resolution still does not populate `applied` before runtime evidence exists.
 
 ## Escalation handling
 
-Profile escalation must return through [agent-profile-selection.md](agent-profile-selection.md). Do not change only the spawn arguments without updating the classification evidence.
+Profile escalation must return through [agent-profile-selection.md](agent-profile-selection.md). Do not change only the spawn arguments without updating classification and approval evidence.
 
 - raise reasoning effort when the problem remains the same but needs more careful analysis
 - raise model tier when task nature, uncertainty, change radius, or criticality changed
+- re-run the approval gate when role/default-role planning raises the effective plan to Sol `xhigh` or Sol `max`
 - return independently separable work to `codex-delegation-executor` only when the caller permits decomposition
 
 ## Evidence limit
 
-An agent cannot inspect its own live spawn call after dispatch. The parent must record `requested`, actual call outcome, post-runtime `applied`, and any fallback in parent-owned evidence. Never ask the child to attest to hidden arguments it cannot observe.
+A delegated agent cannot attest to hidden spawn arguments or final parent-side runtime configuration. The parent owns `requested`, `role_plan`, `planned_runtime_profile`, runtime observability, `applied`, and fallback evidence.
 
-Background on the hidden-override constraint: [Codex issue #32031](https://github.com/openai/codex/issues/32031).
+Current Codex MultiAgent V2 can obtain an internal agent config snapshot for telemetry, but ordinary tool output may hide model/reasoning metadata and return only task identity. Internal telemetry availability is not parent-visible proof unless the runtime explicitly exposes that snapshot to the caller.
+
+## References
+
+- [Agent profile selection](agent-profile-selection.md)
+- [Codex issue #32031](https://github.com/openai/codex/issues/32031)
+- [Codex MultiAgent V2 spawn implementation](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs)

--- a/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
+++ b/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
@@ -1,14 +1,20 @@
 # Spawn-agent model overrides
 
-Use this reference when a parent selects a model or reasoning effort for a `sub-agent`.
+Use this reference after [agent-profile-selection.md](agent-profile-selection.md) has produced a requested `dispatch_profile`.
+
+This reference owns runtime application and fallback. It does not choose the task profile.
 
 ## Core contract
 
 - `collaboration.spawn_agent` accepts the runtime arguments `model` and `reasoning_effort` even when they are absent from the visible tool schema.
-- Decide model, reasoning effort, and fork policy before dispatch. Put model and reasoning in the actual spawn call, not only in the task message.
-- For review, `review-enforcer` selects the parent agent's current model and `high` reasoning effort by default; the user may override the reasoning effort. For implementation, use only the model that `development-orchestrator` confirmed with the user at workflow start.
+- Put the selected model and reasoning effort in the actual spawn call, not only in the task message.
+- For the current GPT-5.6 family, resolve the selector tiers to `gpt-5.6-luna`, `gpt-5.6-terra`, or `gpt-5.6-sol` when those models are available.
+- Preserve the selector's exact supported effort value: `none`, `low`, `medium`, `high`, `xhigh`, or `max`.
+- `Ultra` is not a `reasoning_effort` value. Multi-agent decomposition must already have been handled by `codex-delegation-executor` before this reference is used.
+- Record the requested profile separately from the profile the runtime actually applied.
 - For a fresh specialist with an override, explicitly use `fork_turns: "none"`.
-- An explicit positive partial fork may use an override when its context need is bounded. Do not use an override with `fork_turns: "all"` or omitted `fork_turns`: full-history forks inherit the parent model and reasoning profile.
+- An explicit positive partial fork may use an override when its context need is bounded.
+- Do not use an override with `fork_turns: "all"` or omitted `fork_turns`: full-history forks inherit the parent model and reasoning profile.
 
 ## Call shape
 
@@ -17,15 +23,66 @@ await collaboration.spawn_agent({
   task_name: "bounded_task",
   message: "Task-local instructions only.",
   fork_turns: "none",
-  model: "<caller-selected-model>",
-  reasoning_effort: "<caller-selected-effort>",
+  model: "<dispatch_profile.requested.model>",
+  reasoning_effort: "<dispatch_profile.requested.reasoning_effort>",
 });
 ```
 
-Keep the task request focused on work, scope, and report rules. A model name written only in `message` does not configure the spawned agent.
+Keep the task request focused on work, scope, evidence, and report rules. A model name written only in `message` does not configure the spawned agent.
 
-## Failure handling and limit
+After the call, record:
 
-The visible schema and backend acceptance can differ. If the runtime rejects either override argument, the parent may run the work through `codex exec --model <model> -c model_reasoning_effort="<effort>"`; a sub-agent must never run that fallback or nested Codex.
+```yaml
+applied:
+  model: <actual model or parent-inherited model>
+  reasoning_effort: <actual effort or parent-inherited effort>
+  fork_turns: <actual fork policy>
+application_status: applied | inherited_parent_profile | fallback_applied | capability_gap
+```
 
-An agent cannot inspect its own live spawn call after dispatch. Record the intended profile and call outcome in the parent-owned report, and treat backend rejection as a capability gap rather than claiming the override was applied. Background: [Codex issue #32031](https://github.com/openai/codex/issues/32031).
+Do not copy requested values into `applied` without runtime evidence.
+
+## Full-history constraint
+
+An agent cannot combine a different execution profile with a full-history fork under the current contract.
+
+When full history is mandatory:
+
+1. omit the override and inherit the parent profile
+2. record `application_status: inherited_parent_profile`
+3. preserve the requested profile as unapplied evidence
+4. state which context requirement prevented fresh or partial-fork specialization
+
+Prefer a fresh task-local prompt or bounded positive partial fork when specialization is more important than complete conversational history.
+
+## Failure handling
+
+The visible schema and backend acceptance can differ. Treat rejection as a capability state, not as successful application.
+
+1. record the rejected model, effort, fork policy, and error
+2. do not silently downgrade an explicit user or repository override
+3. when policy permits fallback, the parent may run the work through:
+
+```bash
+codex exec --model <model> -c model_reasoning_effort="<effort>"
+```
+
+4. keep that fallback parent-owned; a sub-agent must never run nested Codex
+5. record the actual fallback profile and `application_status: fallback_applied`
+6. when no compliant fallback exists, record `application_status: capability_gap` and return the blocker
+
+If the selected model is unavailable but the runtime exposes another model in the same or a higher selector tier, the parent may resolve to that model only when no explicit identifier was pinned. Record the resolution as a constraint and preserve the requested tier.
+
+## Escalation handling
+
+Profile escalation must return through [agent-profile-selection.md](agent-profile-selection.md). Do not change only the spawn arguments without updating the classification evidence.
+
+- raise reasoning effort when the problem remains the same but needs more careful analysis
+- raise model tier when task nature, uncertainty, change radius, or criticality changed
+- return independently separable work to `codex-delegation-executor` instead of treating multi-agent execution as an effort value
+
+## Evidence limit
+
+An agent cannot inspect its own live spawn call after dispatch. The parent must record the intended profile, actual call outcome, and any fallback in the parent-owned report. Never ask the child to attest to hidden arguments it cannot observe.
+
+Background on the hidden-override constraint: [Codex issue #32031](https://github.com/openai/codex/issues/32031).

--- a/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
+++ b/skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md
@@ -1,20 +1,37 @@
 # Spawn-agent model overrides
 
-Use this reference after [agent-profile-selection.md](agent-profile-selection.md) has produced a requested `dispatch_profile`.
+Use this reference after [agent-profile-selection.md](agent-profile-selection.md) has produced an approved or ordinary `requested` dispatch profile.
 
 This reference owns runtime application and fallback. It does not choose the task profile.
 
 ## Core contract
 
+- `requested` is a pre-spawn instruction selected by the parent.
+- `applied` is a post-runtime fact and must remain unset until runtime evidence, inheritance evidence, or fallback evidence exists.
 - `collaboration.spawn_agent` accepts the runtime arguments `model` and `reasoning_effort` even when they are absent from the visible tool schema.
-- Put the selected model and reasoning effort in the actual spawn call, not only in the task message.
+- Put the requested model and reasoning effort in the actual spawn call, not only in the task message.
 - For the current GPT-5.6 family, resolve the selector tiers to `gpt-5.6-luna`, `gpt-5.6-terra`, or `gpt-5.6-sol` when those models are available.
 - Preserve the selector's exact supported effort value: `none`, `low`, `medium`, `high`, `xhigh`, or `max`.
-- `Ultra` is not a `reasoning_effort` value. Multi-agent decomposition must already have been handled by `codex-delegation-executor` before this reference is used.
+- `Ultra` is not a `reasoning_effort` value. Multi-agent decomposition must already have been handled by `codex-delegation-executor` when decomposition is permitted.
 - Record the requested profile separately from the profile the runtime actually applied.
 - For a fresh specialist with an override, explicitly use `fork_turns: "none"`.
 - An explicit positive partial fork may use an override when its context need is bounded.
 - Do not use an override with `fork_turns: "all"` or omitted `fork_turns`: full-history forks inherit the parent model and reasoning profile.
+
+## Required application sequence
+
+Use this order without collapsing the steps:
+
+1. finish profile selection and any required user approval
+2. record `requested`
+3. resolve call constraints such as model availability and fork compatibility without writing `applied`
+4. invoke `collaboration.spawn_agent` with the requested override when permitted, or use the required inheritance path
+5. inspect the call result or error
+6. only then record `applied` and `application_status`
+7. if the call rejects the override, record the rejection before considering a parent-owned fallback
+8. if fallback runs, record the fallback's actual profile as `applied`
+
+Never use an `applied` value as the input to the spawn call that is supposed to establish that value.
 
 ## Call shape
 
@@ -30,7 +47,18 @@ await collaboration.spawn_agent({
 
 Keep the task request focused on work, scope, evidence, and report rules. A model name written only in `message` does not configure the spawned agent.
 
-After the call, record:
+Before the call, the evidence shape is:
+
+```yaml
+requested:
+  model: <selected model>
+  reasoning_effort: <selected effort>
+  fork_turns: <selected fork policy>
+applied: null
+application_status: pending_runtime_result
+```
+
+After the call, replace the pending state using actual evidence:
 
 ```yaml
 applied:
@@ -48,10 +76,11 @@ An agent cannot combine a different execution profile with a full-history fork u
 
 When full history is mandatory:
 
-1. omit the override and inherit the parent profile
-2. record `application_status: inherited_parent_profile`
-3. preserve the requested profile as unapplied evidence
-4. state which context requirement prevented fresh or partial-fork specialization
+1. preserve the selected specialization in `requested` as unapplied evidence
+2. omit the incompatible override from the actual full-history spawn and inherit the parent profile
+3. after the runtime path is established, record the inherited parent model and effort in `applied`
+4. record `application_status: inherited_parent_profile`
+5. state which context requirement prevented fresh or partial-fork specialization
 
 Prefer a fresh task-local prompt or bounded positive partial fork when specialization is more important than complete conversational history.
 
@@ -59,19 +88,20 @@ Prefer a fresh task-local prompt or bounded positive partial fork when specializ
 
 The visible schema and backend acceptance can differ. Treat rejection as a capability state, not as successful application.
 
-1. record the rejected model, effort, fork policy, and error
-2. do not silently downgrade an explicit user or repository override
-3. when policy permits fallback, the parent may run the work through:
+1. record the rejected requested model, effort, fork policy, and error
+2. do not populate `applied` with the rejected request
+3. do not silently downgrade an explicit user or repository override
+4. when policy permits fallback, the parent may run the work through:
 
 ```bash
 codex exec --model <model> -c model_reasoning_effort="<effort>"
 ```
 
-4. keep that fallback parent-owned; a sub-agent must never run nested Codex
-5. record the actual fallback profile and `application_status: fallback_applied`
-6. when no compliant fallback exists, record `application_status: capability_gap` and return the blocker
+5. keep that fallback parent-owned; a sub-agent must never run nested Codex
+6. after the fallback actually starts with known settings, record its actual profile and `application_status: fallback_applied`
+7. when no compliant fallback exists, keep `applied` unset or explicitly unavailable, record `application_status: capability_gap`, and return the blocker
 
-If the selected model is unavailable but the runtime exposes another model in the same or a higher selector tier, the parent may resolve to that model only when no explicit identifier was pinned. Record the resolution as a constraint and preserve the requested tier.
+If the selected model is unavailable but the runtime exposes another model in the same or a higher selector tier, the parent may resolve the requested runtime identifier before spawn only when no explicit identifier was pinned. Record the resolution as a constraint and preserve the requested tier. This call-planning resolution still does not populate `applied` before runtime evidence exists.
 
 ## Escalation handling
 
@@ -79,10 +109,10 @@ Profile escalation must return through [agent-profile-selection.md](agent-profil
 
 - raise reasoning effort when the problem remains the same but needs more careful analysis
 - raise model tier when task nature, uncertainty, change radius, or criticality changed
-- return independently separable work to `codex-delegation-executor` instead of treating multi-agent execution as an effort value
+- return independently separable work to `codex-delegation-executor` only when the caller permits decomposition
 
 ## Evidence limit
 
-An agent cannot inspect its own live spawn call after dispatch. The parent must record the intended profile, actual call outcome, and any fallback in the parent-owned report. Never ask the child to attest to hidden arguments it cannot observe.
+An agent cannot inspect its own live spawn call after dispatch. The parent must record `requested`, actual call outcome, post-runtime `applied`, and any fallback in parent-owned evidence. Never ask the child to attest to hidden arguments it cannot observe.
 
 Background on the hidden-override constraint: [Codex issue #32031](https://github.com/openai/codex/issues/32031).


### PR DESCRIPTION
## 概要

参考記事の工程別・難度別の割当方針をCodexSkillへ取り込み、bounded taskごとにmodel tier、reasoning effort、fork policyを選定します。

コスト最適化として、`Sol xhigh` / `Sol max`は自動選定・自動dispatchせず、理由とcost noticeを提示して停止し、current-taskでユーザーが明示了承した後だけ使用します。

## 設計

- `codex-delegation-executor`: main agent / single sub-agent / multi-agent decompositionを判断
- `sub-agent-task-manager`: model / reasoning / fork、agent role/default-role planning、runtime profile observabilityを管理
- Luna: deterministicな機械的・反復作業
- Terra: 通常のbounded technical work
- Sol: 設計・難しい調査・高重要度・review
- Ultra相当: `reasoning_effort`ではなくmulti-agent decomposition
- profile stateを `proposed -> requested -> role plan -> planned runtime profile -> spawn -> applied/unverified` の順に分離
- final runtime profileがparent-visibleな場合だけexact `applied`を記録
- metadata-hidden runtimeでは`applied: null` + `spawn_succeeded_profile_unverified`を正式なobservability stateとして保持
- full-history inheritance、role override、hidden override rejection、parent-owned fallback、capability gapを証跡化

### Sol高コストprofile approval gate

`Sol xhigh` / `Sol max`候補では:

1. `proposed_profile`として記録
2. `Sol high`で不足する理由とcost増加を提示
3. dispatch前に停止
4. current-taskで明示了承された場合だけ`requested`へ昇格
5. explicit/default agent roleがprofileを変更する場合はrole-adjusted planでもgateを再評価
6. reject時は`xhigh/max`を除外して再計算

repository policy、過去taskの了承、silence、inferred preferenceはapprovalとして扱いません。role/default-roleを含め、review / independent final review / release auditにも適用します。

## Review指摘対応

### R1

- `F65-001 / HIGH`: new reviewerを`sub-agent-task-manager`経由へ統一
- `F65-002 / MEDIUM`: existing reviewer reuseではoriginal profile evidenceを維持し`reused_existing_agent_profile`を記録
- `F65-003 / MEDIUM`: standard report templateへparent-owned `Dispatch profile` sectionを追加

### R2

- `F65-R2-001 / HIGH`: `requested`をpre-spawn instruction、`applied`をpost-runtime evidenceへ分離
- `F65-R2-002 / HIGH`: independent-final reportを`deferred_attestation`化し、passing verdictまでreserved report fileを作成しない
- `F65-R2-003 / HIGH`: review executionをsingle reviewer policyへ固定し、reviewer identity / continuity / one exhaustive passを維持

### R3

- `F65-R3-001 / HIGH`: agent role/default-roleをcall planningへ追加し、role-adjusted profileでもapproval gateを再評価。final profileが見えない場合はexact `applied`を断定しない
- `F65-R3-002 / HIGH`: `report-output-manager`をnormal persistence / reservation-only / attestation persistenceのphase-specific contractへ変更
- `F65-R3-003 / MEDIUM`: observed `decomposability`とexecution `decomposition_policy`を分離

### R4

- `F65-R4-001 / HIGH`: `codex-delegation-executor`をruntime-observability contractへ同期
- `F65-R4-002 / HIGH`: independent-final report reservation ownerを`review-enforcer`へ一本化し、`sub-agent-task-manager`はpre-reserved identityをreuse
- `F65-R4-003 / MEDIUM`: Skill hierarchy正本+mirrorと上流delegation contractへdeferred-attestation例外を同期

### R5 / 追加fix verification

- `F65-R4-002 / HIGH` 再オープン分:
  - `development-orchestrator` step 20からreservation-only phase直接実行を削除
  - reviewed implementation HEADの直接freezeも削除
  - orchestratorは`pre_freeze_ready` evidenceを`review-enforcer`へ渡すだけ
  - reservation / stable identity / freezeは`review-enforcer`単独owner
- `F65-R5-001 / HIGH`:
  - `review-enforcer` passing terminal result後にorchestratorがattestation persistenceを再実行しない
  - second attestation commit、final push、`git-pr-submitter`、exact-head CI waitの重複を禁止
  - orchestratorは`review-enforcer` terminal evidenceをconsumeするだけ
  - `Independent-final terminal ownership` contractを追加

既存hierarchy正本はR4時点で`review-enforcer`のterminal ownershipを定義済みであり、R5は`development-orchestrator`をその正本へ整合させる修正です。

R1〜R5の指摘threadへ対応・返信済みです。

## 主な変更ファイル

- `skills/sub-agent-task-manager/SKILL.md`
- `skills/sub-agent-task-manager/references/agent-profile-selection.md`
- `skills/sub-agent-task-manager/references/spawn-agent-model-overrides.md`
- `skills/codex-delegation-executor/SKILL.md`
- `skills/development-orchestrator/SKILL.md`
- `skills/review-enforcer/SKILL.md`
- `skills/report-output-manager/SKILL.md`
- `skills/report-output-manager/references/sub-agent-report-template.md`
- `scripts/verify_skill_repository.py`
- `design/adaptive-agent-assignment-design.md`
- `design/skill-hierarchy-design.md`
- `skills/design/skill-hierarchy-design.md`

## 検証

CodexSkill repository方針に従いTDDは適用していません。

### final exact-head CI

- PR current HEAD: `a618c1e6621032bcf5c4e638b5d840bd5fcbc248`
- workflow: `Validate and release ChatGPT worker skills`
- run ID: `33259244486`
- run number: `201`
- run `head_sha`: `a618c1e6621032bcf5c4e638b5d840bd5fcbc248`
- build job: `99118226158`
- conclusion: `success`

成功step:

- Checkout target HEAD without write credentials
- Validate repository Skill architecture and active links
- Build and verify ChatGPT wrapper and core Skill ZIP
- Upload validation artifact

Artifact:

- `chatgpt-worker-skills-33259244486`
- artifact ID: `9716758212`
- artifact workflow run head SHA: `a618c1e6621032bcf5c4e638b5d840bd5fcbc248`
- digest: `sha256:d851b7db26f7e0f5f98f7c32ee497197e9428cc7ba5b69e8c4c31346307dee52`

別SHAのworkflow runはfinal CI evidenceとして使用していません。

## Report / handoff

- `reports/issue-13-adaptive-agent-assignment-implementation-20260826.md`
- `reports/issue-13-adaptive-agent-assignment-handoff-20260826.yaml`
- `reports/issue-13-sol-expensive-profile-approval-followup-20260827.md`
- `reports/issue-13-pr65-normal-review-20260827.md`
- `reports/issue-13-pr65-review-findings-followup-20260829.md`
- `reports/issue-13-pr65-r2-findings-followup-20260829.md`
- `reports/issue-13-pr65-r3-rereview-20260829.md`
- `reports/issue-13-pr65-r3-findings-followup-20260829.md`
- `reports/issue-13-pr65-r4-rereview-20260829.md`
- `reports/issue-13-pr65-r4-findings-followup-20260829.md`
- `reports/issue-13-pr65-r5-findings-followup-20260830.md`

## 残存事項

- 本repositoryではparent-visible final agent config snapshot APIは追加していません
- runtimeがfinal model/reasoningをparentへ公開しない場合、exact `applied`は不明のまま保持します
- role/default-role configをspawn前に安全確認できないruntimeでは、高コストapproval gate保証のためdispatchをcapability gapとして停止します
- independent-final report reservation / freeze / attestation / final publication / exact-head CIは`review-enforcer`単独ownerです
- multi-agent review lifecycleは今回のscope外で、現行review executionはsingle reviewer policyです

Closes #13

Related #46